### PR TITLE
i18n: translate design-patterns-guide (20 files)

### DIFF
--- a/03-software-design/design-patterns-guide/docs/00-creational/00-singleton.md
+++ b/03-software-design/design-patterns-guide/docs/00-creational/00-singleton.md
@@ -1,113 +1,113 @@
-# Singleton パターン
+# Singleton Pattern
 
-> インスタンスがアプリケーション全体で **ただ1つ** であることを保証し、そのグローバルアクセスポイントを提供する生成パターン。
-
----
-
-## この章で学ぶこと
-
-1. Singleton パターンの目的・構造と、なぜ「インスタンスを1つに制限する」必要があるのかという設計意図（WHY）
-2. スレッドセーフな実装方法（Eager Init / DCL / Holder / Enum / モジュールスコープ）の内部動作と使い分け
-3. DI（依存性注入）による Singleton の代替手法とテスト容易性の確保
-4. Singleton の濫用が招くグローバル状態問題と、適切な利用場面の見極め方
-5. 各言語（TypeScript / Java / Python / Go / Kotlin）での実装パターンとエッジケース
+> A creational pattern that guarantees **only one** instance exists throughout the entire application and provides a global access point to that instance.
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-このガイドを理解するために、以下の知識を事前に習得しておくことを推奨します。
+1. The purpose and structure of the Singleton pattern, and the design intent (WHY) behind restricting an instance to exactly one
+2. The internal mechanics and usage differences of thread-safe implementations (Eager Init / DCL / Holder / Enum / Module Scope)
+3. Alternative approaches to Singleton using DI (Dependency Injection) and how to ensure testability
+4. Global state problems caused by Singleton overuse and how to identify appropriate use cases
+5. Implementation patterns and edge cases in each language (TypeScript / Java / Python / Go / Kotlin)
 
-| トピック | 必要レベル | 参照リンク |
+---
+
+## Prerequisites
+
+The following knowledge is recommended before working through this guide.
+
+| Topic | Required Level | Reference |
 |---------|-----------|-----------|
-| オブジェクト指向の基礎（クラス、インスタンス、コンストラクタ） | 必須 | OOP基礎 |
-| SOLID原則（特にSRP、DIP） | 推奨 | [SOLID原則](../../../clean-code-principles/docs/00-principles/01-solid.md) |
-| マルチスレッド／並行処理の基礎 | 推奨 | 並行処理 |
-| ES Module の仕組み（JavaScript/TypeScript） | 推奨 | [MDN Modules](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Modules) |
-| DI（依存性注入）の概念 | あると望ましい | [DIP](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Object-oriented basics (classes, instances, constructors) | Required | OOP Basics |
+| SOLID principles (especially SRP, DIP) | Recommended | [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Multithreading / concurrency basics | Recommended | Concurrency |
+| ES Module mechanics (JavaScript/TypeScript) | Recommended | [MDN Modules](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Modules) |
+| DI (Dependency Injection) concepts | Helpful | [DIP](../../../clean-code-principles/docs/00-principles/01-solid.md) |
 
 ---
 
-## 1. Singleton パターンとは何か — 本質的な理解
+## 1. What Is the Singleton Pattern — Core Understanding
 
-### 1.1 パターンの定義
+### 1.1 Pattern Definition
 
-Singleton パターンは GoF（Gang of Four）が定義した23のデザインパターンのうち、「生成パターン（Creational Patterns）」に分類される。その意図は以下の通り:
+The Singleton pattern is classified under "Creational Patterns" among the 23 design patterns defined by the GoF (Gang of Four). Its intent is as follows:
 
-> **あるクラスのインスタンスがただ1つしか存在しないことを保証し、それに対するグローバルなアクセスポイントを提供する。**
+> **Ensure that a class has only one instance, and provide a global access point to it.**
 
-この定義には2つの独立した責任が含まれている:
+This definition contains two independent responsibilities:
 
-1. **インスタンス数の制限**: クラス自身が自分のインスタンス生成を制御する
-2. **グローバルアクセス**: アプリケーションのどこからでもそのインスタンスにアクセスできる
+1. **Limiting the number of instances**: The class itself controls its own instance creation
+2. **Global access**: The instance can be accessed from anywhere in the application
 
-### 1.2 なぜ Singleton が必要なのか（WHY）
+### 1.2 Why Singleton Is Necessary (WHY)
 
-Singleton パターンが解決する根本的な問題は「**共有リソースの一貫性保証**」である。
+The fundamental problem that the Singleton pattern solves is **"guaranteeing consistency of shared resources."**
 
 ```
-【問題のシナリオ】
+[Problem Scenario]
 
-スレッド A                      スレッド B
+Thread A                        Thread B
     |                               |
     v                               v
 new DatabasePool()              new DatabasePool()
     |                               |
     v                               v
-コネクション 10本確保           コネクション 10本確保
+Reserves 10 connections         Reserves 10 connections
     |                               |
     v                               v
-合計 20本 → データベースの上限超過でエラー！
+Total 20 connections → Exceeds database limit → Error!
 
-【Singleton による解決】
+[Solution with Singleton]
 
-スレッド A                      スレッド B
+Thread A                        Thread B
     |                               |
     v                               v
 DatabasePool.getInstance()      DatabasePool.getInstance()
     |                               |
-    +--------> 同じインスタンス <----+
+    +--------> Same instance   <----+
                |
                v
-           コネクション 10本（1回だけ確保）
+           10 connections (reserved only once)
 ```
 
-具体的に Singleton が必要になるケース:
+Specific cases where Singleton is needed:
 
-1. **データベースコネクションプール**: 複数のプールが生成されるとコネクション数が制御不能になる
-2. **ロガー**: 複数のロガーインスタンスが同じファイルに書き込むとデータ競合が発生する
-3. **設定オブジェクト**: 異なるインスタンスが異なる設定値を持つと、アプリケーション動作が不整合になる
-4. **キャッシュ**: 複数のキャッシュインスタンスは同じデータの重複保存となり、一貫性も失われる
-5. **ハードウェアアクセス**: プリンタスプーラやGPUコンテキストなど、物理的に1つしか存在しないリソース
+1. **Database connection pool**: Creating multiple pools makes the connection count uncontrollable
+2. **Logger**: Multiple logger instances writing to the same file causes data races
+3. **Configuration object**: Different instances holding different config values causes inconsistent application behavior
+4. **Cache**: Multiple cache instances result in duplicate data storage and loss of consistency
+5. **Hardware access**: Resources that physically exist only once, such as printer spoolers or GPU contexts
 
-### 1.3 Singleton を使うべきでないケース
+### 1.3 Cases Where Singleton Should Not Be Used
 
-一方で、以下の場合は Singleton を避けるべきである:
+Conversely, Singleton should be avoided in the following cases:
 
-- **ステートレスなユーティリティ**: 状態を持たないなら、静的メソッドで十分
-- **ビジネスロジックの共有**: ドメインサービスを Singleton にすると、テストが困難になる
-- **「便利だから」という理由**: グローバル変数の代わりとして使うのは設計の放棄
+- **Stateless utilities**: If there is no state, static methods are sufficient
+- **Sharing business logic**: Making domain services Singleton makes testing difficult
+- **"It's convenient"**: Using it as a substitute for global variables is an abandonment of design
 
 ---
 
-## 2. Singleton の構造
+## 2. Singleton Structure
 
-### 2.1 UML クラス図
+### 2.1 UML Class Diagram
 
 ```
 +---------------------------+
 |       Singleton           |
 +---------------------------+
-| - instance: Singleton     |  ← クラス変数（static）
-| - data: any               |  ← インスタンス変数
+| - instance: Singleton     |  ← class variable (static)
+| - data: any               |  ← instance variable
 +---------------------------+
-| - constructor()           |  ← private: 外部から new 不可
-| + getInstance(): Singleton|  ← 唯一のアクセスポイント
+| - constructor()           |  ← private: prevents external new
+| + getInstance(): Singleton|  ← the sole access point
 | + getData(): any          |
 | + setData(d: any): void   |
 +---------------------------+
         |
-        | instance は 1つだけ生成される
+        | instance is created only once
         v
   +------------------+
   | <<instance>>     |
@@ -116,7 +116,7 @@ DatabasePool.getInstance()      DatabasePool.getInstance()
   +------------------+
 ```
 
-### 2.2 シーケンス図
+### 2.2 Sequence Diagram
 
 ```
 Client A          Singleton Class          Client B
@@ -126,7 +126,7 @@ Client A          Singleton Class          Client B
    |                    |                      |
    |  instance == null  |                      |
    |  → new Singleton() |                      |
-   |  → instance に格納  |                      |
+   |  → stored in instance                     |
    |                    |                      |
    |  <--- instance ----|                      |
    |                    |                      |
@@ -134,66 +134,66 @@ Client A          Singleton Class          Client B
    |                    |<---------------------|
    |                    |                      |
    |                    |   instance != null   |
-   |                    |   → 既存を返す        |
+   |                    |   → return existing  |
    |                    |                      |
    |                    |--- instance -------->|
    |                    |                      |
 
-   ※ Client A と Client B は同じインスタンスを受け取る
+   * Client A and Client B receive the same instance
 ```
 
-### 2.3 内部動作の詳細
+### 2.3 Internal Operation in Detail
 
-Singleton パターンの内部動作を段階的に理解する:
+Understanding the Singleton pattern's internal operation step by step:
 
 ```
-Step 1: 初回アクセス
+Step 1: First access
 ┌─────────────────────────────────────┐
-│ Singleton クラス                     │
+│ Singleton class                      │
 │                                     │
-│  static instance: null  ←── 未生成  │
+│  static instance: null  ← not yet created │
 │                                     │
 │  getInstance() {                    │
 │    if (instance == null) {  ← true  │
 │      instance = new Singleton()     │
-│      ↑ private constructor 呼出     │
+│      ↑ private constructor called   │
 │    }                                │
-│    return instance  ← 新規生成      │
+│    return instance  ← newly created │
 │  }                                  │
 └─────────────────────────────────────┘
 
-Step 2: 2回目以降のアクセス
+Step 2: Second and subsequent accesses
 ┌─────────────────────────────────────┐
-│ Singleton クラス                     │
+│ Singleton class                      │
 │                                     │
-│  static instance: [Object] ← 既存  │
+│  static instance: [Object] ← existing │
 │                                     │
 │  getInstance() {                    │
 │    if (instance == null) { ← false  │
-│      // スキップ                     │
+│      // skipped                     │
 │    }                                │
-│    return instance  ← 既存を返す     │
+│    return instance  ← return existing │
 │  }                                  │
 └─────────────────────────────────────┘
 ```
 
 ---
 
-## 3. 各実装手法の詳細解説
+## 3. Detailed Explanation of Each Implementation Approach
 
-### コード例 1: クラシック Singleton（TypeScript）
+### Code Example 1: Classic Singleton (TypeScript)
 
-最も基本的な実装。シングルスレッド環境（JavaScript/TypeScript）では問題なく動作する。
+The most basic implementation. Works correctly in single-threaded environments (JavaScript/TypeScript).
 
 ```typescript
 class Singleton {
   private static instance: Singleton | null = null;
   private value: number;
 
-  // private constructor で外部からの new を禁止
+  // private constructor prevents external new
   private constructor(value: number) {
     this.value = value;
-    console.log("Singleton: コンストラクタ実行（1度だけ）");
+    console.log("Singleton: constructor executed (only once)");
   }
 
   static getInstance(): Singleton {
@@ -212,33 +212,33 @@ class Singleton {
   }
 }
 
-// 使用例
+// Usage example
 const a = Singleton.getInstance();
 const b = Singleton.getInstance();
 
-console.log(a === b);         // true — 同一インスタンス
+console.log(a === b);         // true — same instance
 console.log(a.getValue());    // 42
 
 a.setValue(100);
-console.log(b.getValue());    // 100 — 同じインスタンスなので反映される
+console.log(b.getValue());    // 100 — reflected because it's the same instance
 ```
 
-**WHY — なぜ private constructor なのか?**
+**WHY — Why is the constructor private?**
 
-コンストラクタを private にすることで、外部コードが `new Singleton()` を呼ぶことを**コンパイル時に防止**する。これがなければ、開発者が誤って複数インスタンスを生成する可能性がある。
+Making the constructor private **prevents at compile time** external code from calling `new Singleton()`. Without this, developers could accidentally create multiple instances.
 
 ```typescript
-// private constructor がない場合の危険
-const s1 = new Singleton(1);  // 直接生成 → 制御不能
-const s2 = new Singleton(2);  // 2つ目が生成されてしまう
+// The danger without a private constructor
+const s1 = new Singleton(1);  // direct creation → uncontrolled
+const s2 = new Singleton(2);  // a second instance is created
 ```
 
-### コード例 2: モジュールスコープ Singleton（TypeScript — 推奨）
+### Code Example 2: Module Scope Singleton (TypeScript — Recommended)
 
-JavaScript/TypeScript では、ES Module 自体がキャッシュされるため、モジュールレベルで export したインスタンスは事実上 Singleton になる。
+In JavaScript/TypeScript, because ES Modules themselves are cached, an instance exported at module level effectively becomes a Singleton.
 
 ```typescript
-// config.ts — ES Module 自体が Singleton として振る舞う
+// config.ts — the ES Module itself behaves as a Singleton
 class AppConfig {
   readonly dbHost: string;
   readonly dbPort: number;
@@ -246,13 +246,13 @@ class AppConfig {
   readonly maxRetries: number;
 
   constructor() {
-    // 環境変数からの読み込み（1度だけ実行される）
+    // Reading from environment variables (executed only once)
     this.dbHost = process.env.DB_HOST ?? "localhost";
     this.dbPort = Number(process.env.DB_PORT ?? 5432);
     this.logLevel = process.env.LOG_LEVEL ?? "info";
     this.maxRetries = Number(process.env.MAX_RETRIES ?? 3);
 
-    console.log("AppConfig: 初期化完了");
+    console.log("AppConfig: initialization complete");
   }
 
   get connectionString(): string {
@@ -260,53 +260,53 @@ class AppConfig {
   }
 }
 
-// モジュールレベルで1度だけインスタンス化
-// import した全てのモジュールが同じインスタンスを受け取る
+// Instantiated only once at module level
+// All modules that import this receive the same instance
 export const appConfig = new AppConfig();
 
-// --- 利用側 ---
+// --- Usage ---
 // import { appConfig } from './config';
 // console.log(appConfig.connectionString);
 ```
 
-**WHY — モジュールスコープが推奨される理由:**
+**WHY — Why module scope is recommended:**
 
-1. **言語仕様で保証**: ECMAScript 仕様によりモジュールは1度だけ評価される
-2. **コード量が最小**: getInstance() のようなボイラープレートが不要
-3. **直感的**: 通常のオブジェクトと同じように使える
-4. **Tree-shaking 対応**: 使われなければバンドラが除外する
+1. **Guaranteed by language spec**: The ECMAScript specification ensures modules are evaluated only once
+2. **Minimal code**: No boilerplate like getInstance() is needed
+3. **Intuitive**: Can be used just like a regular object
+4. **Tree-shaking compatible**: Bundlers will exclude it if it's not used
 
 ```
-モジュール評価のメカニズム:
+Module evaluation mechanism:
 
-1回目の import { appConfig } from './config'
-  → config.ts を評価 → new AppConfig() 実行 → キャッシュに保存
+First import { appConfig } from './config'
+  → evaluates config.ts → executes new AppConfig() → saves to cache
 
-2回目の import { appConfig } from './config'
-  → キャッシュから取得 → 同じインスタンスが返る（再評価なし）
+Second import { appConfig } from './config'
+  → retrieves from cache → same instance returned (no re-evaluation)
 
-3回目の import { appConfig } from './config'
-  → キャッシュから取得 → 同じインスタンスが返る（再評価なし）
+Third import { appConfig } from './config'
+  → retrieves from cache → same instance returned (no re-evaluation)
 ```
 
-### コード例 3: スレッドセーフ — Double-Checked Locking（Java）
+### Code Example 3: Thread-Safe — Double-Checked Locking (Java)
 
-マルチスレッド環境では、2つのスレッドが同時に `getInstance()` を呼ぶと、インスタンスが2つ生成される可能性がある。DCL（Double-Checked Locking）はこれを防ぐ。
+In multithreaded environments, two threads calling `getInstance()` simultaneously may result in two instances being created. DCL (Double-Checked Locking) prevents this.
 
 ```java
 public class Singleton {
-    // volatile: メモリの可視性を保証（CPUキャッシュの問題を防ぐ）
+    // volatile: guarantees memory visibility (prevents CPU cache issues)
     private static volatile Singleton instance;
 
     private Singleton() {
-        // 重い初期化処理（例: DB接続、設定ファイル読み込み）
-        System.out.println("Singleton: 初期化実行");
+        // Heavy initialization (e.g., DB connection, config file loading)
+        System.out.println("Singleton: initialization executed");
     }
 
     public static Singleton getInstance() {
-        if (instance == null) {                  // 1st check (ロックなし — 高速パス)
-            synchronized (Singleton.class) {     // ロック取得
-                if (instance == null) {          // 2nd check (ロック内で再確認)
+        if (instance == null) {                  // 1st check (no lock — fast path)
+            synchronized (Singleton.class) {     // acquire lock
+                if (instance == null) {          // 2nd check (re-verify inside lock)
                     instance = new Singleton();
                 }
             }
@@ -316,77 +316,77 @@ public class Singleton {
 }
 ```
 
-**WHY — なぜ「二重」チェックなのか?**
+**WHY — Why is it "double" checked?**
 
 ```
-【DCLなし（synchronized のみ）の場合】
+[Without DCL (synchronized only)]
 
-Thread A: getInstance() → synchronized ブロックに入る → 待ち
-Thread B: getInstance() → synchronized ブロックに入る → 待ち
-  ↑ 毎回ロック取得のオーバーヘッド（インスタンス生成済みでも）
+Thread A: getInstance() → enters synchronized block → waits
+Thread B: getInstance() → enters synchronized block → waits
+  ↑ lock acquisition overhead on every call (even after instance is created)
 
-【DCLの場合】
+[With DCL]
 
-Step 1: 1st check（ロックなし）
-  instance != null → そのまま return（高速パス、99.99%のケース）
-  instance == null → Step 2 へ
+Step 1: 1st check (no lock)
+  instance != null → return immediately (fast path, 99.99% of cases)
+  instance == null → proceed to Step 2
 
-Step 2: synchronized ブロック（ロック取得）
-  複数スレッドがここに到達しても、1つだけが入れる
+Step 2: synchronized block (acquire lock)
+  Even if multiple threads reach here, only one can enter
 
-Step 3: 2nd check（ロック内）
-  別のスレッドが先に生成していた場合、ここで検出して重複生成を防ぐ
+Step 3: 2nd check (inside lock)
+  If another thread already created it, this detects it and prevents duplicate creation
 ```
 
-**WHY — なぜ volatile が必要なのか?**
+**WHY — Why is volatile necessary?**
 
-`new Singleton()` は内部的に以下の3ステップで実行される:
+`new Singleton()` internally executes in these 3 steps:
 
 ```
-① メモリを確保する
-② コンストラクタを実行する（初期化）
-③ instance 変数にメモリアドレスを代入する
+① Allocate memory
+② Execute constructor (initialization)
+③ Assign memory address to instance variable
 
-JVM の命令リオーダリングにより、実行順序が ①→③→② になる可能性がある。
+Due to JVM instruction reordering, the execution order may become ①→③→②.
 
-Thread A: ①→③ まで完了（②はまだ）
-Thread B: 1st check で instance != null → 未初期化のオブジェクトを使用 → バグ！
+Thread A: completes ①→③ (② not yet done)
+Thread B: 1st check sees instance != null → uses uninitialized object → bug!
 
-volatile はリオーダリングを禁止し、①→②→③ の順序を保証する。
+volatile prohibits reordering and guarantees the order ①→②→③.
 ```
 
-### コード例 4: Bill Pugh Singleton（Java — 推奨）
+### Code Example 4: Bill Pugh Singleton (Java — Recommended)
 
-Holder パターンとも呼ばれる。JVM のクラスローディングメカニズムを利用した、最もエレガントなスレッドセーフ実装。
+Also known as the Holder pattern. The most elegant thread-safe implementation, leveraging the JVM's class loading mechanism.
 
 ```java
 public class Singleton {
     private Singleton() {
-        System.out.println("Singleton: 初期化実行");
+        System.out.println("Singleton: initialization executed");
     }
 
-    // 内部クラスは、最初にアクセスされるまでロードされない
+    // Inner class is not loaded until it is first accessed
     private static class Holder {
-        // static final により JVM が初期化の排他制御を保証
+        // static final guarantees JVM ensures exclusive initialization
         private static final Singleton INSTANCE = new Singleton();
     }
 
     public static Singleton getInstance() {
-        return Holder.INSTANCE;  // 初回呼出時に Holder クラスがロードされる
+        return Holder.INSTANCE;  // Holder class is loaded on first call
     }
 }
 ```
 
-**WHY — なぜ Holder パターンが推奨なのか?**
+**WHY — Why is the Holder pattern recommended?**
 
-1. **遅延初期化**: `Holder` クラスは `getInstance()` が初めて呼ばれるまでロードされない
-2. **スレッドセーフ**: JVM 仕様により、クラスの初期化は排他的に行われる（JLS 12.4.2）
-3. **ロックフリー**: synchronized を使わないため、パフォーマンスへの影響がない
-4. **コードがシンプル**: volatile も synchronized も不要
+1. **Lazy initialization**: The `Holder` class is not loaded until `getInstance()` is called for the first time
+2. **Thread-safe**: JVM specification guarantees class initialization is done exclusively (JLS 12.4.2)
+3. **Lock-free**: No impact on performance since synchronized is not used
+4. **Simple code**: No volatile or synchronized needed
 
-### コード例 5: Enum Singleton（Java）
+### Code Example 5: Enum Singleton (Java)
 
-Joshua Bloch（Effective Java著者）が推奨する、Java における最善の Singleton 実装。
+The best Singleton implementation in Java, recommended by Joshua Bloch (author of Effective Java).
 
 ```java
 public enum Singleton {
@@ -407,47 +407,47 @@ public enum Singleton {
     }
 }
 
-// 使用
+// Usage
 Singleton.INSTANCE.setValue(42);
 Singleton.INSTANCE.doSomething();
 ```
 
-**WHY — なぜ Enum が最善なのか?**
+**WHY — Why is Enum the best option?**
 
-1. **スレッドセーフ**: JVM が enum の初期化を保証
-2. **シリアライゼーション対応**: デシリアライズで新インスタンスが生成されない（自動対応）
-3. **リフレクション攻撃防止**: `Constructor.newInstance()` で enum は生成できない
-4. **コードが最小**: ボイラープレートがほぼゼロ
+1. **Thread-safe**: JVM guarantees enum initialization
+2. **Serialization support**: No new instance is created on deserialization (automatic)
+3. **Reflection attack prevention**: enum cannot be instantiated via `Constructor.newInstance()`
+4. **Minimal code**: Almost zero boilerplate
 
 ```
-通常の Singleton が脆弱な攻撃:
+Attacks that regular Singleton is vulnerable to:
 
-1. リフレクション攻撃
+1. Reflection attack
    Constructor<Singleton> c = Singleton.class.getDeclaredConstructor();
    c.setAccessible(true);
-   Singleton s2 = c.newInstance();  // 2つ目が生成される！
-   → Enum では IllegalArgumentException
+   Singleton s2 = c.newInstance();  // second instance created!
+   → Enum throws IllegalArgumentException
 
-2. デシリアライゼーション攻撃
+2. Deserialization attack
    ObjectInputStream ois = new ObjectInputStream(...);
-   Singleton s2 = (Singleton) ois.readObject();  // 別インスタンス！
-   → Enum では同じ INSTANCE が返る
+   Singleton s2 = (Singleton) ois.readObject();  // different instance!
+   → Enum returns the same INSTANCE
 ```
 
-### コード例 6: Python — メタクラス Singleton
+### Code Example 6: Python — Metaclass Singleton
 
-Python では、メタクラスを使うことで、クラスのインスタンス生成プロセスをカスタマイズできる。
+In Python, metaclasses can be used to customize the instance creation process of a class.
 
 ```python
 import threading
 
 class SingletonMeta(type):
-    """スレッドセーフなSingletonメタクラス"""
+    """Thread-safe Singleton metaclass"""
     _instances: dict = {}
     _lock: threading.Lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
-        # Double-Checked Locking パターン
+        # Double-Checked Locking pattern
         if cls not in cls._instances:
             with cls._lock:
                 if cls not in cls._instances:
@@ -458,47 +458,47 @@ class SingletonMeta(type):
 class Database(metaclass=SingletonMeta):
     def __init__(self):
         self.connection = "connected"
-        print(f"Database: 初期化実行 (id={id(self)})")
+        print(f"Database: initialization executed (id={id(self)})")
 
     def query(self, sql: str) -> str:
         return f"Result of: {sql}"
 
-# 使用
-db1 = Database()  # "Database: 初期化実行 (id=...)"
-db2 = Database()  # 出力なし（既存インスタンスを返す）
+# Usage
+db1 = Database()  # "Database: initialization executed (id=...)"
+db2 = Database()  # no output (returns existing instance)
 
 print(db1 is db2)            # True
 print(db1.query("SELECT 1")) # "Result of: SELECT 1"
 ```
 
-**WHY — なぜメタクラスなのか?**
+**WHY — Why a metaclass?**
 
 ```
-Python のインスタンス生成フロー:
+Python instance creation flow:
 
 obj = MyClass(args)
   ↓
-MyClass.__call__(args)     ← メタクラスの __call__ が呼ばれる
+MyClass.__call__(args)     ← metaclass __call__ is invoked
   ↓
-MyClass.__new__(cls)       ← オブジェクトのメモリ確保
+MyClass.__new__(cls)       ← memory allocation for object
   ↓
-MyClass.__init__(self)     ← 初期化
+MyClass.__init__(self)     ← initialization
   ↓
 return obj
 
-SingletonMeta.__call__ をオーバーライドすることで、
-__new__ と __init__ の「前」にインスタンス存在チェックを挿入できる。
+By overriding SingletonMeta.__call__,
+we can insert an instance existence check "before" __new__ and __init__.
 ```
 
-### コード例 7: Python — デコレータ Singleton
+### Code Example 7: Python — Decorator Singleton
 
-メタクラスより軽量な方法として、デコレータを使うアプローチもある。
+A lighter-weight approach than metaclasses using a decorator.
 
 ```python
 from functools import wraps
 
 def singleton(cls):
-    """Singletonデコレータ"""
+    """Singleton decorator"""
     instances = {}
 
     @wraps(cls)
@@ -513,23 +513,23 @@ def singleton(cls):
 class Logger:
     def __init__(self):
         self.logs: list[str] = []
-        print("Logger: 初期化実行")
+        print("Logger: initialization executed")
 
     def log(self, message: str):
         self.logs.append(message)
         print(f"[LOG] {message}")
 
-# 使用
-logger1 = Logger()  # "Logger: 初期化実行"
-logger2 = Logger()  # 出力なし
+# Usage
+logger1 = Logger()  # "Logger: initialization executed"
+logger2 = Logger()  # no output
 
 logger1.log("Start")
-print(logger2.logs)  # ["Start"] — 同じインスタンス
+print(logger2.logs)  # ["Start"] — same instance
 ```
 
-### コード例 8: Go — sync.Once
+### Code Example 8: Go — sync.Once
 
-Go 言語では `sync.Once` を使うことで、ゴルーチンセーフな遅延初期化を実現する。
+In Go, `sync.Once` is used to achieve goroutine-safe lazy initialization.
 
 ```go
 package main
@@ -550,32 +550,32 @@ var (
 
 func GetInstance() *singleton {
     once.Do(func() {
-        fmt.Println("Singleton: 初期化実行")
+        fmt.Println("Singleton: initialization executed")
         instance = &singleton{value: 42}
     })
     return instance
 }
 
 func main() {
-    s1 := GetInstance() // "Singleton: 初期化実行"
-    s2 := GetInstance() // 出力なし
+    s1 := GetInstance() // "Singleton: initialization executed"
+    s2 := GetInstance() // no output
 
     fmt.Println(s1 == s2)    // true
     fmt.Println(s1.value)    // 42
 }
 ```
 
-**WHY — sync.Once の内部実装:**
+**WHY — Internal implementation of sync.Once:**
 
 ```go
-// sync.Once の内部（簡略版）
+// Internal implementation of sync.Once (simplified)
 type Once struct {
-    done uint32     // atomic でチェック（高速パス）
-    m    Mutex      // 初回のみ使用
+    done uint32     // checked atomically (fast path)
+    m    Mutex      // used only on first call
 }
 
 func (o *Once) Do(f func()) {
-    if atomic.LoadUint32(&o.done) == 0 {  // 高速パス
+    if atomic.LoadUint32(&o.done) == 0 {  // fast path
         o.doSlow(f)
     }
 }
@@ -590,9 +590,9 @@ func (o *Once) doSlow(f func()) {
 }
 ```
 
-### コード例 9: Kotlin — object 宣言
+### Code Example 9: Kotlin — object Declaration
 
-Kotlin では `object` キーワードにより、言語レベルで Singleton がサポートされている。
+In Kotlin, the `object` keyword provides language-level support for Singleton.
 
 ```kotlin
 object AppConfig {
@@ -603,21 +603,21 @@ object AppConfig {
         "postgresql://$dbHost:$dbPort/mydb"
 
     init {
-        println("AppConfig: 初期化実行")
+        println("AppConfig: initialization executed")
     }
 }
 
-// 使用
+// Usage
 fun main() {
     println(AppConfig.connectionString())
-    // AppConfig.connectionString() == AppConfig.connectionString() は常に同じ結果
+    // AppConfig.connectionString() always returns the same result
 }
 ```
 
-**WHY — Kotlin の object は内部的に何をしているのか?**
+**WHY — What does Kotlin's object do internally?**
 
 ```
-Kotlin の object 宣言は、コンパイル時に以下の Java コードに変換される:
+Kotlin's object declaration is compiled to the following Java code at compile time:
 
 public final class AppConfig {
     public static final AppConfig INSTANCE;
@@ -630,18 +630,18 @@ public final class AppConfig {
     private AppConfig() { ... }
 }
 
-→ Eager Init パターン + private constructor が自動生成される
+→ Eager Init pattern + private constructor is auto-generated
 ```
 
-### コード例 10: DI コンテナによる Singleton ライフタイム
+### Code Example 10: Singleton Lifetime via DI Container
 
-実務では、クラス自身が Singleton 制約を管理するより、DI コンテナに委譲する方が圧倒的に優れている。
+In practice, delegating Singleton constraint management to a DI container is far superior to having the class manage it itself.
 
 ```typescript
-// InversifyJS の例
+// InversifyJS example
 import { Container, injectable, inject } from "inversify";
 
-// インタフェース
+// Interfaces
 interface Logger {
   log(message: string): void;
 }
@@ -655,11 +655,11 @@ const TYPES = {
   Database: Symbol.for("Database"),
 };
 
-// 実装クラス（Singleton であることを知らない）
+// Implementation classes (unaware that they are Singletons)
 @injectable()
 class ConsoleLogger implements Logger {
   constructor() {
-    console.log("ConsoleLogger: 初期化");
+    console.log("ConsoleLogger: initialized");
   }
 
   log(message: string): void {
@@ -670,7 +670,7 @@ class ConsoleLogger implements Logger {
 @injectable()
 class PostgresDatabase implements Database {
   constructor(@inject(TYPES.Logger) private logger: Logger) {
-    this.logger.log("PostgresDatabase: 初期化");
+    this.logger.log("PostgresDatabase: initialized");
   }
 
   async query(sql: string): Promise<any> {
@@ -679,164 +679,165 @@ class PostgresDatabase implements Database {
   }
 }
 
-// DI コンテナでライフタイムを制御
+// DI container controls lifetime
 const container = new Container();
 
 container
   .bind<Logger>(TYPES.Logger)
   .to(ConsoleLogger)
-  .inSingletonScope();   // ← コンテナが1インスタンスを保証
+  .inSingletonScope();   // ← container guarantees one instance
 
 container
   .bind<Database>(TYPES.Database)
   .to(PostgresDatabase)
   .inSingletonScope();
 
-// 取得
+// Retrieve
 const logger1 = container.get<Logger>(TYPES.Logger);
 const logger2 = container.get<Logger>(TYPES.Logger);
 console.log(logger1 === logger2); // true
 
-// テスト時はモックに差し替え可能
+// In tests, can be swapped with a mock
 const testContainer = new Container();
 testContainer.bind<Logger>(TYPES.Logger).toConstantValue({
   log: jest.fn(),
 });
 ```
 
-**WHY — DI コンテナが優れている理由:**
+**WHY — Why DI containers are superior:**
 
 ```
-クラス内 Singleton:
+Class-internal Singleton:
 ┌──────────────────────┐
 │ class Database {     │
-│   static instance    │  ← クラスがライフタイムを管理
-│   private constructor│  ← テストでモック不可
-│   static getInstance │  ← 直接参照 = 密結合
+│   static instance    │  ← class manages lifetime
+│   private constructor│  ← cannot mock in tests
+│   static getInstance │  ← direct reference = tight coupling
 │ }                    │
 └──────────────────────┘
 
-DI コンテナ Singleton:
+DI Container Singleton:
 ┌──────────────────────┐
-│ interface Database { │  ← インタフェースに依存
+│ interface Database { │  ← depends on interface
 │   query(): ...       │
 │ }                    │
 │                      │
-│ container.bind(...)  │  ← コンテナがライフタイム管理
-│   .inSingletonScope()│  ← スコープの変更が1行
+│ container.bind(...)  │  ← container manages lifetime
+│   .inSingletonScope()│  ← scope change in one line
 │                      │
-│ テスト時:             │
-│   bind(...).to(Mock) │  ← モック差し替え容易
+│ In tests:            │
+│   bind(...).to(Mock) │  ← easy mock substitution
 └──────────────────────┘
 ```
 
 ---
 
-## 4. スレッドセーフ実装の比較
+## 4. Comparison of Thread-Safe Implementations
 
-### 4.1 実装戦略の全体像
+### 4.1 Overview of Implementation Strategies
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│              スレッドセーフ Singleton 実装戦略                  │
+│          Thread-Safe Singleton Implementation Strategies       │
 ├──────────────┬───────────────────────────────────────────────┤
-│  Eager Init  │  クラスロード時に生成（最も単純）                │
+│  Eager Init  │  Created at class load (simplest)             │
 │              │  static instance = new Singleton()            │
-│              │  利点: 実装簡単、スレッドセーフ保証              │
-│              │  欠点: 使われなくてもメモリを消費              │
+│              │  Pros: easy to implement, thread-safe         │
+│              │  Cons: consumes memory even if unused         │
 ├──────────────┼───────────────────────────────────────────────┤
 │  DCL         │  Double-Checked Locking                       │
 │              │  volatile + synchronized                      │
-│              │  利点: 遅延初期化 + 高速パス                    │
-│              │  欠点: 実装複雑、volatile の理解が必要          │
+│              │  Pros: lazy init + fast path                  │
+│              │  Cons: complex impl, volatile understanding   │
 ├──────────────┼───────────────────────────────────────────────┤
-│  Holder      │  内部クラスの遅延ロード（Bill Pugh）            │
-│              │  利点: 遅延 + ロックフリー + シンプル            │
-│              │  欠点: Java 専用のイディオム                    │
+│  Holder      │  Inner class lazy loading (Bill Pugh)         │
+│              │  Pros: lazy + lock-free + simple              │
+│              │  Cons: Java-specific idiom                    │
 ├──────────────┼───────────────────────────────────────────────┤
-│  Enum        │  JVM が保証。直列化・リフレクションにも対応       │
-│              │  利点: 完全防御、コード最小                      │
-│              │  欠点: 継承不可、Java 専用                      │
+│  Enum        │  Guaranteed by JVM. Handles serialization     │
+│              │  and reflection.                              │
+│              │  Pros: complete protection, minimal code      │
+│              │  Cons: no inheritance, Java-specific          │
 ├──────────────┼───────────────────────────────────────────────┤
-│  sync.Once   │  Go 標準ライブラリ                              │
-│              │  利点: ゴルーチンセーフ、イディオマティック         │
-│              │  欠点: Go 専用                                  │
+│  sync.Once   │  Go standard library                         │
+│              │  Pros: goroutine-safe, idiomatic              │
+│              │  Cons: Go-specific                            │
 ├──────────────┼───────────────────────────────────────────────┤
-│  Module      │  ES Module のキャッシュ機構を利用               │
-│  Scope       │  利点: 言語仕様で保証、コード最小               │
-│              │  欠点: JS/TS 専用、テスト時のリセットに注意      │
+│  Module      │  Leverages ES Module caching mechanism        │
+│  Scope       │  Pros: guaranteed by language spec, minimal  │
+│              │  Cons: JS/TS only, care needed on test reset  │
 └──────────────┴───────────────────────────────────────────────┘
 ```
 
-### 4.2 パフォーマンス特性
+### 4.2 Performance Characteristics
 
 ```
-アクセス回数 vs レイテンシ（概念図）
+Number of accesses vs. latency (conceptual diagram)
 
-レイテンシ
+Latency
   ^
   |
-  |  * Lazy (synchronized毎回)
+  |  * Lazy (lock on every call)
   |  |
-  |  |   * DCL (初回のみロック)
+  |  |   * DCL (lock on first call only)
   |  |   |
   |  |   |  * Eager / Holder / Enum / Module
   |  |   |  |
-  |--+---+--+-------------------------> アクセス回数
+  |--+---+--+-------------------------> Number of accesses
      1   2  3   4   5   ...  1000
 
-  ※ DCL は2回目以降、Eager/Holder と同等の速度
-  ※ synchronized 毎回は常にロック取得コストがかかる
+  * DCL is equivalent to Eager/Holder speed from the second access onward
+  * Synchronized every time always incurs lock acquisition cost
 ```
 
 ---
 
-## 5. 比較表
+## 5. Comparison Tables
 
-### 比較表 1: Singleton 実装手法の比較
+### Comparison Table 1: Singleton Implementation Methods
 
-| 手法 | 遅延初期化 | スレッドセーフ | 実装難易度 | 直列化対応 | リフレクション防御 | 推奨度 |
+| Method | Lazy Init | Thread-Safe | Impl Complexity | Serialization | Reflection Defense | Rating |
 |------|:---:|:---:|:---:|:---:|:---:|:---:|
-| Eager Init | No | Yes | 低 | 要対応 | No | B |
-| Lazy (同期なし) | Yes | No | 低 | 要対応 | No | D |
-| DCL | Yes | Yes | 中 | 要対応 | No | B |
-| Holder パターン | Yes | Yes | 中 | 要対応 | No | A |
-| Enum (Java) | No | Yes | 低 | 自動 | Yes | S |
-| sync.Once (Go) | Yes | Yes | 低 | N/A | N/A | A |
-| object (Kotlin) | No | Yes | 低 | 要対応 | No | A |
-| モジュールスコープ (JS/TS) | Yes* | N/A | 低 | N/A | N/A | S |
+| Eager Init | No | Yes | Low | Needs handling | No | B |
+| Lazy (no sync) | Yes | No | Low | Needs handling | No | D |
+| DCL | Yes | Yes | Medium | Needs handling | No | B |
+| Holder Pattern | Yes | Yes | Medium | Needs handling | No | A |
+| Enum (Java) | No | Yes | Low | Automatic | Yes | S |
+| sync.Once (Go) | Yes | Yes | Low | N/A | N/A | A |
+| object (Kotlin) | No | Yes | Low | Needs handling | No | A |
+| Module Scope (JS/TS) | Yes* | N/A | Low | N/A | N/A | S |
 
-*モジュール初回インポート時に評価される。
+*Evaluated on first module import.
 
-### 比較表 2: Singleton vs DI コンテナ vs グローバル変数
+### Comparison Table 2: Singleton vs DI Container vs Global Variable
 
-| 観点 | クラス内 Singleton | DI コンテナ Singleton | グローバル変数 |
+| Aspect | Class-internal Singleton | DI Container Singleton | Global Variable |
 |------|:---:|:---:|:---:|
-| テスト容易性 | 低い | 高い | 最低 |
-| 結合度 | 高い（直接参照） | 低い（IF経由） | 最高 |
-| ライフタイム管理 | クラス自身 | コンテナ | なし |
-| グローバル状態 | 露出する | 隠蔽可能 | 完全露出 |
-| 柔軟性 | 低い | 高い | 低い |
-| 型安全性 | あり | あり | 言語依存 |
-| IDEサポート | 良好 | 良好 | 限定的 |
+| Testability | Low | High | Worst |
+| Coupling | High (direct ref) | Low (via interface) | Highest |
+| Lifetime management | Class itself | Container | None |
+| Global state | Exposed | Can be hidden | Fully exposed |
+| Flexibility | Low | High | Low |
+| Type safety | Yes | Yes | Language-dependent |
+| IDE support | Good | Good | Limited |
 
-### 比較表 3: 言語別 Singleton 推奨実装
+### Comparison Table 3: Recommended Singleton Implementation by Language
 
-| 言語 | 推奨実装 | 理由 |
+| Language | Recommended Implementation | Reason |
 |------|---------|------|
-| Java | Enum Singleton | 完全防御、Effective Java 推奨 |
-| Kotlin | object 宣言 | 言語ネイティブサポート |
-| TypeScript | モジュールスコープ export | 言語仕様で保証、最小コード |
-| Python | メタクラス or デコレータ | 柔軟、Pythonic |
-| Go | sync.Once | 標準ライブラリ、イディオマティック |
-| C# | Lazy<T> | .NET 標準、スレッドセーフ |
-| Rust | once_cell / std::sync::OnceLock | 所有権システムと統合 |
+| Java | Enum Singleton | Complete protection, Effective Java recommended |
+| Kotlin | object declaration | Native language support |
+| TypeScript | Module scope export | Guaranteed by language spec, minimal code |
+| Python | Metaclass or decorator | Flexible, Pythonic |
+| Go | sync.Once | Standard library, idiomatic |
+| C# | Lazy<T> | .NET standard, thread-safe |
+| Rust | once_cell / std::sync::OnceLock | Integrated with ownership system |
 
 ---
 
-## 6. Singleton と関連パターンの関係
+## 6. Singleton and Related Patterns
 
-### 6.1 Singleton が使われる場面マップ
+### 6.1 Usage Map of Singleton
 
 ```
                     Singleton
@@ -844,20 +845,20 @@ DI コンテナ Singleton:
         +--------------+--------------+
         |              |              |
    Logger         Config         Registry
-   (ロガー)       (設定)         (レジストリ)
+   (logger)       (config)       (registry)
         |              |              |
-        |              |              +--- Factory の
-        |              |                   プロダクト登録先
-        |              +--- Builder で
-        |                   複雑な設定を構築
-        +--- Observer の
-             イベント集約先
+        |              |              +--- Factory product
+        |              |                   registration target
+        |              +--- Use Builder to
+        |                   construct complex config
+        +--- Event aggregation
+             point for Observer
 ```
 
-### 6.2 Singleton と他パターンの組み合わせ
+### 6.2 Singleton Combined with Other Patterns
 
 ```typescript
-// Singleton + Factory: レジストリパターン
+// Singleton + Factory: Registry pattern
 class PluginRegistry {
   private static instance: PluginRegistry;
   private plugins = new Map<string, () => Plugin>();
@@ -882,7 +883,7 @@ class PluginRegistry {
   }
 }
 
-// Singleton + Observer: イベントバス
+// Singleton + Observer: Event bus
 class EventBus {
   private static instance: EventBus;
   private listeners = new Map<string, Set<Function>>();
@@ -911,33 +912,33 @@ class EventBus {
 
 ---
 
-## 7. 実世界での適用例
+## 7. Real-World Application Examples
 
-### 7.1 Node.js のモジュールキャッシュ（Singleton の実例）
+### 7.1 Node.js Module Cache (A Real Example of Singleton)
 
-Node.js の `require()` / `import` は内部的にモジュールをキャッシュする。これは Singleton パターンの実装そのものである。
+Node.js `require()` / `import` internally caches modules. This is a direct implementation of the Singleton pattern.
 
 ```
-require('express') の内部動作:
+Internal behavior of require('express'):
 
-Module._cache = {};  // グローバルキャッシュ
+Module._cache = {};  // global cache
 
 Module._load(filename) {
   if (Module._cache[filename]) {
-    return Module._cache[filename].exports;  // キャッシュヒット
+    return Module._cache[filename].exports;  // cache hit
   }
 
   const module = new Module(filename);
-  Module._cache[filename] = module;  // キャッシュに保存
-  module.load(filename);             // ファイルを読み込み・実行
+  Module._cache[filename] = module;  // save to cache
+  module.load(filename);             // read and execute file
   return module.exports;
 }
 ```
 
-### 7.2 データベースコネクションプール
+### 7.2 Database Connection Pool
 
 ```typescript
-// 実務的な Singleton コネクションプール
+// Practical Singleton connection pool
 import { Pool, PoolConfig } from 'pg';
 
 class DatabasePool {
@@ -951,24 +952,24 @@ class DatabasePool {
         database: process.env.DB_NAME ?? 'myapp',
         user: process.env.DB_USER ?? 'postgres',
         password: process.env.DB_PASSWORD,
-        max: 20,                    // 最大コネクション数
-        idleTimeoutMillis: 30000,   // アイドルタイムアウト
-        connectionTimeoutMillis: 2000, // 接続タイムアウト
+        max: 20,                    // maximum connections
+        idleTimeoutMillis: 30000,   // idle timeout
+        connectionTimeoutMillis: 2000, // connection timeout
       };
 
       DatabasePool.pool = new Pool(config);
 
-      // エラーハンドリング
+      // Error handling
       DatabasePool.pool.on('error', (err) => {
         console.error('Unexpected pool error:', err);
       });
 
-      console.log('DatabasePool: 初期化完了 (max=20)');
+      console.log('DatabasePool: initialized (max=20)');
     }
     return DatabasePool.pool;
   }
 
-  // テスト用: プールをリセット
+  // For tests: reset the pool
   static async reset(): Promise<void> {
     if (DatabasePool.pool) {
       await DatabasePool.pool.end();
@@ -977,7 +978,7 @@ class DatabasePool {
   }
 }
 
-// 使用
+// Usage
 async function getUsers() {
   const pool = DatabasePool.getPool();
   const result = await pool.query('SELECT * FROM users');
@@ -985,10 +986,10 @@ async function getUsers() {
 }
 ```
 
-### 7.3 設定管理（環境別切り替え）
+### 7.3 Configuration Management (Switching by Environment)
 
 ```typescript
-// 環境別の設定を Singleton で管理
+// Managing environment-specific settings with Singleton
 type Environment = 'development' | 'staging' | 'production';
 
 interface AppSettings {
@@ -1029,12 +1030,12 @@ export const appSettings: Readonly<AppSettings> = Object.freeze(settings[env]);
 
 ---
 
-## 8. エッジケースと注意点
+## 8. Edge Cases and Cautions
 
-### 8.1 シリアライゼーションによる Singleton 破壊
+### 8.1 Singleton Broken by Serialization
 
 ```java
-// Java: デシリアライゼーションで Singleton が破壊される例
+// Java: Example of Singleton being broken by deserialization
 public class Singleton implements Serializable {
     private static final Singleton INSTANCE = new Singleton();
 
@@ -1044,23 +1045,23 @@ public class Singleton implements Serializable {
         return INSTANCE;
     }
 
-    // これがないと、デシリアライズ時に新インスタンスが生成される
-    // readResolve() で既存インスタンスを返すことで防御
+    // Without this, a new instance is created during deserialization
+    // readResolve() returns the existing instance as a defense
     private Object readResolve() {
         return INSTANCE;
     }
 }
 ```
 
-### 8.2 リフレクションによる Singleton 破壊
+### 8.2 Singleton Broken by Reflection
 
 ```java
-// 攻撃コード
+// Attack code
 Constructor<Singleton> constructor = Singleton.class.getDeclaredConstructor();
 constructor.setAccessible(true);
-Singleton s2 = constructor.newInstance(); // private constructor を迂回！
+Singleton s2 = constructor.newInstance(); // bypasses private constructor!
 
-// 防御策: コンストラクタ内でチェック
+// Defense: check inside the constructor
 private Singleton() {
     if (INSTANCE != null) {
         throw new IllegalStateException("Singleton already initialized");
@@ -1068,77 +1069,77 @@ private Singleton() {
 }
 ```
 
-### 8.3 クラスローダーによる複数インスタンス
+### 8.3 Multiple Instances via Class Loaders
 
 ```
-Java EE / OSGi 環境では、異なるクラスローダーが同じクラスを
-別々にロードする可能性がある:
+In Java EE / OSGi environments, different class loaders may load
+the same class separately:
 
 ClassLoader A → Singleton.class → instance A
 ClassLoader B → Singleton.class → instance B
 
-→ 2つの「Singleton」が存在してしまう！
+→ Two "Singletons" now exist!
 
-対策:
-- アプリケーションの共有クラスローダーに Singleton を配置
-- JNDI を使ってインスタンスを共有
-- DI コンテナのスコープ管理に委譲（推奨）
+Solutions:
+- Place Singleton in the application's shared class loader
+- Share the instance using JNDI
+- Delegate to DI container scope management (recommended)
 ```
 
-### 8.4 JavaScript テスト環境での問題
+### 8.4 Issues in JavaScript Test Environments
 
 ```typescript
-// Jest でモジュールキャッシュがリセットされる問題
+// Problem with module cache being reset in Jest
 
 // config.ts
 export const config = { value: "original" };
 
 // test1.spec.ts
 import { config } from './config';
-config.value = "modified";  // テスト中に変更
+config.value = "modified";  // modified during test
 
 // test2.spec.ts
 import { config } from './config';
 console.log(config.value);  // "original" or "modified"?
-// Jest の --isolateModules 設定によって異なる
+// Depends on Jest's --isolateModules setting
 
-// 対策: テストごとにリセットメカニズムを提供
+// Solution: provide a reset mechanism per test
 export function resetConfig(): void {
   Object.assign(config, defaultConfig);
 }
 ```
 
-### 8.5 マイクロサービスにおける Singleton の罠
+### 8.5 The Singleton Trap in Microservices
 
 ```
-モノリス:
+Monolith:
 ┌─────────────────────────────────┐
 │ Application                     │
-│   Singleton.getInstance() ──→ 1つのインスタンス
+│   Singleton.getInstance() ──→ one instance
 │                                 │
-│   全てのリクエストが共有          │
+│   Shared by all requests        │
 └─────────────────────────────────┘
 
-マイクロサービス:
+Microservices:
 ┌──────────┐  ┌──────────┐  ┌──────────┐
 │ Instance1│  │ Instance2│  │ Instance3│
 │ Singleton│  │ Singleton│  │ Singleton│
 │ (state A)│  │ (state B)│  │ (state C)│
 └──────────┘  └──────────┘  └──────────┘
-  ↑ 各プロセスに独立した Singleton が存在
-  ↑ 状態の同期が必要 → Redis 等の外部ストアが必要
+  ↑ An independent Singleton exists in each process
+  ↑ State synchronization is needed → external store such as Redis is required
 
-教訓: Singleton = プロセス内Singleton であり、分散環境では不十分
+Lesson: Singleton = in-process Singleton; insufficient for distributed environments
 ```
 
 ---
 
-## 9. アンチパターン
+## 9. Anti-Patterns
 
-### アンチパターン 1: God Singleton（神シングルトン）
+### Anti-Pattern 1: God Singleton
 
 ```typescript
-// NG: 何でも詰め込む「神」シングルトン
+// NG: A "god" Singleton that holds everything
 class AppState {
   private static instance: AppState;
 
@@ -1148,7 +1149,7 @@ class AppState {
   notifications: Notification[] = [];
   searchHistory: string[] = [];
   recentProducts: Product[] = [];
-  // ... 50以上のプロパティ
+  // ... 50+ properties
 
   static getInstance(): AppState {
     if (!this.instance) this.instance = new AppState();
@@ -1156,22 +1157,22 @@ class AppState {
   }
 }
 
-// 使用側: あらゆるモジュールが AppState に依存
+// Usage: every module depends on AppState
 function processOrder() {
   const state = AppState.getInstance();
-  state.cart;           // カート機能が依存
-  state.user;           // ユーザー機能が依存
-  state.notifications;  // 通知機能が依存
+  state.cart;           // cart feature depends on it
+  state.user;           // user feature depends on it
+  state.notifications;  // notification feature depends on it
 }
 ```
 
-**問題**:
-- 単一責任原則（SRP）に違反
-- あらゆるモジュールが AppState に依存し、変更の影響範囲が膨大
-- テストで不要なプロパティまで初期化が必要
+**Problems**:
+- Violates the Single Responsibility Principle (SRP)
+- Every module depends on AppState, creating a massive scope of impact for changes
+- Tests require initializing unnecessary properties
 
 ```typescript
-// OK: ドメインごとに分割し、DI コンテナで管理
+// OK: Split by domain and manage with DI container
 interface UserState {
   currentUser: User | null;
   login(credentials: Credentials): Promise<void>;
@@ -1190,16 +1191,16 @@ interface NotificationState {
   markRead(id: string): void;
 }
 
-// 各状態を独立して管理
+// Manage each state independently
 container.bind<UserState>(TYPES.UserState).to(UserStateImpl).inSingletonScope();
 container.bind<CartState>(TYPES.CartState).to(CartStateImpl).inSingletonScope();
 container.bind<NotificationState>(TYPES.NotificationState).to(NotificationStateImpl).inSingletonScope();
 ```
 
-### アンチパターン 2: テスト間での状態リーク
+### Anti-Pattern 2: State Leaking Between Tests
 
 ```typescript
-// NG: テスト間で Singleton の状態がリークする
+// NG: Singleton state leaks between tests
 class Counter {
   private static instance: Counter;
   private count = 0;
@@ -1215,7 +1216,7 @@ class Counter {
   getCount(): number { return this.count; }
 }
 
-// テスト（NG）
+// Test (NG)
 describe("feature A", () => {
   it("increments counter", () => {
     Counter.getInstance().increment();
@@ -1226,14 +1227,14 @@ describe("feature A", () => {
 
 describe("feature B", () => {
   it("starts at zero", () => {
-    // 前のテストの状態が残っている！
+    // State from previous test remains!
     expect(Counter.getInstance().getCount()).toBe(0); // FAIL: 2
   });
 });
 ```
 
 ```typescript
-// OK: リセットメカニズムを提供する
+// OK: Provide a reset mechanism
 class Counter {
   private static instance: Counter;
   private count = 0;
@@ -1248,30 +1249,30 @@ class Counter {
   increment(): void { this.count++; }
   getCount(): number { return this.count; }
 
-  // テスト用リセット（本番コードでは呼ばない）
+  // For testing (do not call in production code)
   static resetForTesting(): void {
     this.instance = undefined as any;
   }
 }
 
-// テスト（OK）
+// Test (OK)
 beforeEach(() => {
   Counter.resetForTesting();
 });
 ```
 
-### アンチパターン 3: Singleton 内での副作用的な初期化
+### Anti-Pattern 3: Side-Effect Initialization Inside Singleton
 
 ```typescript
-// NG: コンストラクタで外部リソースに接続
+// NG: Connecting to external resources in the constructor
 class ApiClient {
   private static instance: ApiClient;
   private connection: WebSocket;
 
   private constructor() {
-    // コンストラクタで WebSocket 接続を開始
-    // → いつ getInstance() が呼ばれるか制御できない
-    // → テストで実際の接続が発生する
+    // Starting WebSocket connection in constructor
+    // → cannot control when getInstance() is called
+    // → actual connection occurs during tests
     this.connection = new WebSocket("wss://api.example.com");
   }
 
@@ -1283,7 +1284,7 @@ class ApiClient {
 ```
 
 ```typescript
-// OK: 明示的な初期化メソッドを分離
+// OK: Separate the explicit initialization method
 class ApiClient {
   private static instance: ApiClient;
   private connection: WebSocket | null = null;
@@ -1308,72 +1309,74 @@ class ApiClient {
   }
 }
 
-// 使用: 初期化タイミングを制御できる
+// Usage: can control initialization timing
 const client = ApiClient.getInstance();
 await client.connect("wss://api.example.com");
 ```
 
 ---
 
-## 10. トレードオフ分析
+## 10. Trade-off Analysis
 
-### 10.1 Singleton を使う場合の利点と欠点
+### 10.1 Pros and Cons of Using Singleton
 
 ```
-利点                              欠点
+Pros                              Cons
 +------------------------------+  +------------------------------+
-| インスタンス数を制御できる    |  | グローバル状態になりがち      |
-| メモリ効率が良い              |  | テストが困難（モック困難）    |
-| 共有リソースの一貫性保証      |  | 結合度が上がる                |
-| アクセスポイントが明確        |  | 並行処理の考慮が必要          |
-| 遅延初期化が可能              |  | 状態のリセットが困難          |
-+------------------------------+  +------------------------------+
+| Can control instance count   |  | Tends to become global state |
+| Good memory efficiency       |  | Testing is difficult (hard   |
+| Guarantees shared resource   |  |   to mock)                   |
+|   consistency                |  | Increases coupling           |
+| Clear access point           |  | Concurrent processing needs  |
+| Lazy initialization possible |  |   consideration              |
++------------------------------+  | Difficult to reset state     |
+                                  +------------------------------+
 ```
 
-### 10.2 判断フローチャート
+### 10.2 Decision Flowchart
 
 ```
-インスタンスを1つに制限する必要がある？
+Is there a need to limit to a single instance?
 │
-├── No → Singleton 不要。通常のクラスまたは DI を使う
+├── No → Singleton not needed. Use a regular class or DI
 │
 └── Yes
     │
-    ├── DI コンテナを使えるか？
-    │   ├── Yes → DI の Singleton スコープを使う（推奨）
-    │   └── No → 次の質問へ
+    ├── Can a DI container be used?
+    │   ├── Yes → Use DI Singleton scope (recommended)
+    │   └── No → Proceed to next question
     │
-    ├── 言語は何か？
+    ├── What language?
     │   ├── Java → Enum Singleton
-    │   ├── Kotlin → object 宣言
-    │   ├── JS/TS → モジュールスコープ export
-    │   ├── Python → メタクラス or デコレータ
+    │   ├── Kotlin → object declaration
+    │   ├── JS/TS → Module scope export
+    │   ├── Python → Metaclass or decorator
     │   ├── Go → sync.Once
-    │   └── その他 → Holder or DCL
+    │   └── Other → Holder or DCL
     │
-    └── テスト時にモック可能か確認
-        ├── Yes → 実装を進める
-        └── No → リセットメカニズムを追加する
+    └── Confirm that mocking is possible during tests
+        ├── Yes → Proceed with implementation
+        └── No → Add a reset mechanism
 ```
 
 ---
 
-## 11. 実践演習
+## 11. Practice Exercises
 
-### 演習 1: 基礎 — ロガー Singleton の実装
+### Exercise 1: Basic — Implementing a Logger Singleton
 
-**課題**: アプリケーション全体で共有されるロガーを Singleton パターンで実装してください。
+**Task**: Implement a logger shared across the entire application using the Singleton pattern.
 
-**要件**:
-- ログレベル（debug / info / warn / error）をサポート
-- ログメッセージにタイムスタンプを付与
-- `getInstance()` によるアクセス
-- ログ履歴を保持し、`getHistory()` で取得可能
+**Requirements**:
+- Support log levels (debug / info / warn / error)
+- Attach timestamps to log messages
+- Access via `getInstance()`
+- Maintain log history and retrieve it via `getHistory()`
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 
-// ヒント: 以下のインタフェースを満たすこと
+// Hint: satisfy the following interface
 interface ILogger {
   debug(message: string): void;
   info(message: string): void;
@@ -1383,7 +1386,7 @@ interface ILogger {
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 const logger1 = Logger.getInstance();
@@ -1405,7 +1408,7 @@ console.log(logger1.getHistory());
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Model Answer (click to expand)</summary>
 
 ```typescript
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -1448,10 +1451,10 @@ class Logger implements ILogger {
   error(message: string): void { this.log('error', message); }
 
   getHistory(): string[] {
-    return [...this.history]; // コピーを返す（防御的コピー）
+    return [...this.history]; // return a copy (defensive copy)
   }
 
-  // テスト用
+  // For testing
   static resetForTesting(): void {
     Logger.instance = null;
   }
@@ -1460,21 +1463,21 @@ class Logger implements ILogger {
 
 </details>
 
-### 演習 2: 応用 — 設定マネージャ with 環境切替
+### Exercise 2: Intermediate — Configuration Manager with Environment Switching
 
-**課題**: 環境（development / staging / production）に応じた設定を管理する Singleton を実装してください。
+**Task**: Implement a Singleton that manages settings based on the environment (development / staging / production).
 
-**要件**:
-- モジュールスコープ Singleton として実装
-- 環境変数 `NODE_ENV` から環境を判定
-- 設定値の取得は型安全に行う
-- 設定値の動的な上書き（override）をサポート
-- 設定値のバリデーション
+**Requirements**:
+- Implement as a module scope Singleton
+- Determine the environment from the `NODE_ENV` environment variable
+- Retrieve config values in a type-safe manner
+- Support dynamic overriding of config values
+- Validate config values
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 
-// ヒント: 以下のインタフェースを満たすこと
+// Hint: satisfy the following interface
 interface ConfigManager {
   get<T>(key: string): T;
   get<T>(key: string, defaultValue: T): T;
@@ -1484,7 +1487,7 @@ interface ConfigManager {
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 // NODE_ENV=development
@@ -1500,11 +1503,11 @@ console.log(configManager.get<string>("apiBaseUrl"));
 // "http://localhost:4000"
 
 console.log(configManager.get<number>("maxRetries", 5));
-// 5 (デフォルト値が返る)
+// 5 (default value returned)
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Model Answer (click to expand)</summary>
 
 ```typescript
 type Environment = 'development' | 'staging' | 'production';
@@ -1580,27 +1583,27 @@ class ConfigManagerImpl implements ConfigManager {
   }
 }
 
-// モジュールスコープ Singleton
+// Module scope Singleton
 export const configManager: ConfigManager = new ConfigManagerImpl();
 ```
 
 </details>
 
-### 演習 3: 発展 — DI コンテナ対応の Singleton
+### Exercise 3: Advanced — DI Container-Compatible Singleton
 
-**課題**: DI コンテナ（InversifyJS 風）を使って、テスト可能な Singleton サービスを設計してください。
+**Task**: Design a testable Singleton service using a DI container (InversifyJS-style).
 
-**要件**:
-- `ICacheService` インタフェースを定義
-- `RedisCacheService` として本番実装を作成
-- `InMemoryCacheService` としてテスト用実装を作成
-- DI コンテナで Singleton スコープを設定
-- テストコードでモック差し替えを実演
+**Requirements**:
+- Define the `ICacheService` interface
+- Create a production implementation as `RedisCacheService`
+- Create a test implementation as `InMemoryCacheService`
+- Configure Singleton scope in the DI container
+- Demonstrate mock substitution in test code
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 
-// ヒント: 以下のインタフェースを満たすこと
+// Hint: satisfy the following interface
 interface ICacheService {
   get<T>(key: string): Promise<T | null>;
   set<T>(key: string, value: T, ttlSeconds?: number): Promise<void>;
@@ -1609,16 +1612,16 @@ interface ICacheService {
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-// 本番
+// Production
 const cache = container.get<ICacheService>(TYPES.Cache);
 await cache.set("user:1", { name: "Taro" }, 3600);
 const user = await cache.get("user:1");
 console.log(user); // { name: "Taro" }
 
-// テスト
+// Test
 const testCache = testContainer.get<ICacheService>(TYPES.Cache);
 await testCache.set("key", "value");
 console.log(await testCache.get("key")); // "value"
@@ -1627,7 +1630,7 @@ console.log(await testCache.get("key")); // null
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Model Answer (click to expand)</summary>
 
 ```typescript
 import { Container, injectable, inject } from "inversify";
@@ -1637,15 +1640,15 @@ const TYPES = {
   Logger: Symbol.for("ILogger"),
 };
 
-// インタフェース定義（上述のICacheService）
+// Interface definition (ICacheService as above)
 
-// 本番実装
+// Production implementation
 @injectable()
 class RedisCacheService implements ICacheService {
   private client: any; // Redis client
 
   constructor(@inject(TYPES.Logger) private logger: ILogger) {
-    this.logger.info("RedisCacheService: 初期化");
+    this.logger.info("RedisCacheService: initialized");
     // this.client = createClient({ url: process.env.REDIS_URL });
   }
 
@@ -1675,7 +1678,7 @@ class RedisCacheService implements ICacheService {
   }
 }
 
-// テスト用実装
+// Test implementation
 @injectable()
 class InMemoryCacheService implements ICacheService {
   private store = new Map<string, { value: string; expiresAt?: number }>();
@@ -1706,19 +1709,19 @@ class InMemoryCacheService implements ICacheService {
   }
 }
 
-// 本番コンテナ
+// Production container
 const container = new Container();
 container.bind<ICacheService>(TYPES.Cache)
   .to(RedisCacheService)
   .inSingletonScope();
 
-// テストコンテナ
+// Test container
 const testContainer = new Container();
 testContainer.bind<ICacheService>(TYPES.Cache)
   .to(InMemoryCacheService)
   .inSingletonScope();
 
-// テスト例
+// Test example
 describe("UserService", () => {
   let cache: ICacheService;
 
@@ -1727,7 +1730,7 @@ describe("UserService", () => {
   });
 
   afterEach(async () => {
-    await cache.clear(); // 状態リーク防止
+    await cache.clear(); // prevent state leaks
   });
 
   it("should cache user data", async () => {
@@ -1744,95 +1747,95 @@ describe("UserService", () => {
 
 ## 12. FAQ
 
-### Q1: Singleton はいつ使うべきですか？
+### Q1: When should Singleton be used?
 
-ロガー、設定オブジェクト、コネクションプール、キャッシュマネージャなど、**アプリケーション全体で共有され、複数インスタンスが存在すると矛盾を起こすリソース**に対して使います。ただし、DI コンテナが利用可能なら、そちらで Singleton スコープを設定する方が望ましいです。
+Use it for **resources that are shared across the entire application and would cause inconsistency if multiple instances existed**, such as loggers, configuration objects, connection pools, and cache managers. However, if a DI container is available, it is preferable to configure Singleton scope there.
 
-**判断基準チェックリスト:**
+**Decision checklist:**
 
-| チェック項目 | Yes なら Singleton 検討 |
+| Check item | If Yes, consider Singleton |
 |-------------|----------------------|
-| 複数インスタンスが存在するとバグになるか？ | Yes → 強い根拠 |
-| 共有状態の一貫性が必要か？ | Yes → 根拠あり |
-| リソースの初期化コストが高いか？ | Yes → 根拠あり |
-| DI コンテナが使えないか？ | Yes → Singleton を自前実装 |
+| Would multiple instances cause a bug? | Yes → Strong justification |
+| Is consistency of shared state necessary? | Yes → Justification |
+| Is the initialization cost of the resource high? | Yes → Justification |
+| Can a DI container not be used? | Yes → Implement Singleton manually |
 
-### Q2: Singleton はなぜ「アンチパターン」と呼ばれることがあるのですか？
+### Q2: Why is Singleton sometimes called an "anti-pattern"?
 
-Singleton 自体がアンチパターンなのではなく、**濫用**がアンチパターンです。以下の問題を引き起こしやすい:
+Singleton itself is not an anti-pattern — **overuse** is. It tends to cause the following problems:
 
-1. **グローバル状態**: どこからでもアクセスでき、状態変更の追跡が困難
-2. **テスト困難**: モックへの差し替えが難しい（特にクラス内 Singleton）
-3. **結合度の増大**: 具象クラスへの直接依存が生まれる
-4. **並行処理の複雑化**: 共有状態へのアクセスに排他制御が必要
-5. **隠れた依存**: メソッドシグネチャに現れない依存関係が生じる
+1. **Global state**: Accessible from anywhere, making state change tracking difficult
+2. **Testing difficulty**: Hard to swap with mocks (especially class-internal Singleton)
+3. **Increased coupling**: Direct dependency on concrete classes
+4. **Concurrency complexity**: Exclusive control is needed for access to shared state
+5. **Hidden dependencies**: Dependencies that don't appear in method signatures
 
 ```typescript
-// 隠れた依存の例
+// Example of hidden dependencies
 function processOrder(order: Order): void {
-  // 関数のシグネチャからは Database と Logger への依存が見えない
-  const db = Database.getInstance();      // 隠れた依存
-  const logger = Logger.getInstance();    // 隠れた依存
+  // Dependencies on Database and Logger are invisible from the function signature
+  const db = Database.getInstance();      // hidden dependency
+  const logger = Logger.getInstance();    // hidden dependency
 
   db.save(order);
   logger.info(`Order ${order.id} processed`);
 }
 
-// DI で明示的にする
+// Making them explicit with DI
 function processOrder(
   order: Order,
-  db: IDatabase,       // 依存が明示的
-  logger: ILogger      // 依存が明示的
+  db: IDatabase,       // dependency is explicit
+  logger: ILogger      // dependency is explicit
 ): void {
   db.save(order);
   logger.info(`Order ${order.id} processed`);
 }
 ```
 
-### Q3: ES Module で export したオブジェクトは Singleton ですか？
+### Q3: Is an object exported from an ES Module a Singleton?
 
-はい。Node.js や主要バンドラ（webpack, Vite, esbuild）はモジュールを一度だけ評価しキャッシュします。そのため `export const x = new X()` は事実上 Singleton です。
+Yes. Node.js and major bundlers (webpack, Vite, esbuild) evaluate and cache modules only once. Therefore `export const x = new X()` is effectively a Singleton.
 
-ただし、以下の注意点があります:
+However, be aware of the following:
 
-| 環境 | 動作 |
+| Environment | Behavior |
 |------|------|
-| Node.js (CJS) | `require()` はキャッシュする。ただしパスが異なると別モジュール扱い |
-| Node.js (ESM) | `import` はキャッシュする |
-| Jest | `--isolateModules` でモジュールキャッシュをリセット可能 |
-| Webpack | バンドル内で1度だけ評価される |
-| SSR (Next.js) | サーバーリクエスト間で共有される（注意が必要） |
+| Node.js (CJS) | `require()` caches. However, different paths are treated as different modules |
+| Node.js (ESM) | `import` caches |
+| Jest | Module cache can be reset with `--isolateModules` |
+| Webpack | Evaluated only once within the bundle |
+| SSR (Next.js) | Shared between server requests (caution required) |
 
-### Q4: Singleton と静的クラス（static class）の違いは何ですか？
+### Q4: What is the difference between Singleton and a static class?
 
 ```
 Singleton:
-- インスタンスが1つ存在する
-- インタフェースを実装できる（ポリモーフィズム）
-- DI コンテナで管理可能
-- 遅延初期化が可能
-- 状態を持てる
+- One instance exists
+- Can implement interfaces (polymorphism)
+- Can be managed by a DI container
+- Lazy initialization is possible
+- Can hold state
 
-静的クラス:
-- インスタンスが存在しない
-- インタフェースを実装できない
-- DI コンテナで管理不可
-- クラスロード時に確定
-- ステートレス（推奨）
+Static class:
+- No instance exists
+- Cannot implement interfaces
+- Cannot be managed by a DI container
+- Determined at class load time
+- Stateless (recommended)
 ```
 
-Singleton を選ぶべき場合: インタフェースへの準拠、DI 対応、遅延初期化が必要な場合
-静的クラスを選ぶべき場合: ステートレスなユーティリティ（Math.max(), String.format() 等）
+Choose Singleton when: interface conformance, DI support, or lazy initialization is needed
+Choose static class when: stateless utilities (Math.max(), String.format(), etc.)
 
-### Q5: マイクロサービス環境で Singleton は使えますか？
+### Q5: Can Singleton be used in a microservice environment?
 
-使えますが、Singleton の「唯一性」はプロセス内に限定されることを理解してください。複数のサービスインスタンスが存在する場合、各プロセスに独立した Singleton が存在します。
+Yes, but understand that the "uniqueness" of Singleton is limited to within a process. When multiple service instances exist, an independent Singleton exists in each process.
 
 ```
-解決策:
-1. ステートレス Singleton: 状態を持たなければ問題なし（Logger, Config等）
-2. 外部ストア: 状態を Redis や DB に保存し、Singleton はアクセス層として機能
-3. リーダー選出: 分散ロック（Redis の SETNX等）で1つのインスタンスだけが処理
+Solutions:
+1. Stateless Singleton: No problem if it holds no state (Logger, Config, etc.)
+2. External store: Save state to Redis or DB, with Singleton serving as the access layer
+3. Leader election: Use distributed locks (e.g., Redis SETNX) so only one instance processes
 ```
 
 ---
@@ -1840,53 +1843,53 @@ Singleton を選ぶべき場合: インタフェースへの準拠、DI 対応�
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just through theory, but by actually writing code and confirming behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. It is recommended to thoroughly understand the fundamental concepts explained in this guide before moving to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in daily development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## 13. まとめ
+## 13. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| 目的 | インスタンスを1つに制限し、グローバルアクセスを提供 |
-| 本質的な問題 | 共有リソースの一貫性保証 |
-| 利点 | 共有リソースの一元管理、メモリ効率、遅延初期化 |
-| 欠点 | グローバル状態、テスト困難、結合度増大、並行処理の複雑化 |
-| スレッドセーフ | volatile/synchronized、Holder、Enum、sync.Once 等で対応 |
-| Java 推奨 | Enum Singleton（Effective Java 推奨） |
-| Kotlin 推奨 | object 宣言 |
-| JS/TS 推奨 | モジュールスコープ export |
-| Python 推奨 | メタクラス or デコレータ |
-| Go 推奨 | sync.Once |
-| 最善の代替 | DI コンテナの Singleton スコープ |
-| 判断基準 | 複数インスタンスが矛盾を起こす場合のみ使用 |
+| Purpose | Limit to one instance and provide global access |
+| Core problem | Guaranteeing consistency of shared resources |
+| Pros | Centralized shared resource management, memory efficiency, lazy initialization |
+| Cons | Global state, testing difficulty, increased coupling, concurrency complexity |
+| Thread safety | Handled with volatile/synchronized, Holder, Enum, sync.Once, etc. |
+| Java recommended | Enum Singleton (Effective Java recommended) |
+| Kotlin recommended | object declaration |
+| JS/TS recommended | Module scope export |
+| Python recommended | Metaclass or decorator |
+| Go recommended | sync.Once |
+| Best alternative | DI container Singleton scope |
+| Decision criterion | Use only when multiple instances would cause inconsistency |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [Factory Method / Abstract Factory](./01-factory.md) -- 生成の委譲と抽象化。Singleton Registry と Factory の組み合わせ
-- [Builder パターン](./02-builder.md) -- 複雑なオブジェクト構築。Singleton の設定構築に活用
-- [Prototype パターン](./03-prototype.md) -- クローンによる生成。Singleton との対比
-- [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) -- 単一責任原則と依存性逆転原則
-- [Observer パターン](../02-behavioral/00-observer.md) -- イベントバス Singleton との組み合わせ
-- [Facade パターン](../01-structural/02-facade.md) -- Singleton が提供する簡略化インタフェース
+- [Factory Method / Abstract Factory](./01-factory.md) -- Delegating and abstracting creation. Combining Singleton Registry with Factory
+- [Builder Pattern](./02-builder.md) -- Constructing complex objects. Applied to building Singleton configurations
+- [Prototype Pattern](./03-prototype.md) -- Creation by cloning. Contrast with Singleton
+- [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) -- Single Responsibility Principle and Dependency Inversion Principle
+- [Observer Pattern](../02-behavioral/00-observer.md) -- Combined with Event Bus Singleton
+- [Facade Pattern](../01-structural/02-facade.md) -- Simplified interface provided by Singleton
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Singleton パターンの原典
+1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Original source of the Singleton pattern
 2. Bloch, J. (2018). *Effective Java* (3rd ed.). Addison-Wesley. Item 3: Enforce the singleton property with a private constructor or an enum type.
 3. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media. Chapter 5: The Singleton Pattern.
 4. Fowler, M. (2004). *Inversion of Control Containers and the Dependency Injection pattern*. martinfowler.com. https://martinfowler.com/articles/injection.html

--- a/03-software-design/design-patterns-guide/docs/00-creational/01-factory.md
+++ b/03-software-design/design-patterns-guide/docs/00-creational/01-factory.md
@@ -1,46 +1,46 @@
-# Factory Method / Abstract Factory パターン
+# Factory Method / Abstract Factory Pattern
 
-> オブジェクト生成をサブクラスや専用ファクトリに **委譲** し、生成ロジックを利用側から分離する生成パターン。
-
----
-
-## この章で学ぶこと
-
-1. Factory Method と Abstract Factory の構造的な違い、および Simple Factory との使い分け（WHY）
-2. 生成ロジックの抽象化がもたらす柔軟性・テスト容易性・OCP 準拠の仕組み
-3. Registry パターンやDIとの組み合わせなど、実務での適用場面と過剰設計を避けるための判断基準
-4. 各言語（TypeScript / Python / Java / Go）での具体的な実装方法
-5. Factory パターンに伴うトレードオフとアンチパターンの回避方法
+> A creational pattern that **delegates** object creation to subclasses or dedicated factories, separating creation logic from the consuming code.
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-このガイドを理解するために、以下の知識を事前に習得しておくことを推奨します。
+1. The structural differences between Factory Method, Abstract Factory, and Simple Factory, and when to use each (WHY)
+2. How abstracting creation logic provides flexibility, testability, and OCP compliance
+3. Practical application scenarios — including combining Registry pattern with DI — and criteria for avoiding over-engineering
+4. Concrete implementations in each language (TypeScript / Python / Java / Go)
+5. Tradeoffs and anti-pattern avoidance associated with the Factory pattern
 
-| トピック | 必要レベル | 参照リンク |
+---
+
+## Prerequisites
+
+It is recommended to acquire the following knowledge before working through this guide.
+
+| Topic | Required Level | Reference |
 |---------|-----------|-----------|
-| オブジェクト指向の基礎（継承、ポリモーフィズム、インタフェース） | 必須 | OOP基礎 |
-| SOLID原則（特にOCP、DIP） | 推奨 | [SOLID原則](../../../clean-code-principles/docs/00-principles/01-solid.md) |
-| Singleton パターン | 推奨 | [Singleton](./00-singleton.md) |
-| ジェネリクス / 型パラメータ | あると望ましい | TypeScript / Java のジェネリクス |
-| DI（依存性注入）の概念 | あると望ましい | [DIP](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| OOP fundamentals (inheritance, polymorphism, interfaces) | Required | OOP Basics |
+| SOLID principles (especially OCP, DIP) | Recommended | [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Singleton pattern | Recommended | [Singleton](./00-singleton.md) |
+| Generics / type parameters | Nice to have | TypeScript / Java Generics |
+| DI (Dependency Injection) concept | Nice to have | [DIP](../../../clean-code-principles/docs/00-principles/01-solid.md) |
 
 ---
 
-## 1. Factory パターンの本質 -- なぜ生成を分離するのか
+## 1. The Essence of the Factory Pattern -- Why Separate Creation?
 
-### 1.1 解決する問題
+### 1.1 The Problem It Solves
 
-ソフトウェア開発で最も頻繁に直面する問題の1つが「**どのクラスをインスタンス化するかを、利用側が知りすぎている**」ことである。
+One of the most common problems in software development is that the **consuming code knows too much about which class to instantiate**.
 
 ```typescript
-// 問題のあるコード: 利用側が具象クラスを直接知っている
+// Problematic code: the consumer directly knows about concrete classes
 class OrderService {
   processPayment(order: Order): void {
     let processor;
 
-    // 利用側が「どのクラスを生成するか」を知っている
+    // The consumer decides "which class to instantiate"
     if (order.paymentMethod === "credit") {
       processor = new CreditCardProcessor(order.cardNumber, order.cvv);
     } else if (order.paymentMethod === "paypal") {
@@ -48,64 +48,66 @@ class OrderService {
     } else if (order.paymentMethod === "bank") {
       processor = new BankTransferProcessor(order.bankAccount);
     }
-    // 新しい支払い方法を追加するたびに、ここを変更する必要がある → OCP 違反
+    // Every time a new payment method is added, this must change → OCP violation
 
     processor.charge(order.amount);
   }
 }
 ```
 
-**WHY -- なぜこれが問題なのか?**
+**WHY -- Why is this a problem?**
 
 ```
-1. OCP（開放閉鎖原則）違反
-   新しい支払い方法の追加 → OrderService の変更が必要
-   → テストの再実行、レビュー、デプロイが必要
+1. OCP (Open/Closed Principle) violation
+   Adding a new payment method → requires changing OrderService
+   → Tests must be re-run, code must be reviewed, and redeployed
 
-2. SRP（単一責任原則）違反
-   OrderService は「注文処理」と「支払いプロセッサの選択」の2つの責任を持つ
+2. SRP (Single Responsibility Principle) violation
+   OrderService has two responsibilities: "order processing" and "payment processor selection"
 
-3. テスト困難
-   特定の支払いプロセッサをモックするために、
-   OrderService 内の条件分岐を意識する必要がある
+3. Difficult to test
+   To mock a specific payment processor,
+   you must be aware of the conditional branching inside OrderService
 
-4. 重複コード
-   別のサービスでも同じ条件分岐が発生する可能性がある
+4. Duplicate code
+   The same conditional branching may appear in other services
 ```
 
-Factory パターンはこの問題を「**生成の責任を専用のオブジェクトに委譲する**」ことで解決する。
+The Factory pattern resolves this by **delegating the responsibility of creation to a dedicated object**.
 
-### 1.2 Factory パターンの3つのバリエーション
+### 1.2 Three Variations of the Factory Pattern
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                Factory パターンの分類                         │
+│                Factory Pattern Taxonomy                       │
 ├─────────────┬───────────────────────────────────────────────┤
 │             │                                               │
-│  Simple     │  関数やクラスメソッドで条件分岐し生成           │
-│  Factory    │  GoF パターンではないが実務で最も多用           │
-│             │  例: createNotification("email")               │
+│  Simple     │  Creates objects via conditional branching    │
+│  Factory    │  in a function or class method                │
+│             │  Not a GoF pattern, but the most widely used  │
+│             │  e.g., createNotification("email")            │
 │             │                                               │
 ├─────────────┼───────────────────────────────────────────────┤
 │             │                                               │
-│  Factory    │  サブクラスが生成するプロダクトの型を決定       │
-│  Method     │  GoF パターン。テンプレートメソッドの生成版     │
-│             │  例: abstract createNotification(): Notification│
+│  Factory    │  Subclass decides the type of product created │
+│  Method     │  GoF pattern; the creational version of       │
+│             │  Template Method                              │
+│             │  e.g., abstract createNotification(): Notification│
 │             │                                               │
 ├─────────────┼───────────────────────────────────────────────┤
 │             │                                               │
-│  Abstract   │  関連するプロダクト群をまとめて生成             │
-│  Factory    │  GoF パターン。テーマ/プラットフォーム切替      │
-│             │  例: createButton() + createInput()             │
+│  Abstract   │  Creates a family of related products together│
+│  Factory    │  GoF pattern; theme/platform switching        │
+│             │  e.g., createButton() + createInput()         │
 │             │                                               │
 └─────────────┴───────────────────────────────────────────────┘
 ```
 
 ---
 
-## 2. Factory Method の構造
+## 2. Structure of Factory Method
 
-### 2.1 UML クラス図
+### 2.1 UML Class Diagram
 
 ```
 +-------------------+           +-------------------+
@@ -134,7 +136,7 @@ Factory パターンはこの問題を「**生成の責任を専用のオブジ�
 +-------------------+
 ```
 
-### 2.2 シーケンス図
+### 2.2 Sequence Diagram
 
 ```
 Client         ConcreteCreator         Product
@@ -156,23 +158,23 @@ Client         ConcreteCreator         Product
   |                  |                     |
 ```
 
-### 2.3 Factory Method の内部動作
+### 2.3 Internal Mechanics of Factory Method
 
 ```
-Factory Method の核心:
-「何を生成するか」は子クラスが決定し、
-「いつ・どのように使うか」は親クラスが決定する。
+The core of Factory Method:
+The child class decides "what to create",
+while the parent class decides "when and how to use it."
 
-Creator (親クラス):
+Creator (parent class):
 ┌──────────────────────────────────┐
 │ operation() {                    │
-│   const product = this.factory() │ ← 「何を」は子クラスに委譲
-│   product.prepare()              │ ← 「どのように使うか」は自分で定義
+│   const product = this.factory() │ ← "What" is delegated to the child class
+│   product.prepare()              │ ← "How to use it" is defined here
 │   product.use()                  │
 │   return product.result()        │
 │ }                                │
 │                                  │
-│ abstract factoryMethod(): Product│ ← 抽象メソッド
+│ abstract factoryMethod(): Product│ ← abstract method
 └──────────────────────────────────┘
          ^                ^
          |                |
@@ -185,9 +187,9 @@ Creator (親クラス):
 
 ---
 
-## 3. Abstract Factory の構造
+## 3. Structure of Abstract Factory
 
-### 3.1 UML クラス図
+### 3.1 UML Class Diagram
 
 ```
 +---------------------------+       +-------------+  +-------------+
@@ -206,34 +208,34 @@ Creator (親クラス):
                                   +-------------+  +-------------+
 ```
 
-### 3.2 Abstract Factory と Factory Method の関係
+### 3.2 Relationship Between Abstract Factory and Factory Method
 
 ```
-Abstract Factory は複数の Factory Method の集合体と見なせる:
+Abstract Factory can be viewed as a collection of multiple Factory Methods:
 
 AbstractFactory
 ├── createProductA()  ← Factory Method 1
 ├── createProductB()  ← Factory Method 2
 └── createProductC()  ← Factory Method 3
 
-各メソッドが「1つのプロダクトの生成」を担い、
-ファクトリ全体が「関連するプロダクト群の整合性」を保証する。
+Each method is responsible for creating one product,
+and the factory as a whole ensures consistency across the related product family.
 
-例: Material Design ファクトリ
+Example: Material Design factory
 ├── createButton()  → MaterialButton
 ├── createInput()   → MaterialInput
 └── createDialog()  → MaterialDialog
-  ↑ 全てが Material Design のスタイルで統一される
+  ↑ All are unified under the Material Design style
 ```
 
 ---
 
-## 4. コード例
+## 4. Code Examples
 
-### コード例 1: Factory Method（TypeScript）
+### Code Example 1: Factory Method (TypeScript)
 
 ```typescript
-// Product インタフェース
+// Product interface
 interface Notification {
   send(message: string): void;
   getType(): string;
@@ -276,12 +278,12 @@ class SmsNotification implements Notification {
   }
 }
 
-// Creator（抽象クラス）
+// Creator (abstract class)
 abstract class NotificationService {
-  // Factory Method: サブクラスが具体的な Notification を決定
+  // Factory Method: subclass determines the concrete Notification
   abstract createNotification(): Notification;
 
-  // Template Method: 通知の送信フロー
+  // Template Method: the notification sending flow
   notify(message: string): void {
     const notification = this.createNotification();
     console.log(`Sending via ${notification.getType()}...`);
@@ -311,25 +313,25 @@ class SlackService extends NotificationService {
   }
 }
 
-// 使用: Creator の型で扱えるため、具体的な通知手段に依存しない
+// Usage: handled via the Creator type, so there is no dependency on the concrete notification method
 function sendDeployNotification(service: NotificationService): void {
-  service.notify("デプロイ完了: v2.1.0");
+  service.notify("Deploy complete: v2.1.0");
 }
 
 sendDeployNotification(new SlackService("deployments"));
 // Sending via slack...
-// [Slack #deployments] デプロイ完了: v2.1.0
+// [Slack #deployments] Deploy complete: v2.1.0
 // Notification sent successfully.
 
 sendDeployNotification(new EmailService("admin@example.com"));
 // Sending via email...
-// [Email → admin@example.com] デプロイ完了: v2.1.0
+// [Email → admin@example.com] Deploy complete: v2.1.0
 // Notification sent successfully.
 ```
 
-### コード例 2: Simple Factory（関数ベース）
+### Code Example 2: Simple Factory (Function-Based)
 
-実務では GoF の Factory Method より、Simple Factory の方が圧倒的に多用される。
+In practice, Simple Factory is used far more often than the GoF Factory Method.
 
 ```typescript
 type NotificationType = "email" | "slack" | "sms";
@@ -341,7 +343,7 @@ interface NotificationConfig {
   phoneNumber?: string;
 }
 
-// Simple Factory 関数
+// Simple Factory function
 function createNotification(config: NotificationConfig): Notification {
   switch (config.type) {
     case "email":
@@ -354,13 +356,13 @@ function createNotification(config: NotificationConfig): Notification {
       if (!config.phoneNumber) throw new Error("SMS requires phoneNumber");
       return new SmsNotification(config.phoneNumber);
     default:
-      // TypeScript の exhaustive check
+      // TypeScript exhaustive check
       const _exhaustive: never = config.type;
       throw new Error(`Unknown notification type: ${_exhaustive}`);
   }
 }
 
-// 使用
+// Usage
 const emailNotif = createNotification({
   type: "email",
   recipient: "user@example.com"
@@ -374,26 +376,26 @@ const slackNotif = createNotification({
 slackNotif.send("Hello team!");
 ```
 
-**WHY -- Simple Factory と Factory Method の使い分け:**
+**WHY -- When to use Simple Factory vs Factory Method:**
 
 ```
-Simple Factory を選ぶ場合:
-- 条件分岐が単純（型名で分岐するだけ）
-- テンプレートメソッドパターンが不要
-- 生成ロジックを1箇所に集約したい
-- 関数型アプローチが好ましい
+Use Simple Factory when:
+- The conditional branching is simple (just switching on a type name)
+- Template Method pattern is not needed
+- You want to consolidate creation logic in one place
+- A functional approach is preferred
 
-Factory Method を選ぶ場合:
-- 生成するプロダクトに加えて、使用方法もカスタマイズしたい
-- テンプレートメソッドとの組み合わせが有効
-- フレームワーク設計で、拡張ポイントを提供したい
-- サブクラス化による段階的な機能追加が必要
+Use Factory Method when:
+- You want to customize not just the product created, but also how it is used
+- Combining with Template Method is effective
+- You are designing a framework and want to provide extension points
+- Incremental feature additions via subclassing are required
 ```
 
-### コード例 3: Abstract Factory（TypeScript）
+### Code Example 3: Abstract Factory (TypeScript)
 
 ```typescript
-// 抽象プロダクト
+// Abstract products
 interface Button {
   render(): string;
   onClick(handler: () => void): void;
@@ -411,7 +413,7 @@ interface Dialog {
   close(): void;
 }
 
-// 抽象ファクトリ
+// Abstract factory
 interface UIFactory {
   createButton(label: string): Button;
   createInput(placeholder: string): Input;
@@ -474,11 +476,11 @@ class IOSFactory implements UIFactory {
   createDialog(title: string) { return new IOSDialog(title); }
 }
 
-// 使用: ファクトリを差し替えるだけで UI 全体のテーマが変わる
+// Usage: swapping the factory changes the entire UI theme
 function buildLoginForm(factory: UIFactory): string {
-  const emailInput = factory.createInput("メールアドレス");
-  const passwordInput = factory.createInput("パスワード");
-  const submitButton = factory.createButton("ログイン");
+  const emailInput = factory.createInput("Email address");
+  const passwordInput = factory.createInput("Password");
+  const submitButton = factory.createButton("Login");
 
   return [
     emailInput.render(),
@@ -489,20 +491,20 @@ function buildLoginForm(factory: UIFactory): string {
 
 console.log("--- Material Design ---");
 console.log(buildLoginForm(new MaterialFactory()));
-// <md-input placeholder="メールアドレス" />
-// <md-input placeholder="パスワード" />
-// <md-button>ログイン</md-button>
+// <md-input placeholder="Email address" />
+// <md-input placeholder="Password" />
+// <md-button>Login</md-button>
 
 console.log("--- iOS Style ---");
 console.log(buildLoginForm(new IOSFactory()));
-// <ios-input placeholder="メールアドレス" />
-// <ios-input placeholder="パスワード" />
-// <ios-button>ログイン</ios-button>
+// <ios-input placeholder="Email address" />
+// <ios-input placeholder="Password" />
+// <ios-button>Login</ios-button>
 ```
 
-### コード例 4: Registry パターン（拡張可能 Factory）
+### Code Example 4: Registry Pattern (Extensible Factory)
 
-OCP（開放閉鎖原則）を完全に満たすFactory。新しい型の追加が既存コードの変更なしに行える。
+A Factory that fully satisfies OCP (Open/Closed Principle). New types can be added without modifying existing code.
 
 ```typescript
 type Creator<T> = (...args: any[]) => T;
@@ -510,7 +512,7 @@ type Creator<T> = (...args: any[]) => T;
 class NotificationRegistry {
   private static registry = new Map<string, Creator<Notification>>();
 
-  // 型を登録（各モジュールが自分で登録する）
+  // Register a type (each module registers itself)
   static register(type: string, creator: Creator<Notification>): void {
     if (this.registry.has(type)) {
       console.warn(`Overwriting existing creator for: ${type}`);
@@ -518,7 +520,7 @@ class NotificationRegistry {
     this.registry.set(type, creator);
   }
 
-  // 型からインスタンスを生成
+  // Create an instance from a type name
   static create(type: string, ...args: any[]): Notification {
     const creator = this.registry.get(type);
     if (!creator) {
@@ -530,13 +532,13 @@ class NotificationRegistry {
     return creator(...args);
   }
 
-  // 登録されている型の一覧
+  // List of registered types
   static getRegisteredTypes(): string[] {
     return Array.from(this.registry.keys());
   }
 }
 
-// 各モジュールが自分のプロダクトを登録
+// Each module registers its own product
 // email-notification.ts
 NotificationRegistry.register("email",
   (recipient: string) => new EmailNotification(recipient)
@@ -552,7 +554,7 @@ NotificationRegistry.register("sms",
   (phone: string) => new SmsNotification(phone)
 );
 
-// 新しい型の追加: 既存コードの変更は一切不要（OCP 準拠）
+// Adding a new type: no changes to existing code required (OCP compliant)
 // teams-notification.ts
 class TeamsNotification implements Notification {
   constructor(private webhook: string) {}
@@ -563,14 +565,14 @@ NotificationRegistry.register("teams",
   (webhook: string) => new TeamsNotification(webhook)
 );
 
-// 使用
+// Usage
 const notification = NotificationRegistry.create("teams", "https://webhook.url");
 notification.send("Teams notification!");
 console.log(NotificationRegistry.getRegisteredTypes());
 // ["email", "slack", "sms", "teams"]
 ```
 
-### コード例 5: Python -- Factory Method + ABC
+### Code Example 5: Python -- Factory Method + ABC
 
 ```python
 from abc import ABC, abstractmethod
@@ -579,21 +581,21 @@ import json
 import xml.etree.ElementTree as ET
 
 class Serializer(ABC):
-    """直列化の抽象クラス"""
+    """Abstract base class for serialization"""
 
     @abstractmethod
     def serialize(self, data: dict) -> str:
-        """データを文字列に変換する"""
+        """Convert data to a string"""
         ...
 
     @abstractmethod
     def deserialize(self, raw: str) -> dict:
-        """文字列からデータを復元する"""
+        """Restore data from a string"""
         ...
 
     @abstractmethod
     def content_type(self) -> str:
-        """MIME タイプを返す"""
+        """Return the MIME type"""
         ...
 
 class JsonSerializer(Serializer):
@@ -638,7 +640,7 @@ class CsvSerializer(Serializer):
 
 # Simple Factory
 def get_serializer(fmt: str) -> Serializer:
-    """フォーマット名から適切な Serializer を返す Factory"""
+    """Factory that returns the appropriate Serializer based on format name"""
     factories: dict[str, type[Serializer]] = {
         "json": JsonSerializer,
         "xml": XmlSerializer,
@@ -650,8 +652,8 @@ def get_serializer(fmt: str) -> Serializer:
         raise ValueError(f"Unknown format: '{fmt}'. Available: [{available}]")
     return cls()
 
-# 使用
-data = {"name": "太郎", "age": "30", "city": "東京"}
+# Usage
+data = {"name": "Taro", "age": "30", "city": "Tokyo"}
 
 for fmt in ["json", "xml", "csv"]:
     s = get_serializer(fmt)
@@ -662,7 +664,7 @@ for fmt in ["json", "xml", "csv"]:
     print(f"Restored: {restored}")
 ```
 
-### コード例 6: Java -- Parameterized Factory Method
+### Code Example 6: Java -- Parameterized Factory Method
 
 ```java
 public interface Shape {
@@ -722,21 +724,21 @@ public class ShapeFactory {
     }
 }
 
-// 使用
+// Usage
 Shape circle = ShapeFactory.create(ShapeType.CIRCLE, 5.0);
 Shape rect = ShapeFactory.create(ShapeType.RECTANGLE, 3.0, 4.0);
 System.out.println(circle.description()); // Circle(radius=5.00, area=78.54)
 System.out.println(rect.description());   // Rectangle(3.00 x 4.00, area=12.00)
 ```
 
-### コード例 7: Go -- インタフェースベースの Factory
+### Code Example 7: Go -- Interface-Based Factory
 
 ```go
 package main
 
 import "fmt"
 
-// Product インタフェース
+// Product interface
 type Logger interface {
     Log(message string)
     Level() string
@@ -768,7 +770,7 @@ func (l *CloudLogger) Log(message string) {
 }
 func (l *CloudLogger) Level() string { return "cloud" }
 
-// Factory 関数（Go ではファーストクラス関数を活用）
+// Factory function (Go leverages first-class functions)
 type LoggerFactory func() Logger
 
 // Registry
@@ -786,7 +788,7 @@ func CreateLogger(loggerType string) (Logger, error) {
     return factory(), nil
 }
 
-// 新しい型の登録
+// Register a new type
 func RegisterLogger(name string, factory LoggerFactory) {
     loggerFactories[name] = factory
 }
@@ -800,12 +802,12 @@ func main() {
 }
 ```
 
-### コード例 8: TypeScript -- 非同期 Factory
+### Code Example 8: TypeScript -- Async Factory
 
-実務では、Factory がDBやAPIから設定を読み込む必要がある場合がある。
+In practice, a Factory may need to load configuration from a database or API.
 
 ```typescript
-// 非同期 Factory パターン
+// Async Factory pattern
 interface DataSource {
   connect(): Promise<void>;
   query(sql: string): Promise<any[]>;
@@ -847,7 +849,7 @@ class MySQLDataSource implements DataSource {
   async disconnect(): Promise<void> {}
 }
 
-// 非同期 Factory: 生成 + 初期化を1ステップで行う
+// Async Factory: creation and initialization in a single step
 async function createDataSource(
   type: "postgres" | "mysql",
   config: Record<string, any>
@@ -869,12 +871,12 @@ async function createDataSource(
       throw new Error(`Unknown data source type: ${type}`);
   }
 
-  // Factory が初期化まで保証する
+  // The Factory guarantees initialization as well
   await ds.connect();
   return ds;
 }
 
-// 使用
+// Usage
 async function main() {
   const ds = await createDataSource("postgres", {
     connectionString: "postgresql://localhost:5432/mydb"
@@ -884,10 +886,10 @@ async function main() {
 }
 ```
 
-### コード例 9: Factory + Strategy の組み合わせ
+### Code Example 9: Combining Factory with Strategy
 
 ```typescript
-// バリデーション戦略を Factory で生成
+// Generating validation strategies with a Factory
 interface ValidationStrategy {
   validate(value: string): { valid: boolean; error?: string };
 }
@@ -930,7 +932,7 @@ function createValidator(type: string): ValidationStrategy {
   return factory();
 }
 
-// 使用: 設定駆動で動的にバリデータを選択
+// Usage: dynamically select a validator driven by configuration
 const formFields = [
   { name: "email", type: "email", value: "user@example.com" },
   { name: "phone", type: "phone", value: "090-1234-5678" },
@@ -947,10 +949,10 @@ for (const field of formFields) {
 // website: OK
 ```
 
-### コード例 10: Factory と DI の統合
+### Code Example 10: Integrating Factory with DI
 
 ```typescript
-// DI コンテナで Factory を管理する実務的なパターン
+// Practical pattern: managing Factory with a DI container
 interface IPaymentProcessor {
   charge(amount: number): Promise<{ success: boolean; transactionId: string }>;
   refund(transactionId: string): Promise<boolean>;
@@ -981,11 +983,11 @@ class PaymentFactory implements IPaymentFactory {
   }
 }
 
-// DI コンテナとの統合
+// Integration with the DI container
 // container.ts
 const container = new Container();
 
-// Factory 自体を Singleton スコープで登録
+// Register the Factory itself in Singleton scope
 container.bind<IPaymentFactory>(TYPES.PaymentFactory)
   .toDynamicValue(() => {
     const factory = new PaymentFactory();
@@ -996,7 +998,7 @@ container.bind<IPaymentFactory>(TYPES.PaymentFactory)
   })
   .inSingletonScope();
 
-// 使用側: Factory を注入してもらう
+// Consumer: has the Factory injected
 class OrderService {
   constructor(
     @inject(TYPES.PaymentFactory) private paymentFactory: IPaymentFactory
@@ -1014,100 +1016,100 @@ class OrderService {
 
 ---
 
-## 5. Factory の選択フロー
+## 5. Factory Selection Flowchart
 
 ```
-生成ロジックを分離したい？
+Do you want to separate the creation logic?
 │
-├── No → 直接 new で十分。Factory は過剰設計
+├── No → new directly is sufficient. Factory is over-engineering
 │
 └── Yes
     │
-    ├── 生成するプロダクトは1種類？
+    ├── Is there only one type of product to create?
     │   │
     │   ├── Yes
     │   │   │
-    │   │   ├── 型で分岐するだけ？
-    │   │   │   ├── Yes → Simple Factory（関数/静的メソッド）
-    │   │   │   └── No  → Factory Method（サブクラスにオーバーライド）
+    │   │   ├── Just branching on a type name?
+    │   │   │   ├── Yes → Simple Factory (function / static method)
+    │   │   │   └── No  → Factory Method (override in subclass)
     │   │   │
-    │   │   └── 実行時に型を動的に追加する必要がある？
-    │   │       ├── Yes → Registry パターン
-    │   │       └── No  → Simple Factory で十分
+    │   │   └── Do you need to add types dynamically at runtime?
+    │   │       ├── Yes → Registry pattern
+    │   │       └── No  → Simple Factory is sufficient
     │   │
-    │   └── No（関連するプロダクト群がある）
+    │   └── No (there is a family of related products)
     │       │
-    │       └── プロダクト群の整合性が重要？
+    │       └── Is consistency across the product family important?
     │           ├── Yes → Abstract Factory
-    │           └── No  → 個別の Factory Method で十分
+    │           └── No  → Individual Factory Methods are sufficient
     │
-    └── テスト時にプロダクトを差し替えたい？
-        ├── Yes → DI + Factory インタフェース
-        └── No  → Simple Factory で十分
+    └── Do you need to swap products during testing?
+        ├── Yes → DI + Factory interface
+        └── No  → Simple Factory is sufficient
 ```
 
 ---
 
-## 6. 比較表
+## 6. Comparison Tables
 
-### 比較表 1: Factory Method vs Abstract Factory vs Simple Factory
+### Comparison Table 1: Factory Method vs Abstract Factory vs Simple Factory
 
-| 観点 | Simple Factory | Factory Method | Abstract Factory |
+| Perspective | Simple Factory | Factory Method | Abstract Factory |
 |------|:---:|:---:|:---:|
-| GoF パターン | No | Yes | Yes |
-| 意図 | 条件分岐で生成を集約 | 生成をサブクラスに委譲 | 関連プロダクト群の生成 |
-| クラス数 | 最小 | 中 | 多い |
-| 拡張方法 | switch 文に追加 | Creator サブクラス追加 | Factory + Product 群追加 |
-| OCP 準拠 | No（switch 変更要） | Yes | Yes |
-| 使用場面 | 単純な分岐 | テンプレートメソッドと併用 | テーマ/プラットフォーム切替 |
-| 複雑度 | 低 | 中 | 高 |
-| テスト容易性 | 中 | 高 | 高 |
+| GoF Pattern | No | Yes | Yes |
+| Intent | Consolidate creation via branching | Delegate creation to subclass | Create a family of related products |
+| Number of Classes | Minimal | Medium | Many |
+| Extension Method | Add to switch statement | Add Creator subclass | Add Factory + Product family |
+| OCP Compliance | No (requires switch change) | Yes | Yes |
+| Use Case | Simple branching | Combined with Template Method | Theme/Platform switching |
+| Complexity | Low | Medium | High |
+| Testability | Medium | High | High |
 
-### 比較表 2: Factory vs その他の生成パターン
+### Comparison Table 2: Factory vs Other Creational Patterns
 
-| パターン | 目的 | 生成の自由度 | 複雑度 | 使用頻度 |
+| Pattern | Purpose | Creation Flexibility | Complexity | Usage Frequency |
 |---------|------|:---:|:---:|:---:|
-| Simple Factory | 条件分岐で生成 | 低 | 低 | 非常に高 |
-| Factory Method | サブクラスに委譲 | 中 | 中 | 高 |
-| Abstract Factory | ファミリー生成 | 高 | 高 | 中 |
-| Builder | 段階的構築 | 高 | 中 | 高 |
-| Prototype | クローンで生成 | 中 | 低 | 低 |
-| Singleton | 唯一インスタンス | N/A | 低 | 高 |
+| Simple Factory | Create via branching | Low | Low | Very High |
+| Factory Method | Delegate to subclass | Medium | Medium | High |
+| Abstract Factory | Create a family | High | High | Medium |
+| Builder | Stepwise construction | High | Medium | High |
+| Prototype | Create via cloning | Medium | Low | Low |
+| Singleton | Single instance | N/A | Low | High |
 
-### 比較表 3: Registry パターン vs DI コンテナ
+### Comparison Table 3: Registry Pattern vs DI Container
 
-| 観点 | Registry パターン | DI コンテナ |
+| Perspective | Registry Pattern | DI Container |
 |------|:---:|:---:|
-| 登録方法 | 手動 register() | 設定/アノテーション |
-| ライフタイム管理 | なし（毎回生成） | Singleton/Transient 等 |
-| 依存解決 | 自前 | 自動 |
-| テスト容易性 | 中 | 高 |
-| 学習コスト | 低 | 中~高 |
-| 導入コスト | 低 | 中 |
-| 推奨場面 | プラグイン登録 | アプリ全体の依存管理 |
+| Registration Method | Manual register() | Configuration / annotations |
+| Lifetime Management | None (created each time) | Singleton / Transient, etc. |
+| Dependency Resolution | Manual | Automatic |
+| Testability | Medium | High |
+| Learning Cost | Low | Medium~High |
+| Adoption Cost | Low | Medium |
+| Recommended Use Case | Plugin registration | App-wide dependency management |
 
 ---
 
-## 7. エッジケースと注意点
+## 7. Edge Cases and Caveats
 
-### 7.1 型安全性の確保
+### 7.1 Ensuring Type Safety
 
 ```typescript
-// 問題: string ベースの Factory は型安全でない
-const notif = createNotification("emal");  // typo! 実行時エラー
+// Problem: string-based Factory is not type-safe
+const notif = createNotification("emal");  // typo! Runtime error
 
-// 解決策 1: Union 型で制限
+// Solution 1: Restrict with union type
 type NotificationType = "email" | "slack" | "sms";
 function createNotification(type: NotificationType): Notification { ... }
 
-// 解決策 2: Enum（Java/TypeScript）
+// Solution 2: Enum (Java/TypeScript)
 enum NotificationType {
   Email = "email",
   Slack = "slack",
   Sms = "sms",
 }
 
-// 解決策 3: Discriminated Union（TypeScript）
+// Solution 3: Discriminated Union (TypeScript)
 type NotificationRequest =
   | { type: "email"; recipient: string }
   | { type: "slack"; channel: string }
@@ -1116,47 +1118,47 @@ type NotificationRequest =
 function createNotification(req: NotificationRequest): Notification {
   switch (req.type) {
     case "email":
-      return new EmailNotification(req.recipient);  // 型安全にアクセス
+      return new EmailNotification(req.recipient);  // type-safe access
     case "slack":
-      return new SlackNotification(req.channel);     // 型安全にアクセス
+      return new SlackNotification(req.channel);     // type-safe access
     case "sms":
-      return new SmsNotification(req.phoneNumber);   // 型安全にアクセス
+      return new SmsNotification(req.phoneNumber);   // type-safe access
   }
 }
 ```
 
-### 7.2 循環依存の回避
+### 7.2 Avoiding Circular Dependencies
 
 ```
-// 問題: Factory と Product が相互依存
-ProductA → Factory（生成に使う）
-Factory → ProductA（生成する）
+// Problem: Factory and Product are mutually dependent
+ProductA → Factory (used for creation)
+Factory → ProductA (creates it)
 
-// 解決策: インタフェースを中間層として導入
-ProductA → IFactory（インタフェースに依存）
-Factory → IProduct（インタフェースに依存）
-ConcreteFactory → ConcreteProduct（具象が具象を参照）
+// Solution: Introduce an interface as an intermediary layer
+ProductA → IFactory (depends on interface)
+Factory → IProduct (depends on interface)
+ConcreteFactory → ConcreteProduct (concrete references concrete)
 
-DIP（依存性逆転原則）を適用:
-  上位モジュール（利用側）→ インタフェース ← 下位モジュール（実装）
+Apply DIP (Dependency Inversion Principle):
+  High-level module (consumer) → Interface ← Low-level module (implementation)
 ```
 
-### 7.3 Factory のメモリリーク
+### 7.3 Memory Leaks in Factories
 
 ```typescript
-// 問題: Registry に登録されたオブジェクトが GC されない
+// Problem: objects registered in a Registry are never GC'd
 class HeavyRegistry {
   private static cache = new Map<string, LargeObject>();
 
   static getOrCreate(key: string): LargeObject {
     if (!this.cache.has(key)) {
-      this.cache.set(key, new LargeObject(key)); // 蓄積し続ける
+      this.cache.set(key, new LargeObject(key)); // accumulates indefinitely
     }
     return this.cache.get(key)!;
   }
 }
 
-// 解決策: WeakMap または LRU キャッシュを使用
+// Solution: use WeakMap or an LRU cache
 class SafeRegistry {
   private static cache = new LRUCache<string, LargeObject>({ max: 100 });
 
@@ -1173,33 +1175,33 @@ class SafeRegistry {
 
 ---
 
-## 8. アンチパターン
+## 8. Anti-Patterns
 
-### アンチパターン 1: 万能 Factory（God Factory）
+### Anti-Pattern 1: God Factory
 
 ```typescript
-// NG: あらゆる型を1つの Factory で処理
+// BAD: handling every type in a single Factory
 class UniversalFactory {
-  create(type: string): any {  // any は危険信号
+  create(type: string): any {  // any is a red flag
     if (type === "user") return new User();
     if (type === "order") return new Order();
     if (type === "product") return new Product();
     if (type === "payment") return new Payment();
     if (type === "notification") return new Notification();
     if (type === "report") return new Report();
-    // ... 50行の if-else
+    // ... 50 lines of if-else
     throw new Error(`Unknown type: ${type}`);
   }
 }
 ```
 
-**問題**:
-- OCP 違反: 新しい型追加のたびにこのクラスを変更する必要がある
-- SRP 違反: 無関係なドメインのオブジェクト生成が1クラスに集約
-- 型安全性がない: 戻り値が any
+**Problems**:
+- OCP violation: this class must be changed every time a new type is added
+- SRP violation: object creation for unrelated domains is consolidated in one class
+- No type safety: return type is any
 
 ```typescript
-// OK: ドメインごとに Factory を分割
+// GOOD: split Factory by domain
 class UserFactory {
   static create(type: UserType): User { ... }
 }
@@ -1213,12 +1215,12 @@ class NotificationFactory {
 }
 ```
 
-### アンチパターン 2: 不要な Abstract Factory
+### Anti-Pattern 2: Unnecessary Abstract Factory
 
 ```typescript
-// NG: プロダクトが1種類なのに Abstract Factory を使う
+// BAD: using Abstract Factory when there is only one type of product
 interface ShapeFactory {
-  createShape(): Shape;  // 1メソッドだけ → Abstract Factory は過剰
+  createShape(): Shape;  // only 1 method → Abstract Factory is overkill
 }
 
 class CircleFactory implements ShapeFactory {
@@ -1230,10 +1232,10 @@ class RectangleFactory implements ShapeFactory {
 }
 ```
 
-**問題**: Factory Method で十分な場面に過剰な抽象化を持ち込んでいる。
+**Problem**: Introduces excessive abstraction in a situation where Factory Method would suffice.
 
 ```typescript
-// OK: Simple Factory または Factory Method を使う
+// GOOD: use Simple Factory or Factory Method
 function createShape(type: "circle" | "rectangle"): Shape {
   switch (type) {
     case "circle": return new Circle();
@@ -1242,25 +1244,25 @@ function createShape(type: "circle" | "rectangle"): Shape {
 }
 ```
 
-**YAGNI 原則**: 複数プロダクトが実際に必要になるまで Abstract Factory にしない。
+**YAGNI Principle**: Do not promote to Abstract Factory until multiple products are actually needed.
 
-### アンチパターン 3: Factory 内でのビジネスロジック
+### Anti-Pattern 3: Business Logic Inside a Factory
 
 ```typescript
-// NG: Factory が生成以外の責任を持つ
+// BAD: Factory holds responsibilities beyond creation
 class OrderFactory {
   static create(items: CartItem[], coupon?: string): Order {
     const order = new Order(items);
 
-    // ビジネスロジック（Factory の責任ではない）
+    // Business logic (not the Factory's responsibility)
     if (coupon) {
-      const discount = this.validateCoupon(coupon);  // クーポン検証
-      order.applyDiscount(discount);                 // 割引適用
+      const discount = this.validateCoupon(coupon);  // coupon validation
+      order.applyDiscount(discount);                 // apply discount
     }
 
-    order.calculateTax();      // 税計算
-    order.calculateShipping(); // 送料計算
-    this.sendAnalytics(order); // 分析データ送信
+    order.calculateTax();      // tax calculation
+    order.calculateShipping(); // shipping calculation
+    this.sendAnalytics(order); // send analytics data
 
     return order;
   }
@@ -1268,10 +1270,10 @@ class OrderFactory {
 ```
 
 ```typescript
-// OK: Factory は生成のみ。ビジネスロジックはドメインサービスに委譲
+// GOOD: Factory only creates. Business logic is delegated to the domain service
 class OrderFactory {
   static create(items: CartItem[]): Order {
-    return new Order(items);  // 生成のみ
+    return new Order(items);  // creation only
   }
 }
 
@@ -1300,57 +1302,58 @@ class OrderService {
 
 ---
 
-## 9. トレードオフ分析
+## 9. Tradeoff Analysis
 
-### 9.1 Factory 導入の利点と欠点
+### 9.1 Benefits and Drawbacks of Introducing a Factory
 
 ```
-利点                              欠点
+Benefits                          Drawbacks
 +------------------------------+  +------------------------------+
-| 生成ロジックの集約            |  | クラス数の増加                |
-| OCP 準拠（拡張が容易）        |  | 間接層による複雑化            |
-| テスト時のモック差替え容易    |  | 過剰設計のリスク              |
-| 利用側の具象クラスへの非依存  |  | 単純な場合は YAGNI            |
-| コードの再利用性向上          |  | デバッグ時の追跡が煩雑        |
+| Centralized creation logic   |  | Increased number of classes  |
+| OCP compliant (easy to extend)|  | Added complexity from indirection |
+| Easy mock swapping in tests  |  | Risk of over-engineering      |
+| No dependency on concrete    |  | YAGNI in simple cases        |
+|   classes in consuming code  |  | More difficult to trace when |
+| Improved code reusability    |  |   debugging                  |
 +------------------------------+  +------------------------------+
 ```
 
-### 9.2 導入判断のガイドライン
+### 9.2 Guidelines for Deciding Whether to Introduce
 
 ```
-Factory を導入すべき場面:
-- new の呼び出しが3箇所以上に散らばっている
-- 生成ロジックに条件分岐がある
-- テストでモック差し替えが必要
-- プラグインシステムを構築する
-- 設定に基づいて動的にオブジェクトを選択する
+When to introduce a Factory:
+- new calls are scattered across 3 or more places
+- Creation logic contains conditional branching
+- Mock swapping is needed in tests
+- Building a plugin system
+- Dynamically selecting objects based on configuration
 
-Factory を導入すべきでない場面:
-- new が1-2箇所でしか呼ばれない
-- 生成対象が変わる見込みがない
-- 生成に条件分岐がない
-- 単純なデータオブジェクト（DTO）の生成
+When NOT to introduce a Factory:
+- new is only called in 1-2 places
+- The type to be created is not expected to change
+- There is no conditional branching in creation
+- Creating simple data objects (DTOs)
 ```
 
 ---
 
-## 10. 実践演習
+## 10. Practice Exercises
 
-### 演習 1: 基礎 -- Simple Factory の実装
+### Exercise 1: Basics -- Implementing a Simple Factory
 
-**課題**: ログフォーマッタの Simple Factory を実装してください。
+**Task**: Implement a Simple Factory for a log formatter.
 
-**要件**:
-- `ILogFormatter` インタフェースを定義（`format(level, message, timestamp)` メソッド）
-- JSON / Text / CSV の3つの具象フォーマッタを実装
-- `createFormatter(type)` Factory 関数を作成
-- 不明な型は適切なエラーメッセージで例外を投げる
+**Requirements**:
+- Define an `ILogFormatter` interface (with a `format(level, message, timestamp)` method)
+- Implement three concrete formatters: JSON, Text, and CSV
+- Create a `createFormatter(type)` Factory function
+- Throw an exception with an appropriate error message for unknown types
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected Output**:
 
 ```
 const jsonFmt = createFormatter("json");
@@ -1367,7 +1370,7 @@ console.log(csvFmt.format("warn", "Memory high", new Date()));
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
 interface ILogFormatter {
@@ -1415,22 +1418,22 @@ function createFormatter(type: FormatterType): ILogFormatter {
 
 </details>
 
-### 演習 2: 応用 -- Registry パターンの拡張
+### Exercise 2: Applied -- Extending the Registry Pattern
 
-**課題**: プラグインシステムとして機能する Registry パターンの Factory を実装してください。
+**Task**: Implement a Registry pattern Factory that functions as a plugin system.
 
-**要件**:
-- `PluginRegistry` クラスを実装
-- プラグインの登録（register）、生成（create）、一覧（list）、登録解除（unregister）をサポート
-- 重複登録時は警告を出す
-- 型安全性を確保（ジェネリクス使用）
-- 登録時にバリデーション関数を指定可能
+**Requirements**:
+- Implement a `PluginRegistry` class
+- Support plugin registration (register), creation (create), listing (list), and deregistration (unregister)
+- Emit a warning on duplicate registration
+- Ensure type safety (use generics)
+- Allow a validation function to be specified at registration time
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected Output**:
 
 ```
 const registry = new PluginRegistry<IPlugin>();
@@ -1447,7 +1450,7 @@ console.log(registry.list()); // ["analytics"]
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
 interface IPlugin {
@@ -1488,7 +1491,7 @@ class PluginRegistry<T extends IPlugin> {
 
     const plugin = factory();
 
-    // バリデーション実行
+    // Run validation
     const validator = this.validators.get(name);
     if (validator && !validator(plugin)) {
       throw new Error(`Plugin "${name}" failed validation`);
@@ -1519,22 +1522,22 @@ class PluginRegistry<T extends IPlugin> {
 
 </details>
 
-### 演習 3: 発展 -- Abstract Factory によるクロスプラットフォーム UI
+### Exercise 3: Advanced -- Cross-Platform UI with Abstract Factory
 
-**課題**: Web / Mobile / Desktop の3プラットフォームに対応する Abstract Factory を設計してください。
+**Task**: Design an Abstract Factory that supports three platforms: Web, Mobile, and Desktop.
 
-**要件**:
-- 各プラットフォームで Button、TextField、Checkbox の3つのUIコンポーネントを生成
-- 各コンポーネントは `render(): string` メソッドを持つ
-- プラットフォームの切り替えは Factory の差し替えのみで行う
-- テスト用の MockFactory も作成
-- Factory の生成自体を別の Factory（Factory of Factories）で管理
+**Requirements**:
+- Generate three UI components — Button, TextField, and Checkbox — for each platform
+- Each component has a `render(): string` method
+- Platform switching is done solely by swapping the Factory
+- Also create a MockFactory for testing
+- Manage factory creation itself with another Factory (Factory of Factories)
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected Output**:
 
 ```
 // Web Platform
@@ -1557,10 +1560,10 @@ const autoUI = buildForm(factory);
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
-// 抽象プロダクト
+// Abstract products
 interface IButton {
   render(): string;
 }
@@ -1571,14 +1574,14 @@ interface ICheckbox {
   render(): string;
 }
 
-// 抽象ファクトリ
+// Abstract factory
 interface IUIFactory {
   createButton(label: string): IButton;
   createTextField(placeholder: string): ITextField;
   createCheckbox(label: string): ICheckbox;
 }
 
-// Web 実装
+// Web implementation
 class WebButton implements IButton {
   constructor(private label: string) {}
   render() { return `<button class="web-btn">${this.label}</button>`; }
@@ -1597,7 +1600,7 @@ class WebUIFactory implements IUIFactory {
   createCheckbox(label: string) { return new WebCheckbox(label); }
 }
 
-// Mobile 実装
+// Mobile implementation
 class MobileButton implements IButton {
   constructor(private label: string) {}
   render() { return `<TouchableOpacity style="mobile">${this.label}</TouchableOpacity>`; }
@@ -1616,7 +1619,7 @@ class MobileUIFactory implements IUIFactory {
   createCheckbox(label: string) { return new MobileCheckbox(label); }
 }
 
-// Desktop 実装
+// Desktop implementation
 class DesktopButton implements IButton {
   constructor(private label: string) {}
   render() { return `<QButton text="${this.label}" />`; }
@@ -1652,7 +1655,7 @@ class UIFactoryProvider {
   }
 }
 
-// 利用コード（プラットフォーム非依存）
+// Consumer code (platform-agnostic)
 function buildForm(factory: IUIFactory): string {
   const nameField = factory.createTextField("Name");
   const agreeBox = factory.createCheckbox("I agree");
@@ -1668,74 +1671,74 @@ function buildForm(factory: IUIFactory): string {
 
 ## 11. FAQ
 
-### Q1: Simple Factory と Factory Method の違いは？
+### Q1: What is the difference between Simple Factory and Factory Method?
 
-Simple Factory は単なる関数やクラスメソッドで条件分岐し生成します。Factory Method はサブクラス化により生成をオーバーライドする GoF パターンです。多くの実務では Simple Factory で十分です。
+Simple Factory creates objects via conditional branching in a plain function or class method. Factory Method is a GoF pattern where creation is overridden through subclassing. In most real-world cases, Simple Factory is sufficient.
 
-| 観点 | Simple Factory | Factory Method |
+| Perspective | Simple Factory | Factory Method |
 |------|:---:|:---:|
-| パターン分類 | イディオム | GoF パターン |
-| 拡張方法 | switch 文の変更 | サブクラスの追加 |
-| OCP 準拠 | No | Yes |
-| 適用場面 | 単純な分岐 | フレームワーク拡張 |
+| Pattern Category | Idiom | GoF Pattern |
+| Extension Method | Modify switch statement | Add subclass |
+| OCP Compliance | No | Yes |
+| Use Case | Simple branching | Framework extension |
 
-### Q2: Factory を使うべき判断基準は？
+### Q2: What criteria should I use to decide whether to use a Factory?
 
-以下の3つの条件のいずれかに該当すれば Factory の導入を検討します:
+Consider introducing a Factory if any of the following three conditions apply:
 
-1. **`new` の呼び出し箇所が3箇所以上に散らばっている**: 生成ロジックの変更が複数箇所に影響する
-2. **生成ロジックに条件分岐がある**: どの型をインスタンス化するかの判断が必要
-3. **テストでモック差し替えが必要**: 具象クラスへの直接依存を解消する必要がある
+1. **`new` calls are scattered across 3 or more places**: Changes to creation logic affect multiple locations
+2. **Creation logic contains conditional branching**: A decision is needed about which type to instantiate
+3. **Mock swapping is needed in tests**: Direct dependency on concrete classes needs to be removed
 
-逆に、`new` が1-2箇所でしか使われず、条件分岐もなく、モックの必要もなければ、Factory は過剰設計です。
+Conversely, if `new` is only used in 1-2 places, there is no conditional branching, and mocking is not needed, a Factory is over-engineering.
 
-### Q3: DI コンテナがあれば Factory は不要ですか？
+### Q3: If I have a DI container, do I still need a Factory?
 
-DI コンテナは**起動時**に依存を解決しますが、**実行時**に動的に型を切り替える場合は Factory が必要です。両者は補完関係にあります。
+A DI container resolves dependencies at **startup time**, but a Factory is still needed when you need to dynamically switch types at **runtime**. The two are complementary.
 
 ```
-DI コンテナ: 起動時に決定（設定ベース）
+DI container: resolved at startup (configuration-based)
   container.bind<Logger>().to(ConsoleLogger)
-  → アプリケーション起動時に1度だけ解決
+  → resolved once when the application starts
 
-Factory: 実行時に決定（データベース）
+Factory: resolved at runtime (data-driven)
   factory.create(user.preferredNotificationType)
-  → リクエストごとに異なる型を生成
+  → a different type is created per request
 
-ベストプラクティス: DI コンテナで Factory 自体を管理する
+Best practice: manage the Factory itself with the DI container
   container.bind<INotificationFactory>()
     .to(NotificationFactory)
     .inSingletonScope();
 ```
 
-### Q4: Factory Method と Strategy パターンはどう使い分けるべきですか？
+### Q4: How should I choose between Factory Method and Strategy pattern?
 
 ```
 Factory Method:
-- 「何を生成するか」が関心事
-- サブクラスがプロダクトの型を決定
-- 生成されたオブジェクトをテンプレートメソッド内で使用
+- The concern is "what to create"
+- The subclass decides the type of product
+- The created object is used inside a Template Method
 
 Strategy:
-- 「どう振る舞うか」が関心事
-- 実行時にアルゴリズムを切り替え
-- コンポジション（委譲）で実現
+- The concern is "how to behave"
+- An algorithm is switched at runtime
+- Achieved through composition (delegation)
 
-併用:
-- Factory で Strategy オブジェクトを生成するのが一般的
-- Strategy が必要な場面では、まず Strategy を設計し、
-  その生成に Factory を使う
+Combined use:
+- It is common to use a Factory to generate Strategy objects
+- When a Strategy is needed, design the Strategy first,
+  then use a Factory for its creation
 ```
 
-### Q5: Abstract Factory でプロダクトを追加する場合の影響は？
+### Q5: What is the impact of adding a product to an Abstract Factory?
 
-Abstract Factory に新しいプロダクト（createNewProduct()）を追加すると、全ての具象ファクトリに影響します（インタフェースの変更）。これが Abstract Factory の最大の弱点です。
+Adding a new product (createNewProduct()) to an Abstract Factory affects all concrete factories (it changes the interface). This is the biggest weakness of Abstract Factory.
 
 ```
-解決策:
-1. インタフェース分離原則（ISP）を適用し、Factory を分割
-2. Default 実装を持つ抽象クラスを使用
-3. Generic Factory メソッド: create<T>(type: Class<T>): T
+Solutions:
+1. Apply the Interface Segregation Principle (ISP) and split the Factory
+2. Use an abstract class with a default implementation
+3. Generic Factory method: create<T>(type: Class<T>): T
 ```
 
 ---
@@ -1743,51 +1746,51 @@ Abstract Factory に新しいプロダクト（createNewProduct()）を追加す
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining hands-on experience is most important. Understanding deepens not just through theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the fundamentals and jumping straight to advanced topics. It is recommended to thoroughly understand the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this applied in real-world practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architectural design.
 
 ---
 
-## 12. まとめ
+## 12. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| Factory Method | 1プロダクトの生成をサブクラスに委譲。テンプレートメソッドと相性が良い |
-| Abstract Factory | 関連プロダクト群をまとめて生成。テーマ/プラットフォーム切替に最適 |
-| Simple Factory | 最も軽量。関数1つで実現。実務で最多 |
-| Registry | OCP 準拠の拡張可能 Factory。プラグインシステムに最適 |
-| 判断基準 | new の散在 / 条件分岐 / モック必要性 のいずれかで導入検討 |
-| 過剰設計の回避 | YAGNI 原則: 現在の要件に合った最小の Factory を選択 |
-| DI との関係 | DI コンテナと Factory は補完関係。DI で Factory を管理するのが最善 |
-| 最大の注意点 | Factory 内にビジネスロジックを入れない |
+| Factory Method | Delegates creation of one product to a subclass. Works well with Template Method |
+| Abstract Factory | Creates a family of related products together. Ideal for theme/platform switching |
+| Simple Factory | The most lightweight option. Realized with a single function. Most common in practice |
+| Registry | OCP-compliant extensible Factory. Ideal for plugin systems |
+| Decision Criteria | Consider introducing when: new calls are scattered / conditional branching exists / mocking is needed |
+| Avoiding Over-Engineering | YAGNI principle: choose the minimal Factory that fits the current requirements |
+| Relationship with DI | DI container and Factory are complementary. Best practice is to manage the Factory with DI |
+| Key Caution | Do not put business logic inside a Factory |
 
 ---
 
-## 次に読むべきガイド
+## What to Read Next
 
-- [Builder パターン](./02-builder.md) -- 複雑なオブジェクトの段階的構築。Factory が「何を」、Builder が「どのように」を担当
-- [Prototype パターン](./03-prototype.md) -- クローンによる生成。Factory の代替手法
-- [Singleton パターン](./00-singleton.md) -- Factory Registry の Singleton 管理
-- [Strategy パターン](../02-behavioral/01-strategy.md) -- アルゴリズムの交換。Factory + Strategy の併用
-- [Adapter パターン](../01-structural/00-adapter.md) -- 既存クラスの適合。Factory でAdapter を生成
-- [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) -- OCP、DIP の詳細
+- [Builder Pattern](./02-builder.md) -- Stepwise construction of complex objects. Factory handles "what", Builder handles "how"
+- [Prototype Pattern](./03-prototype.md) -- Creation via cloning. An alternative approach to Factory
+- [Singleton Pattern](./00-singleton.md) -- Singleton management of the Factory Registry
+- [Strategy Pattern](../02-behavioral/01-strategy.md) -- Swapping algorithms. Combining Factory + Strategy
+- [Adapter Pattern](../01-structural/00-adapter.md) -- Adapting existing classes. Using Factory to create Adapters
+- [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) -- Details of OCP and DIP
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Factory Method / Abstract Factory の原典
+1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- The original source for Factory Method / Abstract Factory
 2. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media. Chapter 4: The Factory Pattern.
-3. Martin, R.C. (2017). *Clean Architecture*. Prentice Hall. -- SOLID原則と Factory の関係
+3. Martin, R.C. (2017). *Clean Architecture*. Prentice Hall. -- The relationship between SOLID principles and Factory
 4. Refactoring.Guru -- Factory Method. https://refactoring.guru/design-patterns/factory-method
 5. Refactoring.Guru -- Abstract Factory. https://refactoring.guru/design-patterns/abstract-factory
 6. Fowler, M. -- Plugin Pattern. https://martinfowler.com/eaaCatalog/plugin.html

--- a/03-software-design/design-patterns-guide/docs/00-creational/02-builder.md
+++ b/03-software-design/design-patterns-guide/docs/00-creational/02-builder.md
@@ -1,75 +1,75 @@
-# Builder パターン
+# Builder Pattern
 
-> 複雑なオブジェクトの構築プロセスを **段階的に** 分離し、同じ構築手順で異なる表現を作成できるようにする生成パターン。
-
----
-
-## この章で学ぶこと
-
-1. Builder パターンの本質的な目的と、なぜ「段階的な構築」が必要なのかという設計意図（WHY）
-2. Fluent API / Step Builder / Director の各バリエーションと使い分け
-3. Telescoping Constructor 問題の根本的な解決と不変オブジェクトの安全な構築
-4. 各言語（TypeScript / Python / Java / Go / Kotlin）での実装パターンとベストプラクティス
-5. Builder パターンの過剰適用を避けるための判断基準とトレードオフ
+> A creational pattern that **incrementally** separates the construction process of complex objects, enabling the same construction procedure to create different representations.
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-このガイドを理解するために、以下の知識を事前に習得しておくことを推奨します。
+1. The essential purpose of the Builder pattern and the design intent (WHY) behind "incremental construction"
+2. The Fluent API, Step Builder, and Director variations and when to use each
+3. A fundamental solution to the Telescoping Constructor problem and safe construction of immutable objects
+4. Implementation patterns and best practices in each language (TypeScript / Python / Java / Go / Kotlin)
+5. Decision criteria and trade-offs for avoiding over-application of the Builder pattern
 
-| トピック | 必要レベル | 参照リンク |
+---
+
+## Prerequisites
+
+It is recommended that you have prior knowledge of the following topics before working through this guide.
+
+| Topic | Required Level | Reference |
 |---------|-----------|-----------|
-| オブジェクト指向の基礎（クラス、インタフェース、メソッドチェーン） | 必須 | OOP基礎 |
-| Factory パターン | 推奨 | [Factory](./01-factory.md) |
-| 不変性（Immutability）の概念 | 推奨 | [不変性](../../../clean-code-principles/docs/03-practices-advanced/00-immutability.md) |
-| TypeScript の型システム（ジェネリクス、条件型） | あると望ましい | TypeScript ドキュメント |
-| 関数設計（引数の設計） | あると望ましい | [関数設計](../../../clean-code-principles/docs/01-practices/01-functions.md) |
+| Object-oriented basics (classes, interfaces, method chaining) | Required | OOP Basics |
+| Factory pattern | Recommended | [Factory](./01-factory.md) |
+| Concept of Immutability | Recommended | [Immutability](../../../clean-code-principles/docs/03-practices-advanced/00-immutability.md) |
+| TypeScript type system (generics, conditional types) | Nice to have | TypeScript Documentation |
+| Function design (parameter design) | Nice to have | [Function Design](../../../clean-code-principles/docs/01-practices/01-functions.md) |
 
 ---
 
-## 1. Builder パターンの本質 -- なぜ段階的構築が必要なのか
+## 1. The Essence of the Builder Pattern -- Why Incremental Construction Is Necessary
 
-### 1.1 解決する問題: Telescoping Constructor
+### 1.1 The Problem It Solves: Telescoping Constructor
 
-ソフトウェア開発でオブジェクトの属性が増えるにつれ、コンストラクタの引数が膨大になる「**Telescoping Constructor（テレスコーピング・コンストラクタ）問題**」が発生する。
+As the number of attributes on an object grows in software development, a "**Telescoping Constructor**" problem arises, where the constructor ends up with an enormous number of parameters.
 
 ```typescript
-// 問題: 引数が増えるとどれが何か分からない
+// Problem: when arguments grow, it's impossible to tell what each one is
 //                  name    email      age  role   notify  theme   lang  tz
 new User("Taro", "t@x.com", 30, "admin", true, "dark", "ja", "Asia/Tokyo");
 //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//                                  6番目以降が何を表すか、読み手には分からない
+//                                  From the 6th argument onward, a reader cannot tell what they represent
 
-// さらに問題: オプション引数がある場合
+// A further problem: when there are optional arguments
 new User("Taro", "t@x.com", 30, undefined, true, undefined, "ja");
 //                                ^^^^^^^^         ^^^^^^^^
-//                                何を省略したのか不明
+//                                it is unclear what was omitted
 ```
 
-**WHY -- なぜこれが深刻な問題なのか?**
+**WHY -- Why is this a serious problem?**
 
 ```
-1. 可読性の破壊
+1. Destruction of readability
    new User("Taro", "t@x.com", 30, "admin", true, "dark")
-   → 3番目は年齢？ ID？ スコア？ コードを読むたびにクラス定義を参照する必要がある
+   → Is the 3rd argument age? An ID? A score? You must look up the class definition every time you read the code.
 
-2. 引数の順序ミス（サイレントバグ）
-   new Config(8080, 3000)  ← port と timeout のどちらが先？
-   → 型が同じ（number）なのでコンパイラも検出できない
+2. Argument order mistakes (silent bugs)
+   new Config(8080, 3000)  ← which comes first, port or timeout?
+   → Since both are the same type (number), the compiler cannot catch this.
 
-3. オプション引数の表現力不足
+3. Lack of expressiveness for optional arguments
    new User("Taro", "t@x.com", undefined, undefined, true, undefined, "ja")
-   → undefined の連鎖は読みにくく、バグの温床
+   → A chain of undefined values is hard to read and a breeding ground for bugs.
 
-4. 不変条件の維持が困難
-   コンストラクタの引数が多いと、バリデーションロジックが複雑化する
+4. Difficulty maintaining invariants
+   When a constructor has many arguments, validation logic becomes complex.
 ```
 
-### 1.2 Builder による解決
+### 1.2 The Solution with Builder
 
 ```typescript
-// Builder なら自己文書化される
+// With a Builder, the code is self-documenting
 const user = User.builder()
   .setName("Taro")
   .setEmail("t@x.com")
@@ -81,29 +81,29 @@ const user = User.builder()
   .setTimezone("Asia/Tokyo")
   .build();
 
-// 利点:
-// 1. 各値の意味が明確（自己文書化）
-// 2. 順序に依存しない
-// 3. オプション値は省略するだけでデフォルト値が適用
-// 4. build() でバリデーションを集約できる
+// Benefits:
+// 1. The meaning of each value is clear (self-documenting)
+// 2. No dependency on argument order
+// 3. Optional values simply omitted, with defaults applied
+// 4. Validation can be centralized in build()
 ```
 
-### 1.3 Builder パターンの定義
+### 1.3 Definition of the Builder Pattern
 
-GoF の定義:
+The GoF definition:
 
-> **複雑なオブジェクトの構築を表現から分離し、同じ構築プロセスで異なる表現を作成できるようにする。**
+> **Separate the construction of a complex object from its representation, allowing the same construction process to create different representations.**
 
-この定義には2つの意図がある:
+This definition carries two intentions:
 
-1. **構築と表現の分離**: オブジェクトの組み立て手順（HOW）と、最終的な形（WHAT）を分離
-2. **同じプロセスで異なる結果**: 同じ手順で HTML / Markdown / PDF など異なる出力を生成
+1. **Separation of construction and representation**: Separate the assembly procedure (HOW) from the final form (WHAT)
+2. **Different results from the same process**: Use the same steps to produce different outputs such as HTML, Markdown, or PDF
 
 ---
 
-## 2. Builder の構造
+## 2. Structure of the Builder
 
-### 2.1 UML クラス図
+### 2.1 UML Class Diagram
 
 ```
 +------------+       +-----------------+
@@ -131,7 +131,7 @@ GoF の定義:
               +-----------+  +-----------+
 ```
 
-### 2.2 シーケンス図
+### 2.2 Sequence Diagram
 
 ```
 Client         Director         Builder          Product
@@ -153,21 +153,21 @@ Client         Director         Builder          Product
   |<-- product ---|                |                |
 ```
 
-### 2.3 Fluent Builder の内部動作
+### 2.3 Internal Operation of the Fluent Builder
 
 ```
-Fluent Builder の核心:
-各 setter が this を返すことで、メソッドチェーンを実現する。
+The core of the Fluent Builder:
+Each setter returns `this`, enabling method chaining.
 
-HttpRequest.builder("POST", "/api")  ← Builder を生成
-  .setHeader("Content-Type", "json") ← this を返す → 次のメソッド呼出可能
-  .setBody('{"name": "Taro"}')       ← this を返す → 次のメソッド呼出可能
-  .setTimeout(5000)                  ← this を返す → 次のメソッド呼出可能
-  .build()                           ← Product を生成して返す
+HttpRequest.builder("POST", "/api")  ← creates a Builder
+  .setHeader("Content-Type", "json") ← returns this → allows the next method call
+  .setBody('{"name": "Taro"}')       ← returns this → allows the next method call
+  .setTimeout(5000)                  ← returns this → allows the next method call
+  .build()                           ← creates and returns the Product
 
-内部状態の変化:
+Internal state changes:
 ┌────────────────────────────────────┐
-│ Builder 内部                        │
+│ Builder internals                   │
 │                                    │
 │ Step 1: method = "POST"            │
 │         url = "/api"               │
@@ -182,19 +182,19 @@ HttpRequest.builder("POST", "/api")  ← Builder を生成
 │ Step 4: timeout = 5000             │
 │                                    │
 │ Step 5 (build): → new HttpRequest  │
-│   全フィールドを Product にコピー    │
-│   バリデーション実行                │
-│   Product は不変（readonly）       │
+│   Copy all fields to Product       │
+│   Run validation                   │
+│   Product is immutable (readonly)  │
 └────────────────────────────────────┘
 ```
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: Fluent Builder（TypeScript）
+### Code Example 1: Fluent Builder (TypeScript)
 
-最も一般的な Builder 実装。実務で圧倒的に多用される。
+The most common Builder implementation, overwhelmingly used in real-world practice.
 
 ```typescript
 class HttpRequest {
@@ -238,7 +238,7 @@ class HttpRequestBuilder {
 
   setHeader(key: string, value: string): this {
     this.headers[key] = value;
-    return this;  // this を返すことでメソッドチェーンを実現
+    return this;  // Returning this enables method chaining
   }
 
   setBody(body: string): this {
@@ -259,7 +259,7 @@ class HttpRequestBuilder {
   }
 
   build(): HttpRequest {
-    // バリデーション
+    // Validation
     if (!this.method) throw new Error("Method is required");
     if (!this.url) throw new Error("URL is required");
 
@@ -267,7 +267,7 @@ class HttpRequestBuilder {
   }
 }
 
-// 使用
+// Usage
 const req = HttpRequest.builder("POST", "/api/users")
   .setHeader("Content-Type", "application/json")
   .setHeader("Authorization", "Bearer token123")
@@ -282,9 +282,9 @@ console.log(req.headers);
 // { "Content-Type": "application/json", "Authorization": "Bearer token123" }
 ```
 
-### コード例 2: Director パターン
+### Code Example 2: Director Pattern
 
-Director は構築手順をカプセル化し、再利用可能にする。
+The Director encapsulates the construction procedure and makes it reusable.
 
 ```typescript
 interface QueryBuilder {
@@ -344,7 +344,7 @@ class SQLQueryBuilder implements QueryBuilder {
   }
 }
 
-// Director: 構築手順を再利用可能にカプセル化
+// Director: encapsulates construction procedures for reuse
 class QueryDirector {
   buildPaginatedQuery(builder: QueryBuilder, table: string, page: number, size: number): string {
     return builder
@@ -377,7 +377,7 @@ class QueryDirector {
   }
 }
 
-// 使用
+// Usage
 const director = new QueryDirector();
 
 const listQuery = director.buildPaginatedQuery(new SQLQueryBuilder(), "users", 2, 20);
@@ -389,7 +389,7 @@ console.log(countQuery);
 // SELECT COUNT(*) as total FROM users WHERE active = true
 ```
 
-### コード例 3: 不変オブジェクトの構築
+### Code Example 3: Building Immutable Objects
 
 ```typescript
 interface UserConfig {
@@ -439,51 +439,51 @@ class UserConfigBuilder {
   }
 
   build(): UserConfig {
-    // 必須フィールドのバリデーション
+    // Validate required fields
     if (!this.config.name) throw new Error("name is required");
     if (!this.config.email) throw new Error("email is required");
 
-    // デフォルト値の適用 + Object.freeze で不変性を保証
+    // Apply defaults + guarantee immutability with Object.freeze
     return Object.freeze({
       name: this.config.name,
       email: this.config.email,
       role: this.config.role ?? "viewer",
       notifications: this.config.notifications ?? true,
-      language: this.config.language ?? "ja",
+      language: this.config.language ?? "en",
       theme: this.config.theme ?? "system",
     });
   }
 }
 
-// 使用
+// Usage
 const config = new UserConfigBuilder()
-  .setName("太郎")
+  .setName("Taro")
   .setEmail("taro@example.com")
   .setRole("admin")
   .setTheme("dark")
   .build();
 
 console.log(config);
-// { name: "太郎", email: "taro@example.com", role: "admin",
-//   notifications: true, language: "ja", theme: "dark" }
+// { name: "Taro", email: "taro@example.com", role: "admin",
+//   notifications: true, language: "en", theme: "dark" }
 
-// config.name = "次郎"; // Error: Cannot assign to read only property
+// config.name = "Jiro"; // Error: Cannot assign to read only property
 ```
 
-### コード例 4: Step Builder（型安全な必須フィールド保証）
+### Code Example 4: Step Builder (Type-safe guarantee of required fields)
 
-コンパイル時に必須フィールドの設定順序を強制する高度なパターン。
+An advanced pattern that enforces the setting order of required fields at compile time.
 
 ```typescript
-// Step 1: name が必須
+// Step 1: name is required
 interface NeedsName {
   setName(name: string): NeedsEmail;
 }
-// Step 2: email が必須
+// Step 2: email is required
 interface NeedsEmail {
   setEmail(email: string): OptionalFields;
 }
-// Step 3: 任意フィールド + build
+// Step 3: optional fields + build
 interface OptionalFields {
   setAge(age: number): OptionalFields;
   setRole(role: string): OptionalFields;
@@ -546,35 +546,35 @@ class PersonBuilder implements NeedsName, NeedsEmail, OptionalFields {
   }
 }
 
-// コンパイル時に順序が強制される
+// The order is enforced at compile time
 const person = PersonBuilder.create()
-  .setName("Taro")           // NeedsEmail が返る → setEmail 以外呼べない
-  .setEmail("t@example.com") // OptionalFields が返る → 任意フィールドと build が呼べる
+  .setName("Taro")           // Returns NeedsEmail → only setEmail can be called next
+  .setEmail("t@example.com") // Returns OptionalFields → optional fields and build become callable
   .setAge(30)
   .setRole("engineer")
   .build();
 
-// コンパイルエラーの例:
-// PersonBuilder.create().setAge(30)           // Error: setAge は NeedsName に存在しない
-// PersonBuilder.create().setName("A").build() // Error: build は NeedsEmail に存在しない
+// Examples of compile errors:
+// PersonBuilder.create().setAge(30)           // Error: setAge does not exist on NeedsName
+// PersonBuilder.create().setName("A").build() // Error: build does not exist on NeedsEmail
 ```
 
-**WHY -- Step Builder が必要な場面:**
+**WHY -- When Step Builder is needed:**
 
 ```
-通常の Fluent Builder の問題:
+The problem with a regular Fluent Builder:
   new UserBuilder()
-    .setAge(30)          // name を設定し忘れ
-    .setRole("admin")    // email を設定し忘れ
-    .build()             // 実行時エラー（build内のバリデーションで検出）
+    .setAge(30)          // forgot to set name
+    .setRole("admin")    // forgot to set email
+    .build()             // runtime error (caught by validation inside build)
 
-Step Builder なら:
+With a Step Builder:
   PersonBuilder.create()
-    .setAge(30)          // コンパイルエラー！NeedsName に setAge は存在しない
-    → 実行前に問題を検出できる
+    .setAge(30)          // Compile error! setAge does not exist on NeedsName
+    → The problem is caught before execution.
 ```
 
-### コード例 5: Python -- Builder with dataclass
+### Code Example 5: Python -- Builder with dataclass
 
 ```python
 from dataclasses import dataclass, field
@@ -582,27 +582,27 @@ from typing import Optional
 
 @dataclass(frozen=True)
 class Pizza:
-    """不変の Pizza オブジェクト"""
+    """Immutable Pizza object"""
     size: str
     crust: str
     cheese: bool
     pepperoni: bool
     mushrooms: bool
-    extra_toppings: tuple[str, ...]  # tuple で不変性を保証
+    extra_toppings: tuple[str, ...]  # tuple guarantees immutability
 
     def description(self) -> str:
         toppings = []
-        if self.cheese: toppings.append("チーズ")
-        if self.pepperoni: toppings.append("ペパロニ")
-        if self.mushrooms: toppings.append("マッシュルーム")
+        if self.cheese: toppings.append("Cheese")
+        if self.pepperoni: toppings.append("Pepperoni")
+        if self.mushrooms: toppings.append("Mushrooms")
         toppings.extend(self.extra_toppings)
-        return f"{self.size} {self.crust} ピザ: {', '.join(toppings)}"
+        return f"{self.size} {self.crust} Pizza: {', '.join(toppings)}"
 
 class PizzaBuilder:
-    """Pizza の段階的構築"""
+    """Incremental construction of a Pizza"""
     def __init__(self, size: str):
         self._size = size
-        self._crust = "レギュラー"
+        self._crust = "Regular"
         self._cheese = False
         self._pepperoni = False
         self._mushrooms = False
@@ -635,41 +635,41 @@ class PizzaBuilder:
             cheese=self._cheese,
             pepperoni=self._pepperoni,
             mushrooms=self._mushrooms,
-            extra_toppings=tuple(self._extra),  # list → tuple で不変化
+            extra_toppings=tuple(self._extra),  # list → tuple for immutability
         )
 
-# 使用
+# Usage
 pizza = (PizzaBuilder("Large")
-    .crust("シンクラスト")
+    .crust("Thin Crust")
     .add_cheese()
     .add_pepperoni()
-    .add_topping("オリーブ")
-    .add_topping("バジル")
+    .add_topping("Olives")
+    .add_topping("Basil")
     .build())
 
 print(pizza.description())
-# Large シンクラスト ピザ: チーズ, ペパロニ, オリーブ, バジル
+# Large Thin Crust Pizza: Cheese, Pepperoni, Olives, Basil
 ```
 
-### コード例 6: Java -- Builder（Effective Java スタイル）
+### Code Example 6: Java -- Builder (Effective Java Style)
 
-Joshua Bloch が推奨するスタイル。Builder をネストクラスとして定義する。
+The style recommended by Joshua Bloch. The Builder is defined as a nested class.
 
 ```java
 public class NutritionFacts {
-    private final int servingSize;   // 必須
-    private final int servings;      // 必須
-    private final int calories;      // 任意
-    private final int fat;           // 任意
-    private final int sodium;        // 任意
-    private final int carbohydrate;  // 任意
+    private final int servingSize;   // required
+    private final int servings;      // required
+    private final int calories;      // optional
+    private final int fat;           // optional
+    private final int sodium;        // optional
+    private final int carbohydrate;  // optional
 
     public static class Builder {
-        // 必須パラメータ
+        // Required parameters
         private final int servingSize;
         private final int servings;
 
-        // 任意パラメータ（デフォルト値で初期化）
+        // Optional parameters (initialized to default values)
         private int calories = 0;
         private int fat = 0;
         private int sodium = 0;
@@ -705,7 +705,7 @@ public class NutritionFacts {
     }
 }
 
-// 使用
+// Usage
 NutritionFacts cocaCola = new NutritionFacts.Builder(240, 8)
     .calories(100)
     .sodium(35)
@@ -713,9 +713,9 @@ NutritionFacts cocaCola = new NutritionFacts.Builder(240, 8)
     .build();
 ```
 
-### コード例 7: Go -- Functional Options Pattern
+### Code Example 7: Go -- Functional Options Pattern
 
-Go 言語では Builder パターンの代わりに Functional Options パターンが推奨される。
+In Go, the Functional Options pattern is preferred over the Builder pattern.
 
 ```go
 package main
@@ -734,10 +734,10 @@ type Server struct {
     certFile     string
 }
 
-// Option は Server の設定を変更する関数型
+// Option is a function type that modifies Server configuration
 type Option func(*Server)
 
-// 各オプションを関数として定義
+// Define each option as a function
 func WithPort(port int) Option {
     return func(s *Server) {
         s.port = port
@@ -763,9 +763,9 @@ func WithTLS(certFile string) Option {
     }
 }
 
-// コンストラクタ: 必須引数 + 可変長オプション
+// Constructor: required arguments + variadic options
 func NewServer(host string, opts ...Option) *Server {
-    // デフォルト値
+    // Default values
     s := &Server{
         host:    host,
         port:    8080,
@@ -773,7 +773,7 @@ func NewServer(host string, opts ...Option) *Server {
         maxConn: 100,
     }
 
-    // オプションを適用
+    // Apply options
     for _, opt := range opts {
         opt(s)
     }
@@ -782,12 +782,12 @@ func NewServer(host string, opts ...Option) *Server {
 }
 
 func main() {
-    // デフォルト設定
+    // Default configuration
     s1 := NewServer("localhost")
     fmt.Printf("Server: %s:%d\n", s1.host, s1.port)
     // Server: localhost:8080
 
-    // カスタム設定
+    // Custom configuration
     s2 := NewServer("api.example.com",
         WithPort(443),
         WithTimeout(10*time.Second),
@@ -799,19 +799,19 @@ func main() {
 }
 ```
 
-**WHY -- Go で Functional Options が好まれる理由:**
+**WHY -- Why Functional Options are preferred in Go:**
 
 ```
-1. Go にはメソッドチェーンの文化がない（error を返す慣習）
-2. ゼロ値が有用なデフォルトとして機能する
-3. 関数はファーストクラスオブジェクトなので自然
-4. テストで特定のオプションだけ変更しやすい
-5. 後方互換性を保ちながらオプションを追加できる
+1. Go does not have a culture of method chaining (convention is to return errors)
+2. Zero values serve as useful defaults
+3. Functions are first-class objects, so this approach is natural
+4. Easy to change only specific options in tests
+5. Options can be added while maintaining backward compatibility
 ```
 
-### コード例 8: Kotlin -- data class + copy
+### Code Example 8: Kotlin -- data class + copy
 
-Kotlin では data class の copy メソッドが Builder の多くのユースケースをカバーする。
+In Kotlin, the `copy` method of data classes covers many Builder use cases.
 
 ```kotlin
 data class ServerConfig(
@@ -823,7 +823,7 @@ data class ServerConfig(
     val certFile: String? = null,
 )
 
-// Kotlin のデフォルト引数 + 名前付き引数 = Builder 不要
+// Kotlin default arguments + named arguments = no Builder needed
 val config1 = ServerConfig(
     host = "localhost",
     port = 3000,
@@ -831,7 +831,7 @@ val config1 = ServerConfig(
     certFile = "/etc/certs/server.pem",
 )
 
-// copy で一部だけ変更（Prototype + Builder の合成）
+// copy to change only some fields (a combination of Prototype + Builder)
 val config2 = config1.copy(
     host = "api.example.com",
     port = 443,
@@ -842,12 +842,12 @@ println(config2)
 //   maxConnections=100, enableTLS=true, certFile=/etc/certs/server.pem)
 ```
 
-### コード例 9: TypeScript -- Generic Builder
+### Code Example 9: TypeScript -- Generic Builder
 
-型安全にフィールドの設定状態を追跡する高度な Builder。
+An advanced Builder that tracks the state of field settings at the type level.
 
 ```typescript
-// 設定されたフィールドを型レベルで追跡
+// Track set fields at the type level
 type BuilderState = {
   name: boolean;
   email: boolean;
@@ -871,27 +871,27 @@ class TypedBuilder<State extends BuilderState = { name: false; email: false }> {
     return this as any;
   }
 
-  // build は name と email が両方 true の場合のみ呼べる
+  // build can only be called when both name and email are true
   build(this: TypedBuilder<{ name: true; email: true }>): Person {
     return this.data as Person;
   }
 }
 
-// OK: name と email が設定済み
+// OK: name and email are both set
 const p1 = new TypedBuilder()
   .setName("Taro")
   .setEmail("t@example.com")
   .setAge(30)
   .build(); // OK
 
-// Error: build は name: false の状態では呼べない
+// Error: build cannot be called when name is false
 // new TypedBuilder().setEmail("t@example.com").build();
 ```
 
-### コード例 10: 複雑なドメインオブジェクトの構築
+### Code Example 10: Building Complex Domain Objects
 
 ```typescript
-// 実務的な例: 電子メール構築
+// A practical example: building an email
 interface Email {
   readonly from: string;
   readonly to: string[];
@@ -990,7 +990,7 @@ class EmailBuilder {
   }
 }
 
-// 使用
+// Usage
 const email = new EmailBuilder()
   .setFrom("noreply@example.com")
   .addTo("user1@example.com", "user2@example.com")
@@ -1003,140 +1003,140 @@ const email = new EmailBuilder()
 
 ---
 
-## 4. 比較表
+## 4. Comparison Tables
 
-### 比較表 1: Builder vs コンストラクタ vs オブジェクトリテラル
+### Comparison Table 1: Builder vs Constructor vs Object Literal
 
-| 観点 | コンストラクタ | オブジェクトリテラル | Builder |
+| Aspect | Constructor | Object Literal | Builder |
 |------|:---:|:---:|:---:|
-| 必須フィールド強制 | Yes | 要バリデーション | Yes (Step Builder) |
-| 可読性（多引数） | 低い | 中 | 高い |
-| 不変性保証 | 可能 | 困難 | 容易 |
-| 複雑な構築ロジック | 困難 | 困難 | 容易 |
-| コード量 | 少ない | 少ない | 多い |
-| バリデーション集約 | コンストラクタ内 | 外部 | build() 内 |
-| IDEサポート（補完） | 良好 | 良好 | 優秀 |
-| 導入の判断基準 | 引数 1-3個 | 全て任意 | 引数 4個以上 |
+| Enforce required fields | Yes | Requires validation | Yes (Step Builder) |
+| Readability (many args) | Low | Medium | High |
+| Immutability guarantee | Possible | Difficult | Easy |
+| Complex construction logic | Difficult | Difficult | Easy |
+| Amount of code | Small | Small | Large |
+| Centralized validation | Inside constructor | External | Inside build() |
+| IDE support (autocomplete) | Good | Good | Excellent |
+| When to use | 1-3 arguments | All optional | 4+ arguments |
 
-### 比較表 2: Builder vs Factory
+### Comparison Table 2: Builder vs Factory
 
-| 観点 | Builder | Factory |
+| Aspect | Builder | Factory |
 |------|---------|---------|
-| 目的 | 段階的な構築 | 型の選択 |
-| 返すもの | 1つの複雑なオブジェクト | さまざまな型のオブジェクト |
-| メソッドチェーン | 一般的 | まれ |
-| 適用場面 | 多数のオプション引数 | バリエーションの切り替え |
-| 構築の柔軟性 | 高い（段階的にカスタマイズ） | 低い（事前定義された型から選択） |
-| 組み合わせ | Factory が Builder を返すこともある | Builder が Factory を使うこともある |
+| Purpose | Incremental construction | Type selection |
+| What it returns | One complex object | Objects of various types |
+| Method chaining | Common | Rare |
+| Use case | Many optional arguments | Switching between variations |
+| Construction flexibility | High (incrementally customizable) | Low (select from predefined types) |
+| Combination | Factory can return a Builder | Builder can use a Factory |
 
-### 比較表 3: 言語別 Builder 代替手法
+### Comparison Table 3: Builder Alternatives by Language
 
-| 言語 | Builder 代替 | 使い分け |
+| Language | Builder Alternative | When to Use |
 |------|-------------|---------|
-| TypeScript | オブジェクトリテラル + Partial<T> | 単純なケース |
-| Python | キーワード引数 + dataclass | Builder 不要なことが多い |
-| Kotlin | 名前付き引数 + copy() | Builder 不要なことが多い |
-| Java | Effective Java Builder | 標準的なアプローチ |
-| Go | Functional Options | Go のイディオム |
-| Rust | Builder derive macro | ボイラープレート削減 |
-| C# | Object Initializer | Builder 不要なことが多い |
+| TypeScript | Object literal + Partial<T> | Simple cases |
+| Python | Keyword arguments + dataclass | Builder often unnecessary |
+| Kotlin | Named arguments + copy() | Builder often unnecessary |
+| Java | Effective Java Builder | Standard approach |
+| Go | Functional Options | Go idiom |
+| Rust | Builder derive macro | Reduces boilerplate |
+| C# | Object Initializer | Builder often unnecessary |
 
 ---
 
-## 5. エッジケースと注意点
+## 5. Edge Cases and Caveats
 
-### 5.1 build() の呼び忘れ
+### 5.1 Forgetting to Call build()
 
 ```typescript
-// BAD: build() を忘れて Builder オブジェクトを使ってしまう
+// BAD: forgetting build() and accidentally using the Builder object
 const config = new ConfigBuilder()
   .setHost("localhost")
   .setPort(8080);
-  // .build() を忘れた！ config は ConfigBuilder 型
+  // forgot .build()! config is of type ConfigBuilder
 
-server.start(config); // 型エラーまたは実行時エラー
+server.start(config); // type error or runtime error
 ```
 
-**対策:**
+**Countermeasures:**
 
 ```typescript
-// 1. TypeScript の型システムで Builder と Product を明確に区別
-//    → server.start() は ServerConfig 型のみ受け付ける
+// 1. Use TypeScript's type system to clearly distinguish Builder from Product
+//    → server.start() only accepts ServerConfig type
 
-// 2. Step Builder で build() を最終ステップに強制
+// 2. Use Step Builder to force build() as the final step
 
-// 3. ESLint ルールで Builder 型の変数への代入を警告
+// 3. Use an ESLint rule to warn on variable assignments of Builder type
 ```
 
-### 5.2 Builder の再利用問題
+### 5.2 Builder Reuse Problem
 
 ```typescript
-// BAD: 同じ Builder インスタンスを再利用
+// BAD: reusing the same Builder instance
 const builder = new UserBuilder().setName("Taro").setEmail("t@example.com");
 
 const user1 = builder.setRole("admin").build();
 const user2 = builder.setRole("viewer").build();
 
-// user2 は admin? viewer? → Builder の内部状態に依存する
-// builder.setRole("admin") が builder を変更しているので、
-// user2 も admin になる可能性がある
+// Is user2 admin or viewer? → depends on the Builder's internal state
+// Since builder.setRole("admin") modified the builder,
+// user2 may also end up as admin
 ```
 
-**対策:**
+**Countermeasures:**
 
 ```typescript
-// Builder の build() 後にリセットするか、
-// 毎回新しい Builder を生成する
+// Either reset the Builder after build(), or
+// create a new Builder each time
 
-// 方法 1: build() でリセット
+// Option 1: reset on build()
 build(): User {
   const user = new User(this);
-  this.reset(); // 内部状態をリセット
+  this.reset(); // reset internal state
   return user;
 }
 
-// 方法 2: 毎回新しい Builder（推奨）
+// Option 2: create a new Builder each time (recommended)
 const user1 = User.builder().setName("Taro").setRole("admin").build();
 const user2 = User.builder().setName("Taro").setRole("viewer").build();
 ```
 
-### 5.3 スレッドセーフティ
+### 5.3 Thread Safety
 
 ```
-マルチスレッド環境で Builder を共有すると問題が発生する:
+Sharing a Builder in a multithreaded environment causes problems:
 
 Thread A: builder.setName("Taro")
-Thread B: builder.setName("Jiro")   ← 競合！
-Thread A: builder.build()            ← Jiro が返る可能性
+Thread B: builder.setName("Jiro")   ← race condition!
+Thread A: builder.build()            ← may return "Jiro"
 
-対策:
-1. Builder は共有せず、各スレッドで新規生成する（推奨）
-2. Builder のメソッドを synchronized にする（非推奨: パフォーマンス低下）
-3. Immutable Builder: 各メソッドが新しい Builder を返す
+Countermeasures:
+1. Do not share Builders; create a new one per thread (recommended)
+2. Synchronize Builder methods (not recommended: performance degradation)
+3. Immutable Builder: each method returns a new Builder
 ```
 
 ---
 
-## 6. アンチパターン
+## 6. Anti-patterns
 
-### アンチパターン 1: Builder の build() を呼び忘れる
+### Anti-pattern 1: Forgetting to Call build()
 
 ```typescript
-// NG: build() を忘れて Builder オブジェクトを使ってしまう
+// NG: forgetting build() and accidentally using the Builder object
 const config = new ConfigBuilder()
   .setHost("localhost")
   .setPort(8080);
-  // .build() を忘れた！
+  // forgot .build()!
 
-server.start(config); // 型エラーまたは実行時エラー
+server.start(config); // type error or runtime error
 ```
 
-**改善**: TypeScript の型システムで Builder と Product を明確に区別する。Step Builder を使えばコンパイルエラーにできる。
+**Fix**: Use TypeScript's type system to clearly distinguish Builder from Product. Using a Step Builder makes this a compile error.
 
-### アンチパターン 2: Builder にビジネスロジックを詰める
+### Anti-pattern 2: Stuffing Business Logic into the Builder
 
 ```typescript
-// NG: Builder が構築以外の責任を持つ
+// NG: Builder takes on responsibilities beyond construction
 class OrderBuilder {
   private items: CartItem[] = [];
   private coupon?: string;
@@ -1154,14 +1154,14 @@ class OrderBuilder {
   build(): Order {
     const order = new Order(this.items);
 
-    // NG: ビジネスロジック
+    // NG: business logic
     if (this.coupon) {
-      const discount = validateCoupon(this.coupon); // クーポン検証
-      order.applyDiscount(discount);                 // 割引適用
+      const discount = validateCoupon(this.coupon); // coupon validation
+      order.applyDiscount(discount);                 // apply discount
     }
-    order.calculateTax();       // 税計算
-    order.calculateShipping();  // 送料計算
-    sendNotification(order);    // 通知送信（副作用）
+    order.calculateTax();       // tax calculation
+    order.calculateShipping();  // shipping calculation
+    sendNotification(order);    // send notification (side effect)
 
     return order;
   }
@@ -1169,7 +1169,7 @@ class OrderBuilder {
 ```
 
 ```typescript
-// OK: Builder は構築のみ。ビジネスロジックはドメインサービスに委譲
+// OK: Builder only constructs. Business logic is delegated to domain services.
 class OrderBuilder {
   private items: CartItem[] = [];
 
@@ -1180,11 +1180,11 @@ class OrderBuilder {
 
   build(): Order {
     if (this.items.length === 0) throw new Error("Order must have items");
-    return new Order([...this.items]); // 構築のみ
+    return new Order([...this.items]); // construction only
   }
 }
 
-// ビジネスロジックはサービスに委譲
+// Business logic is delegated to a service
 class OrderService {
   async processOrder(order: Order, couponCode?: string): Promise<Order> {
     if (couponCode) {
@@ -1198,10 +1198,10 @@ class OrderService {
 }
 ```
 
-### アンチパターン 3: 単純なオブジェクトに Builder を使う
+### Anti-pattern 3: Using Builder for Simple Objects
 
 ```typescript
-// NG: フィールドが2つしかないのに Builder を使う
+// NG: using a Builder for an object with only 2 fields
 class PointBuilder {
   private x = 0;
   private y = 0;
@@ -1211,11 +1211,11 @@ class PointBuilder {
   build(): Point { return new Point(this.x, this.y); }
 }
 
-// 20行のコードが、やりたいことに対して過剰
+// 20 lines of code is excessive for what this accomplishes
 ```
 
 ```typescript
-// OK: コンストラクタで十分
+// OK: a constructor is sufficient
 class Point {
   constructor(public readonly x: number, public readonly y: number) {}
 }
@@ -1223,43 +1223,46 @@ class Point {
 const p = new Point(10, 20);
 ```
 
-**判断基準**: 引数が4つ未満、オプション引数が2つ未満なら、Builder は過剰設計。
+**Decision criteria**: If there are fewer than 4 arguments and fewer than 2 optional arguments, a Builder is over-engineering.
 
 ---
 
-## 7. トレードオフ分析
+## 7. Trade-off Analysis
 
 ```
-利点                              欠点
+Benefits                                   Drawbacks
 +------------------------------+  +------------------------------+
-| 自己文書化された構築コード    |  | ボイラープレートコードが多い  |
-| 不変オブジェクトの安全な構築  |  | クラス数の増加                |
-| バリデーションの集約          |  | 単純なケースには過剰設計      |
-| 順序非依存のフィールド設定    |  | build() の呼び忘れリスク      |
-| IDEの優れたオートコンプリート  |  | Builder と Product の同期維持  |
-| テストでの柔軟な構築          |  | 言語によっては不要（Kotlin等） |
+| Self-documenting build code  |  | Large amount of boilerplate  |
+| Safe construction of         |  | Increased number of classes  |
+|   immutable objects          |  | Over-engineering for simple  |
+| Centralized validation       |  |   cases                      |
+| Order-independent field      |  | Risk of forgetting build()   |
+|   setting                    |  | Need to keep Builder and     |
+| Excellent IDE autocomplete   |  |   Product in sync            |
+| Flexible construction        |  | Unnecessary in some          |
+|   in tests                   |  |   languages (Kotlin, etc.)   |
 +------------------------------+  +------------------------------+
 ```
 
 ---
 
-## 8. 実践演習
+## 8. Practice Exercises
 
-### 演習 1: 基礎 -- HTTP レスポンス Builder
+### Exercise 1: Basic -- HTTP Response Builder
 
-**課題**: HTTP レスポンスオブジェクトを構築する Builder を実装してください。
+**Task**: Implement a Builder that constructs an HTTP response object.
 
-**要件**:
-- ステータスコード（必須）、ヘッダー、ボディ、Content-Type を設定可能
-- Fluent API（メソッドチェーン）
-- build() でバリデーション（ステータスコードが 100-599 の範囲内か）
-- 生成されたレスポンスは不変
+**Requirements**:
+- Configurable status code (required), headers, body, and Content-Type
+- Fluent API (method chaining)
+- Validation in build() (check that status code is in the range 100-599)
+- The generated response is immutable
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 const res = new HttpResponseBuilder(200)
@@ -1274,7 +1277,7 @@ console.log(res.body);        // '{"message":"OK"}'
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Solution (click to expand)</summary>
 
 ```typescript
 interface HttpResponse {
@@ -1321,21 +1324,21 @@ class HttpResponseBuilder {
 
 </details>
 
-### 演習 2: 応用 -- SQL Query Builder with Director
+### Exercise 2: Applied -- SQL Query Builder with Director
 
-**課題**: SQL クエリを構築する Builder と、よく使うクエリパターンを Director として実装してください。
+**Task**: Implement a Builder for constructing SQL queries and a Director for commonly used query patterns.
 
-**要件**:
-- SELECT / FROM / WHERE / JOIN / ORDER BY / LIMIT / OFFSET をサポート
-- WHERE 条件は複数指定可能（AND 結合）
-- Director に「ページネーション付き一覧取得」「件数取得」「検索」の3つの構築パターン
-- パラメータバインディング（SQLインジェクション対策）
+**Requirements**:
+- Support SELECT / FROM / WHERE / JOIN / ORDER BY / LIMIT / OFFSET
+- Multiple WHERE conditions can be specified (joined with AND)
+- Director has three construction patterns: "paginated list retrieval", "count retrieval", and "search"
+- Parameter binding (SQL injection prevention)
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 const director = new QueryDirector();
@@ -1348,7 +1351,7 @@ console.log(listQuery.params);
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Solution (click to expand)</summary>
 
 ```typescript
 interface Query {
@@ -1473,51 +1476,51 @@ class QueryDirector {
 
 </details>
 
-### 演習 3: 発展 -- Step Builder with 条件分岐
+### Exercise 3: Advanced -- Step Builder with Conditional Branching
 
-**課題**: ユーザー種別（個人/法人）によって必須フィールドが異なる Step Builder を設計してください。
+**Task**: Design a Step Builder where required fields differ depending on the user type (individual / corporate).
 
-**要件**:
-- 個人ユーザー: name, email が必須。age はオプション
-- 法人ユーザー: companyName, email, registrationNumber が必須
-- 種別選択後、該当する必須フィールドのみが要求される（型安全）
-- build() は全ての必須フィールドが設定された場合のみ呼び出し可能
+**Requirements**:
+- Individual user: name and email are required. age is optional.
+- Corporate user: companyName, email, and registrationNumber are required.
+- After selecting the type, only the relevant required fields are demanded (type-safe).
+- build() can only be called once all required fields are set.
 
 ```typescript
-// === あなたの実装をここに書いてください ===
+// === Write your implementation here ===
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-// 個人ユーザー
+// Individual user
 const individual = UserBuilder.create()
-  .asIndividual()            // → NeedsIndividualName が返る
-  .setName("太郎")           // → NeedsIndividualEmail が返る
-  .setEmail("taro@test.com") // → IndividualOptional が返る
+  .asIndividual()            // → returns NeedsIndividualName
+  .setName("Taro")           // → returns NeedsIndividualEmail
+  .setEmail("taro@test.com") // → returns IndividualOptional
   .setAge(30)
   .build();
 
-// 法人ユーザー
+// Corporate user
 const corporate = UserBuilder.create()
-  .asCorporate()                       // → NeedsCorporateName が返る
-  .setCompanyName("株式会社Example")    // → NeedsCorporateEmail が返る
-  .setEmail("info@example.co.jp")      // → NeedsCorporateRegNum が返る
-  .setRegistrationNumber("1234567890") // → CorporateOptional が返る
+  .asCorporate()                       // → returns NeedsCorporateName
+  .setCompanyName("Example Corp")      // → returns NeedsCorporateEmail
+  .setEmail("info@example.com")        // → returns NeedsCorporateRegNum
+  .setRegistrationNumber("1234567890") // → returns CorporateOptional
   .build();
 ```
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Solution (click to expand)</summary>
 
 ```typescript
-// 種別選択
+// Type selection
 interface SelectType {
   asIndividual(): NeedsIndividualName;
   asCorporate(): NeedsCorporateName;
 }
 
-// 個人ユーザーのステップ
+// Steps for individual user
 interface NeedsIndividualName {
   setName(name: string): NeedsIndividualEmail;
 }
@@ -1530,7 +1533,7 @@ interface IndividualOptional {
   build(): User;
 }
 
-// 法人ユーザーのステップ
+// Steps for corporate user
 interface NeedsCorporateName {
   setCompanyName(name: string): NeedsCorporateEmail;
 }
@@ -1626,57 +1629,57 @@ class UserBuilder implements
 
 ## 9. FAQ
 
-### Q1: Builder はどの程度の複雑さから導入すべきですか？
+### Q1: From what level of complexity should I introduce a Builder?
 
-目安として、**コンストラクタの引数が 4 つ以上**、または**オプション引数が 2 つ以上**ある場合に Builder の導入を検討します。引数が 2-3 個であればコンストラクタで十分です。
+As a guideline, consider introducing a Builder when a **constructor has 4 or more parameters** or **has 2 or more optional parameters**. If there are 2-3 parameters, a constructor is sufficient.
 
-ただし、以下の場合は引数が少なくても Builder を検討する価値があります:
-- 同じ型の引数が複数ある（順序ミスのリスク）
-- 構築に複数ステップが必要
-- 構築ロジックの再利用が必要（Director）
+However, a Builder is worth considering even with fewer parameters in these cases:
+- There are multiple parameters of the same type (risk of order mistakes)
+- Construction requires multiple steps
+- Reuse of the construction logic is needed (Director)
 
-### Q2: Lombok の @Builder のような自動生成は推奨ですか？
+### Q2: Is auto-generation like Lombok's @Builder recommended?
 
-はい。ボイラープレートコードの削減は生産性に直結します。
+Yes. Reducing boilerplate code directly improves productivity.
 
-| 言語/ツール | 自動生成方法 |
+| Language/Tool | Auto-generation Method |
 |------------|-------------|
 | Java | Lombok @Builder |
 | Kotlin | data class + copy |
-| TypeScript | クラス + ジェネリクスで半自動 |
+| TypeScript | Semi-automatic with classes + generics |
 | Python | dataclasses + Pydantic |
 | Rust | derive_builder crate |
 
-### Q3: Builder と Named Arguments（キーワード引数）の違いは？
+### Q3: What is the difference between Builder and Named Arguments (keyword arguments)?
 
-Python や Kotlin のキーワード引数は Builder の多くのメリットを提供します。しかし、以下の場合は Builder が優位です:
+Keyword arguments in Python and Kotlin provide many of the same benefits as a Builder. However, a Builder has advantages in the following cases:
 
-| 観点 | キーワード引数 | Builder |
+| Aspect | Keyword Arguments | Builder |
 |------|:---:|:---:|
-| 段階的構築 | No | Yes |
-| バリデーション集約 | No | Yes (build()内) |
-| 構築ロジックの再利用 | No | Yes (Director) |
-| 不変性の保証 | 言語依存 | 明示的に制御可能 |
-| コード量 | 少ない | 多い |
+| Incremental construction | No | Yes |
+| Centralized validation | No | Yes (inside build()) |
+| Reuse of construction logic | No | Yes (Director) |
+| Immutability guarantee | Language-dependent | Explicitly controllable |
+| Amount of code | Small | Large |
 
-### Q4: Director は必要ですか？
+### Q4: Is a Director necessary?
 
-多くの実務では Director なしの Fluent Builder で十分です。Director が有効なのは:
+In most real-world situations, a Fluent Builder without a Director is sufficient. A Director is effective when:
 
-1. 同じ構築パターンが複数箇所で使われる場合
-2. 構築手順自体がドメイン知識を表現している場合
-3. テストで定型的なオブジェクトを繰り返し構築する場合
+1. The same construction pattern is used in multiple places
+2. The construction procedure itself expresses domain knowledge
+3. Repeatedly constructing standardized objects in tests
 
-### Q5: Builder と Prototype パターンはどう使い分けますか？
+### Q5: How do you choose between Builder and the Prototype pattern?
 
 ```
-Builder: ゼロからオブジェクトを構築する
-  → 構築パラメータが多い場合に有効
+Builder: construct an object from scratch
+  → Effective when there are many construction parameters
 
-Prototype: 既存オブジェクトをコピーして一部を変更する
-  → ベースとなるオブジェクトが存在する場合に有効
+Prototype: copy an existing object and change some parts
+  → Effective when a base object already exists
 
-Kotlin の copy() は両方を組み合わせている:
+Kotlin's copy() combines both:
   val base = Config(host = "localhost", port = 8080, ...)
   val prod = base.copy(host = "api.example.com", port = 443)
 ```
@@ -1686,50 +1689,50 @@ Kotlin の copy() は両方を組み合わせている:
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not just through theory, but by actually writing code and confirming its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics to jump into advanced topics. It is recommended to thoroughly understand the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## 10. まとめ
+## 10. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| 目的 | 複雑なオブジェクトを段階的に構築 |
-| 本質的な問題 | Telescoping Constructor の解決と不変オブジェクトの安全な構築 |
-| Fluent API | メソッドチェーンで可読性向上。最も一般的な実装 |
-| Step Builder | 型安全に必須フィールドを保証。コンパイル時に検証 |
-| Director | 構築手順を再利用可能にカプセル化 |
-| 判断基準 | 引数 4+ またはオプション 2+ で検討 |
-| 言語別推奨 | Java: Effective Java スタイル / Go: Functional Options / Kotlin: data class |
-| 最大の注意点 | Builder にビジネスロジックを入れない。build() の呼び忘れに注意 |
+| Purpose | Incrementally construct complex objects |
+| Core problem | Solving the Telescoping Constructor problem and safely constructing immutable objects |
+| Fluent API | Improves readability with method chaining. The most common implementation. |
+| Step Builder | Guarantees required fields in a type-safe way. Verified at compile time. |
+| Director | Encapsulates construction procedures for reuse |
+| Decision criteria | Consider when there are 4+ arguments or 2+ optional arguments |
+| Language-specific recommendations | Java: Effective Java style / Go: Functional Options / Kotlin: data class |
+| Most important caution | Do not put business logic in the Builder. Watch out for forgetting to call build(). |
 
 ---
 
-## 次に読むべきガイド
+## Next Guides to Read
 
-- [Prototype パターン](./03-prototype.md) -- クローンによる生成。Builder が「ゼロから構築」、Prototype が「既存からコピー」
-- [Factory パターン](./01-factory.md) -- Factory が Builder を返すパターン
-- [Decorator パターン](../01-structural/01-decorator.md) -- 動的な機能追加。Builder の構築結果を装飾
-- [関数設計](../../../clean-code-principles/docs/01-practices/01-functions.md) -- 引数設計のベストプラクティス
-- [不変性](../../../clean-code-principles/docs/03-practices-advanced/00-immutability.md) -- イミュータブルデータ構造の設計
+- [Prototype Pattern](./03-prototype.md) -- Creation via cloning. Builder "constructs from scratch", Prototype "copies from an existing object"
+- [Factory Pattern](./01-factory.md) -- The pattern where a Factory returns a Builder
+- [Decorator Pattern](../01-structural/01-decorator.md) -- Dynamic feature addition. Decorating the result built by a Builder
+- [Function Design](../../../clean-code-principles/docs/01-practices/01-functions.md) -- Best practices for parameter design
+- [Immutability](../../../clean-code-principles/docs/03-practices-advanced/00-immutability.md) -- Design of immutable data structures
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Builder パターンの原典
+1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- The original source on the Builder pattern
 2. Bloch, J. (2018). *Effective Java* (3rd ed.). Addison-Wesley. Item 2: Consider a builder when faced with many constructor parameters.
 3. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media.
 4. Refactoring.Guru -- Builder. https://refactoring.guru/design-patterns/builder
 5. Dave Cheney (2014). Functional options for friendly APIs. https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
-6. Martin, R.C. (2008). *Clean Code*. Prentice Hall. Chapter 3: Functions -- 引数の数を最小化する
+6. Martin, R.C. (2008). *Clean Code*. Prentice Hall. Chapter 3: Functions -- Minimize the number of arguments

--- a/03-software-design/design-patterns-guide/docs/00-creational/03-prototype.md
+++ b/03-software-design/design-patterns-guide/docs/00-creational/03-prototype.md
@@ -1,84 +1,84 @@
-# Prototype パターン
+# Prototype Pattern
 
-> 既存のオブジェクトを **クローン** して新しいオブジェクトを生成し、コンストラクタの再実行コストを回避する生成パターン。
+> A creational pattern that generates new objects by **cloning** existing ones, avoiding the cost of re-executing constructors.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| オブジェクト指向プログラミング | 基礎 | OOP基礎 |
-| インタフェースと抽象クラス | 基礎 | インタフェース設計 |
-| 参照型とプリミティブ型の違い | 理解 | 各言語リファレンス |
-| Generics（ジェネリクス） | 基礎 | TypeScript Generics |
-| メモリモデル（スタック・ヒープ） | 理解 | CS基礎 |
+| Object-Oriented Programming | Basic | OOP Basics |
+| Interfaces and Abstract Classes | Basic | Interface Design |
+| Reference Types vs Primitive Types | Understanding | Language Reference |
+| Generics | Basic | TypeScript Generics |
+| Memory Model (Stack & Heap) | Understanding | CS Basics |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. Prototype パターンの**目的**と、なぜコンストラクタではなくクローンで生成するのか
-2. **浅いコピー（Shallow Copy）** と **深いコピー（Deep Copy）** の違い・使い分け・実装上の罠
-3. 各言語でのクローン実装方法（TypeScript / Python / Java / Go / Kotlin）
-4. **Prototype Registry** パターンによるプロトタイプのカタログ管理
-5. クローンに伴うリスク・アンチパターンと適切な利用場面の判断基準
-
----
-
-## なぜ Prototype パターンが必要なのか（WHY）
-
-### 問題: コンストラクタ再実行のコストと制約
-
-オブジェクトの生成には、コンストラクタの実行が伴います。以下のようなケースでは、コンストラクタ経由の生成がボトルネックや設計上の制約になります。
-
-```
-[問題1: 生成コストが高い]
-  DB接続、外部API呼び出し、大量データの読み込みなどを
-  コンストラクタで行うオブジェクトを複数作る場合
-  → 毎回同じ初期化を繰り返すのは無駄
-
-[問題2: 実行時に型が決まる]
-  どのクラスのインスタンスを生成すべきか、
-  コンパイル時ではなく実行時に決まる場合
-  → new ConcreteClass() とハードコードできない
-
-[問題3: 複雑な初期状態の再現]
-  多数のプロパティを持つオブジェクトの「ある状態」を
-  別のオブジェクトにも再現したい場合
-  → コンストラクタ引数を全部渡すのは煩雑で脆い
-
-[問題4: フレームワーク/ライブラリの制約]
-  外部ライブラリが提供するオブジェクトの内部構造は
-  非公開だが、そのコピーが必要な場合
-  → private フィールドにはアクセスできない
-```
-
-### 解決: クローンによる生成
-
-Prototype パターンは「**既存の完成したオブジェクトをコピーして新しいオブジェクトを作る**」というアプローチです。
-
-```
-従来のアプローチ:
-  設計図（クラス） → new → オブジェクト → 初期化 → 設定 → 完成
-
-Prototype アプローチ:
-  完成済みオブジェクト → clone() → 独立した新オブジェクト
-                                     ↓
-                                   即座に使用可能
-```
-
-このパターンにより:
-- 初期化コストを**1回だけ**に限定できる
-- 実行時にオブジェクトの型を知らなくてもコピーできる
-- 複雑な状態を正確に再現できる
-- private フィールドも含めてコピーできる（同クラス内の clone() メソッドからアクセス可能）
+1. The **purpose** of the Prototype pattern and why objects are created by cloning rather than through constructors
+2. The difference between **Shallow Copy** and **Deep Copy** — when to use each and common implementation pitfalls
+3. Clone implementation in various languages (TypeScript / Python / Java / Go / Kotlin)
+4. Managing prototypes as a catalog using the **Prototype Registry** pattern
+5. Risks and anti-patterns associated with cloning, and criteria for deciding when to use this pattern
 
 ---
 
-## 1. Prototype の構造
+## Why the Prototype Pattern Is Needed (WHY)
 
-### クラス図
+### Problem: The Cost and Constraints of Re-running Constructors
+
+Creating an object involves executing its constructor. In the following scenarios, constructor-based creation becomes a bottleneck or a design constraint.
+
+```
+[Problem 1: High creation cost]
+  When creating multiple objects whose constructors perform
+  DB connections, external API calls, or bulk data loading
+  → Repeating the same initialization every time is wasteful
+
+[Problem 2: Type determined at runtime]
+  When the class of the instance to be created is determined
+  at runtime rather than at compile time
+  → Cannot hardcode new ConcreteClass()
+
+[Problem 3: Reproducing complex initial state]
+  When you want to replicate a "certain state" of an object
+  with many properties into another object
+  → Passing all constructor arguments is cumbersome and fragile
+
+[Problem 4: Framework/library constraints]
+  When the internal structure of an object provided by
+  an external library is private, but you need a copy of it
+  → Cannot access private fields
+```
+
+### Solution: Creation by Cloning
+
+The Prototype pattern takes the approach of "**creating a new object by copying an already-completed existing object**."
+
+```
+Traditional approach:
+  Blueprint (class) → new → object → initialize → configure → complete
+
+Prototype approach:
+  Completed object → clone() → independent new object
+                                  ↓
+                               Ready to use immediately
+```
+
+With this pattern:
+- Initialization cost can be limited to **just once**
+- Objects can be copied without knowing their type at runtime
+- Complex state can be reproduced accurately
+- Private fields can also be copied (accessible from the clone() method within the same class)
+
+---
+
+## 1. Structure of Prototype
+
+### Class Diagram
 
 ```
 +-------------------+
@@ -90,18 +90,18 @@ Prototype アプローチ:
         △
         |
 +-------------------+       clone()       +-------------------+
-| ConcretePrototype |───────────────────>>| コピーされた       |
-+-------------------+                     | オブジェクト       |
+| ConcretePrototype |───────────────────>>| Copied            |
++-------------------+                     | Object            |
 | - field1: T       |                     +-------------------+
 | - field2: U       |                     | - field1: T (copy)|
 | - nested: V       |                     | - field2: U (copy)|
 | + clone(): Self   |                     | - nested: V (???) |
 +-------------------+                     +-------------------+
                                               ↑
-                                     Shallow? Deep? が設計判断
+                                     Shallow? Deep? is the design decision
 ```
 
-### Prototype Registry 構造
+### Prototype Registry Structure
 
 ```
 +-------------------+          +-------------------+
@@ -121,7 +121,7 @@ Prototype アプローチ:
                    +----------+   +----------+   +----------+
 ```
 
-### シーケンス図
+### Sequence Diagram
 
 ```
 Client          Registry         Prototype(original)    Clone
@@ -131,39 +131,39 @@ Client          Registry         Prototype(original)    Clone
   |                |                    |--new(copy)------>|
   |                |                    |    (Deep Copy)   |
   |                |<---clone instance--|                  |
-  |<--返却---------|                    |                  |
+  |<--returned-----|                    |                  |
   |                                                       |
   |--modify()------------------------------------------------>|
   |                                     |                  |
-  |             (original は影響を受けない)                  |
+  |             (original is not affected)                  |
 ```
 
 ---
 
-## 2. 浅いコピー vs 深いコピー
+## 2. Shallow Copy vs Deep Copy
 
-### 概念図
+### Conceptual Diagram
 
 ```
-=== Shallow Copy（浅いコピー）===
+=== Shallow Copy ===
 
 ┌──────────────┐    clone    ┌──────────────┐
 │   Original   │ ──────────> │    Clone     │
-│ name: "A"    │             │ name: "A"    │  ← プリミティブはコピー
-│ age: 25      │             │ age: 25      │  ← プリミティブはコピー
+│ name: "A"    │             │ name: "A"    │  ← primitives are copied
+│ age: 25      │             │ age: 25      │  ← primitives are copied
 │ tags: ───────┼──┐          │ tags: ───────┼──┐
 │ addr: ───────┼──┼──┐       │ addr: ───────┼──┼──┐
 └──────────────┘  │  │       └──────────────┘  │  │
                   v  │                         v  │
-            ┌────────┐│                  同じ参照！ │
+            ┌────────┐│                  Same reference! │
             │["a","b"]│                            │
             └────────┘                             │
                   ┌────────────┐                   │
-                  │{city:"NYC"}│ <── 同じオブジェクト！
+                  │{city:"NYC"}│ <── Same object!
                   └────────────┘
 
 
-=== Deep Copy（深いコピー）===
+=== Deep Copy ===
 
 ┌──────────────┐    clone    ┌──────────────┐
 │   Original   │ ──────────> │    Clone     │
@@ -174,53 +174,53 @@ Client          Registry         Prototype(original)    Clone
 └──────────────┘  │  │       └──────────────┘  │  │
                   v  │                         v  │
             ┌────────┐│               ┌────────┐  │
-            │["a","b"]│               │["a","b"]│  │ ← 別の配列
+            │["a","b"]│               │["a","b"]│  │ ← separate array
             └────────┘                └────────┘  │
                   ┌────────────┐  ┌────────────┐  │
-                  │{city:"NYC"}│  │{city:"NYC"}│<─┘ ← 別のオブジェクト
+                  │{city:"NYC"}│  │{city:"NYC"}│<─┘ ← separate object
                   └────────────┘  └────────────┘
 ```
 
-### いつどちらを使うか
+### When to Use Which
 
 ```
-オブジェクトをコピーしたい
+Want to copy an object
         |
-  全フィールドがプリミティブ or イミュータブル？
+  Are all fields primitives or immutable?
   |                                            |
   Yes                                          No
   |                                            |
   v                                            v
-Shallow Copy で十分                      参照型フィールドあり
-（String, number, boolean,               |
- readonly, frozen）                  コピー後に変更する？
+Shallow Copy is sufficient             Has reference-type fields
+(String, number, boolean,               |
+ readonly, frozen)                  Will you modify after copying?
                                     |                    |
-                                    Yes                  No（読み取り専用）
+                                    Yes                  No (read-only)
                                     |                    |
                                     v                    v
-                                Deep Copy が必須      Shallow Copy + 注意
+                                Deep Copy required    Shallow Copy + caution
                                     |
                             +-------+--------+
                             |                |
-                      structuredClone    手動再帰コピー
-                      JSON.parse/stringify (循環参照、
-                      copy.deepcopy      特殊型対応)
+                      structuredClone    manual recursive copy
+                      JSON.parse/stringify (for circular refs,
+                      copy.deepcopy      special type handling)
 ```
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: TypeScript — 基本的な Prototype インタフェース
+### Code Example 1: TypeScript — Basic Prototype Interface
 
 ```typescript
-// Cloneable インタフェース
-// 自身と同じ型のオブジェクトを返す clone() メソッドを定義
+// Cloneable interface
+// Defines a clone() method that returns an object of the same type
 interface Cloneable<T> {
   clone(): T;
 }
 
-// Shape 基底クラス
+// Shape base class
 class Shape implements Cloneable<Shape> {
   constructor(
     public x: number,
@@ -229,7 +229,7 @@ class Shape implements Cloneable<Shape> {
   ) {}
 
   clone(): Shape {
-    // プリミティブのみなので Shallow Copy で十分
+    // Only primitives, so Shallow Copy is sufficient
     return new Shape(this.x, this.y, this.color);
   }
 
@@ -238,7 +238,7 @@ class Shape implements Cloneable<Shape> {
   }
 }
 
-// Circle: Shape を拡張
+// Circle: extends Shape
 class Circle extends Shape {
   constructor(
     x: number,
@@ -249,7 +249,7 @@ class Circle extends Shape {
     super(x, y, color);
   }
 
-  // 戻り値型を Circle に特化（共変戻り値型）
+  // Return type specialized to Circle (covariant return type)
   clone(): Circle {
     return new Circle(this.x, this.y, this.color, this.radius);
   }
@@ -259,7 +259,7 @@ class Circle extends Shape {
   }
 }
 
-// Rectangle: Shape を拡張
+// Rectangle: extends Shape
 class Rectangle extends Shape {
   constructor(
     x: number,
@@ -276,26 +276,26 @@ class Rectangle extends Shape {
   }
 }
 
-// 使用例
+// Usage example
 const original = new Circle(10, 20, "red", 50);
 const copy = original.clone();
 copy.color = "blue";
 copy.x = 100;
 
-console.log(original.toString()); // Circle(10, 20, red, r=50)  — 独立
-console.log(copy.toString());     // Circle(100, 20, blue, r=50) — 独立
-console.log(original !== copy);   // true — 別インスタンス
-console.log(copy instanceof Circle); // true — 型も保持
+console.log(original.toString()); // Circle(10, 20, red, r=50)  — independent
+console.log(copy.toString());     // Circle(100, 20, blue, r=50) — independent
+console.log(original !== copy);   // true — separate instances
+console.log(copy instanceof Circle); // true — type is preserved
 ```
 
-**ポイント**: clone() メソッド内でコンストラクタを呼ぶことで、型情報とフィールド値の両方を正確にコピーしています。サブクラスごとに clone() をオーバーライドすることで、共変戻り値型（covariant return type）を実現しています。
+**Key Points**: By calling the constructor inside the clone() method, both the type information and field values are accurately copied. Overriding clone() in each subclass achieves covariant return types.
 
 ---
 
-### コード例 2: Deep Copy（structuredClone と手動実装の比較）
+### Code Example 2: Deep Copy (Comparing structuredClone vs Manual Implementation)
 
 ```typescript
-// === Deep Copy が必要なケース: ネストされたオブジェクト ===
+// === Case where Deep Copy is needed: nested objects ===
 
 class Section {
   constructor(
@@ -308,7 +308,7 @@ class Section {
     return new Section(
       this.heading,
       this.content,
-      this.subsections.map(s => s.clone()) // 再帰的に Deep Copy
+      this.subsections.map(s => s.clone()) // recursively Deep Copy
     );
   }
 }
@@ -320,17 +320,17 @@ class Document implements Cloneable<Document> {
     public metadata: Map<string, string> = new Map()
   ) {}
 
-  // 方法1: 手動 Deep Copy（推奨: メソッド・型情報を完全に保持）
+  // Method 1: Manual Deep Copy (recommended: fully preserves methods and type info)
   clone(): Document {
     const clonedSections = this.sections.map(s => s.clone());
     const clonedMetadata = new Map(this.metadata);
     return new Document(this.title, clonedSections, clonedMetadata);
   }
 
-  // 方法2: structuredClone（メソッドが失われる点に注意）
+  // Method 2: structuredClone (note: methods are lost)
   cloneWithStructuredClone(): Document {
-    // 注意: structuredClone はプレーンデータのみコピー
-    // クラスメソッド、Map、Set のカスタム処理が失われる場合がある
+    // Note: structuredClone only copies plain data
+    // Class methods, Map, Set custom behavior may be lost
     const data = structuredClone({
       title: this.title,
       sections: this.sections.map(s => ({
@@ -349,9 +349,9 @@ class Document implements Cloneable<Document> {
     );
   }
 
-  // 方法3: JSON.parse/stringify（最もシンプルだが制約あり）
+  // Method 3: JSON.parse/stringify (simplest but has limitations)
   cloneWithJson(): Document {
-    // 制約: Date, Map, Set, undefined, 関数, 循環参照に非対応
+    // Limitations: does not support Date, Map, Set, undefined, functions, circular refs
     const plain = JSON.parse(JSON.stringify({
       title: this.title,
       sections: this.sections
@@ -365,7 +365,7 @@ class Document implements Cloneable<Document> {
   }
 }
 
-// 動作確認
+// Verification
 const doc = new Document("Report", [
   new Section("Intro", "Introduction text", [
     new Section("Background", "Background detail")
@@ -380,40 +380,40 @@ copy.sections[0].heading = "Changed Intro";
 copy.sections[0].subsections[0].content = "Modified";
 copy.metadata.set("version", "2.0");
 
-console.log(doc.sections[0].heading);                  // "Intro" — 独立
-console.log(doc.sections[0].subsections[0].content);   // "Background detail" — 独立
-console.log(doc.metadata.get("version"));              // "1.0" — 独立
+console.log(doc.sections[0].heading);                  // "Intro" — independent
+console.log(doc.sections[0].subsections[0].content);   // "Background detail" — independent
+console.log(doc.metadata.get("version"));              // "1.0" — independent
 ```
 
-**Deep Copy 手法の比較**:
+**Comparison of Deep Copy methods**:
 
-| 手法 | メソッド保持 | 循環参照 | Map/Set | Date | パフォーマンス |
+| Method | Preserves Methods | Circular Refs | Map/Set | Date | Performance |
 |------|:---:|:---:|:---:|:---:|:---:|
-| 手動 clone() | Yes | 対応可能 | Yes | Yes | 最速 |
-| structuredClone | No | Yes | Yes | Yes | 中速 |
-| JSON.parse/stringify | No | No | No | No | 遅い |
-| lodash.cloneDeep | No | Yes | Yes | Yes | 中速 |
+| Manual clone() | Yes | Supported | Yes | Yes | Fastest |
+| structuredClone | No | Yes | Yes | Yes | Medium |
+| JSON.parse/stringify | No | No | No | No | Slow |
+| lodash.cloneDeep | No | Yes | Yes | Yes | Medium |
 
 ---
 
-### コード例 3: Prototype Registry パターン
+### Code Example 3: Prototype Registry Pattern
 
 ```typescript
-// プロトタイプをキーで管理し、必要に応じてクローンを提供するレジストリ
+// Registry that manages prototypes by key and provides clones on demand
 class PrototypeRegistry<T extends Cloneable<T>> {
   private prototypes = new Map<string, T>();
 
-  // プロトタイプの登録
+  // Register a prototype
   register(key: string, prototype: T): void {
     this.prototypes.set(key, prototype);
   }
 
-  // 登録解除
+  // Unregister a prototype
   unregister(key: string): boolean {
     return this.prototypes.delete(key);
   }
 
-  // クローンの取得
+  // Get a clone
   create(key: string): T {
     const proto = this.prototypes.get(key);
     if (!proto) {
@@ -424,96 +424,96 @@ class PrototypeRegistry<T extends Cloneable<T>> {
     return proto.clone();
   }
 
-  // 登録済みキー一覧
+  // List registered keys
   keys(): string[] {
     return [...this.prototypes.keys()];
   }
 
-  // 登録済みかチェック
+  // Check if a key is registered
   has(key: string): boolean {
     return this.prototypes.has(key);
   }
 }
 
-// 使用例: 図形のプロトタイプレジストリ
+// Usage example: shape prototype registry
 const shapeRegistry = new PrototypeRegistry<Shape>();
 
-// デフォルトプロトタイプを登録
+// Register default prototypes
 shapeRegistry.register("small-red-circle", new Circle(0, 0, "red", 10));
 shapeRegistry.register("large-blue-circle", new Circle(0, 0, "blue", 100));
 shapeRegistry.register("standard-rect", new Rectangle(0, 0, "gray", 200, 100));
 
-// 使用: プロトタイプからクローン生成
+// Usage: generate clones from prototypes
 const c1 = shapeRegistry.create("small-red-circle");
 const c2 = shapeRegistry.create("small-red-circle");
 
-console.log(c1 !== c2);          // true — 別インスタンス
+console.log(c1 !== c2);          // true — separate instances
 console.log(c1.toString());      // Circle(0, 0, red, r=10)
 
-// カスタマイズ
+// Customization
 c1.x = 50;
 c1.y = 100;
 console.log(c1.toString());      // Circle(50, 100, red, r=10)
 ```
 
-**Registry パターンの利点**:
-- プロトタイプの**中央管理**: 全てのテンプレートが1箇所に集約
-- **実行時の動的登録**: 設定ファイルやAPIレスポンスからプロトタイプを登録可能
-- **クラス名の隠蔽**: クライアントは具象クラスを知る必要がない
-- **Factory との組み合わせ**: Factory パターンの内部実装として Prototype を使える
+**Benefits of the Registry pattern**:
+- **Centralized management** of prototypes: all templates in one place
+- **Dynamic registration at runtime**: prototypes can be registered from config files or API responses
+- **Hiding class names**: clients do not need to know concrete classes
+- **Combination with Factory**: Prototype can be used as the internal implementation of a Factory pattern
 
 ---
 
-### コード例 4: Python — copy モジュールと __copy__ / __deepcopy__
+### Code Example 4: Python — copy Module and __copy__ / __deepcopy__
 
 ```python
 import copy
 from dataclasses import dataclass, field
 from typing import Self
 
-# === 方法1: copy モジュールのデフォルト動作 ===
+# === Method 1: Default behavior of the copy module ===
 
 class GameState:
-    """ゲームの状態を管理するクラス"""
+    """Class that manages game state"""
     def __init__(self, level: int, inventory: list[str], stats: dict[str, int]):
         self.level = level
         self.inventory = inventory
         self.stats = stats
 
     def shallow_clone(self) -> "GameState":
-        """浅いコピー: inventory と stats は同じオブジェクトを参照"""
+        """Shallow copy: inventory and stats reference the same objects"""
         return copy.copy(self)
 
     def deep_clone(self) -> "GameState":
-        """深いコピー: 全てのネストされたオブジェクトも再帰的にコピー"""
+        """Deep copy: all nested objects are recursively copied"""
         return copy.deepcopy(self)
 
     def __repr__(self) -> str:
         return f"GameState(lv={self.level}, inv={self.inventory}, stats={self.stats})"
 
 
-# 動作確認
+# Verification
 state = GameState(5, ["sword", "shield"], {"hp": 100, "mp": 50})
 
-# 浅いコピーの罠
+# The pitfall of shallow copy
 shallow = state.shallow_clone()
 shallow.inventory.append("potion")
-print(state.inventory)    # ["sword", "shield", "potion"] ← 元も変わる！
+print(state.inventory)    # ["sword", "shield", "potion"] ← original changes too!
 print(shallow.inventory)  # ["sword", "shield", "potion"]
 
-# 深いコピーの安全性
+# Safety of deep copy
 state2 = GameState(5, ["sword", "shield"], {"hp": 100, "mp": 50})
 deep = state2.deep_clone()
 deep.inventory.append("potion")
 deep.stats["hp"] = 80
-print(state2.inventory)   # ["sword", "shield"] ← 独立
-print(state2.stats)       # {"hp": 100, "mp": 50} ← 独立
+print(state2.inventory)   # ["sword", "shield"] ← independent
+print(state2.stats)       # {"hp": 100, "mp": 50} ← independent
 
 
-# === 方法2: __copy__ / __deepcopy__ のカスタマイズ ===
+# === Method 2: Customizing __copy__ / __deepcopy__ ===
 
 class CachedResource:
-    """キャッシュ付きリソース: clone 時にキャッシュはリセットしたい"""
+    """Resource with cache: want to reset cache on clone"""
     def __init__(self, url: str, data: dict, cache: dict | None = None):
         self.url = url
         self.data = data
@@ -521,14 +521,14 @@ class CachedResource:
         self._fetch_count = 0
 
     def __copy__(self) -> "CachedResource":
-        """浅いコピーをカスタマイズ: キャッシュとカウンタをリセット"""
+        """Customize shallow copy: reset cache and counter"""
         new = CachedResource(self.url, self.data)
-        new._cache = {}  # キャッシュはリセット
+        new._cache = {}  # reset cache
         new._fetch_count = 0
         return new
 
     def __deepcopy__(self, memo: dict) -> "CachedResource":
-        """深いコピーをカスタマイズ: data は Deep Copy、キャッシュはリセット"""
+        """Customize deep copy: deep copy data, reset cache"""
         new = CachedResource(
             copy.deepcopy(self.url, memo),
             copy.deepcopy(self.data, memo)
@@ -540,36 +540,36 @@ class CachedResource:
 
 resource = CachedResource("https://api.example.com", {"key": "value"}, {"cached": True})
 cloned = copy.deepcopy(resource)
-print(cloned._cache)        # {} ← キャッシュがリセットされている
-print(cloned.data)           # {"key": "value"} ← データはコピーされている
-print(resource.data is cloned.data)  # False ← 独立したオブジェクト
+print(cloned._cache)        # {} ← cache has been reset
+print(cloned.data)           # {"key": "value"} ← data is copied
+print(resource.data is cloned.data)  # False ← independent objects
 
 
-# === 方法3: dataclass + カスタム clone ===
+# === Method 3: dataclass + custom clone ===
 
 @dataclass
 class Config:
-    """設定クラス（dataclass版）"""
+    """Configuration class (dataclass version)"""
     host: str
     port: int
     options: dict[str, str] = field(default_factory=dict)
 
     def clone(self) -> "Config":
-        """Deep Copy で独立したコピーを生成"""
+        """Generate an independent copy using Deep Copy"""
         return Config(
             host=self.host,
             port=self.port,
-            options=dict(self.options)  # dict の浅いコピー（値が str なので十分）
+            options=dict(self.options)  # shallow copy of dict (sufficient since values are str)
         )
 ```
 
 ---
 
-### コード例 5: Java — Cloneable と Copy Constructor
+### Code Example 5: Java — Cloneable and Copy Constructor
 
 ```java
-// === 方法1: Cloneable インタフェース ===
-// 注意: Java の Cloneable は設計上の問題が多く、現在は非推奨の傾向
+// === Method 1: Cloneable interface ===
+// Note: Java's Cloneable has many design issues and is now considered deprecated
 
 public class Spreadsheet implements Cloneable {
     private String name;
@@ -586,7 +586,7 @@ public class Spreadsheet implements Cloneable {
     public Spreadsheet clone() {
         try {
             Spreadsheet copy = (Spreadsheet) super.clone();
-            // Deep copy of cells（2次元リスト）
+            // Deep copy of cells (2D list)
             copy.cells = new ArrayList<>();
             for (List<String> row : this.cells) {
                 copy.cells.add(new ArrayList<>(row));
@@ -595,21 +595,21 @@ public class Spreadsheet implements Cloneable {
             copy.metadata = new HashMap<>(this.metadata);
             return copy;
         } catch (CloneNotSupportedException e) {
-            throw new AssertionError("Cloneable を実装しているので到達しない");
+            throw new AssertionError("Unreachable since Cloneable is implemented");
         }
     }
 }
 
 
-// === 方法2: Copy Constructor（推奨） ===
-// Effective Java で推奨されている方法
+// === Method 2: Copy Constructor (recommended) ===
+// Recommended approach from Effective Java
 
 public class SpreadsheetV2 {
     private final String name;
     private final List<List<String>> cells;
     private final Map<String, String> metadata;
 
-    // 通常のコンストラクタ
+    // Regular constructor
     public SpreadsheetV2(String name, List<List<String>> cells) {
         this.name = name;
         this.cells = cells;
@@ -626,14 +626,14 @@ public class SpreadsheetV2 {
         this.metadata = new HashMap<>(other.metadata);
     }
 
-    // Static Factory Method 形式
+    // Static Factory Method form
     public static SpreadsheetV2 copyOf(SpreadsheetV2 other) {
         return new SpreadsheetV2(other);
     }
 }
 
 
-// === 方法3: Serialization による Deep Copy ===
+// === Method 3: Deep Copy via Serialization ===
 import java.io.*;
 
 public class DeepCopyUtil {
@@ -655,50 +655,50 @@ public class DeepCopyUtil {
 }
 
 
-// 使用例
+// Usage example
 SpreadsheetV2 original = new SpreadsheetV2("Budget", List.of(
     new ArrayList<>(List.of("Item", "Cost")),
     new ArrayList<>(List.of("Server", "500"))
 ));
 
 SpreadsheetV2 copy = new SpreadsheetV2(original); // Copy Constructor
-// または
+// or
 SpreadsheetV2 copy2 = SpreadsheetV2.copyOf(original); // Static Factory
 ```
 
-**Java Cloneable の問題点（Effective Java より）**:
-1. `Cloneable` はメソッドを定義しないマーカーインタフェースだが、`Object.clone()` の動作を変える
-2. `clone()` の戻り値型は `Object`（キャストが必要）
-3. `CloneNotSupportedException` のチェック例外が煩雑
-4. `super.clone()` は Shallow Copy のみ
-5. final フィールドへの代入ができない
+**Issues with Java's Cloneable (from Effective Java)**:
+1. `Cloneable` is a marker interface with no methods, yet it changes the behavior of `Object.clone()`
+2. The return type of `clone()` is `Object` (casting is required)
+3. The checked exception `CloneNotSupportedException` is cumbersome
+4. `super.clone()` only performs a Shallow Copy
+5. Cannot assign to final fields
 
-**推奨**: Copy Constructor または Static Factory Method を使う
+**Recommendation**: Use a Copy Constructor or Static Factory Method
 
 ---
 
-### コード例 6: Go — インタフェースベースの Clone
+### Code Example 6: Go — Interface-Based Clone
 
 ```go
 package main
 
 import "fmt"
 
-// Cloneable インタフェース
+// Cloneable interface
 type Cloneable[T any] interface {
     Clone() T
 }
 
-// Shape 構造体
+// Shape struct
 type Shape struct {
     X, Y  int
     Color string
     Tags  []string
 }
 
-// Clone: Deep Copy を実装
+// Clone: implements Deep Copy
 func (s *Shape) Clone() *Shape {
-    // Tags スライスを新しくコピー
+    // Copy the Tags slice into a new one
     tagsCopy := make([]string, len(s.Tags))
     copy(tagsCopy, s.Tags)
 
@@ -710,13 +710,13 @@ func (s *Shape) Clone() *Shape {
     }
 }
 
-// Circle 構造体
+// Circle struct
 type Circle struct {
-    Shape  // 埋め込み
+    Shape  // embedded
     Radius float64
 }
 
-// Clone: 埋め込み構造体も含めて Deep Copy
+// Clone: Deep Copy including embedded struct
 func (c *Circle) Clone() *Circle {
     shapeCopy := c.Shape.Clone()
     return &Circle{
@@ -725,7 +725,7 @@ func (c *Circle) Clone() *Circle {
     }
 }
 
-// Document 構造体（ネストあり）
+// Document struct (with nesting)
 type Document struct {
     Title    string
     Sections []Section
@@ -738,7 +738,7 @@ type Section struct {
 }
 
 func (d *Document) Clone() *Document {
-    // Sections の Deep Copy
+    // Deep Copy of Sections
     sections := make([]Section, len(d.Sections))
     for i, s := range d.Sections {
         sections[i] = Section{
@@ -747,7 +747,7 @@ func (d *Document) Clone() *Document {
         }
     }
 
-    // Map の Deep Copy
+    // Deep Copy of Map
     meta := make(map[string]string, len(d.Meta))
     for k, v := range d.Meta {
         meta[k] = v
@@ -770,17 +770,17 @@ func main() {
     cloned.Color = "blue"
     cloned.Tags = append(cloned.Tags, "modified")
 
-    fmt.Println(original.Color, original.Tags) // red [important] — 独立
+    fmt.Println(original.Color, original.Tags) // red [important] — independent
     fmt.Println(cloned.Color, cloned.Tags)     // blue [important modified]
 }
 ```
 
 ---
 
-### コード例 7: Kotlin — data class の copy() と手動 Clone
+### Code Example 7: Kotlin — data class copy() and Manual Clone
 
 ```kotlin
-// === 方法1: data class の copy()（Shallow Copy）===
+// === Method 1: data class copy() (Shallow Copy) ===
 
 data class Address(
     val city: String,
@@ -790,8 +790,8 @@ data class Address(
 data class User(
     val name: String,
     val age: Int,
-    val address: Address,    // 参照型
-    val tags: MutableList<String>  // ミュータブルなコレクション
+    val address: Address,    // reference type
+    val tags: MutableList<String>  // mutable collection
 )
 
 fun main() {
@@ -802,37 +802,37 @@ fun main() {
         tags = mutableListOf("admin", "user")
     )
 
-    // data class の copy() は Shallow Copy
+    // data class copy() is a Shallow Copy
     val shallow = original.copy(name = "Jiro")
 
-    // Address は不変（val + data class）なので安全
-    println(original.address === shallow.address) // true（同じ参照だが不変なので問題なし）
+    // Address is immutable (val + data class), so this is safe
+    println(original.address === shallow.address) // true (same reference, but immutable so no problem)
 
-    // MutableList は浅いコピーなので危険！
+    // MutableList is a shallow copy — dangerous!
     shallow.tags.add("editor")
-    println(original.tags) // [admin, user, editor] ← 元も変わる！
+    println(original.tags) // [admin, user, editor] ← original changes too!
 }
 
 
-// === 方法2: Deep Copy を手動実装 ===
+// === Method 2: Manually implement Deep Copy ===
 
 data class UserV2(
     val name: String,
     val age: Int,
     val address: Address,
-    val tags: List<String>  // 不変リストにする（設計で解決）
+    val tags: List<String>  // use immutable list (solved by design)
 ) {
-    // Deep Copy メソッド
+    // Deep Copy method
     fun deepCopy(): UserV2 = UserV2(
         name = this.name,
         age = this.age,
-        address = this.address.copy(), // data class の copy() で OK（全フィールドが val String）
-        tags = this.tags.toList()      // 新しいリストを生成
+        address = this.address.copy(), // data class copy() is fine (all fields are val String)
+        tags = this.tags.toList()      // generate a new list
     )
 }
 
 
-// === 方法3: sealed interface + clone ===
+// === Method 3: sealed interface + clone ===
 
 sealed interface ShapeK {
     fun clone(): ShapeK
@@ -857,7 +857,7 @@ data class RectangleK(
     override fun clone(): RectangleK = this.copy()
 }
 
-// 使用例: 多態的なクローン
+// Usage example: polymorphic cloning
 fun duplicateShapes(shapes: List<ShapeK>): List<ShapeK> {
     return shapes.map { it.clone() }
 }
@@ -865,11 +865,11 @@ fun duplicateShapes(shapes: List<ShapeK>): List<ShapeK> {
 
 ---
 
-### コード例 8: Prototype + Factory パターンの組み合わせ
+### Code Example 8: Combining Prototype + Factory Patterns
 
 ```typescript
-// Prototype を内部的に使う Factory
-// クライアントにはファクトリインタフェースだけを公開
+// Factory that internally uses Prototype
+// Only the factory interface is exposed to the client
 
 interface Notification {
   title: string;
@@ -919,12 +919,12 @@ class SlackNotification implements Notification {
   }
 }
 
-// NotificationFactory: Prototype を内部で管理
+// NotificationFactory: manages Prototypes internally
 class NotificationFactory {
   private prototypes = new Map<string, Notification>();
 
   constructor() {
-    // デフォルトテンプレートを登録
+    // Register default templates
     this.prototypes.set("welcome-email", new EmailNotification(
       "Welcome!",
       "Welcome to our service.",
@@ -941,7 +941,7 @@ class NotificationFactory {
     ));
   }
 
-  // Factory メソッド: Prototype をクローンしてカスタマイズ
+  // Factory method: clone a Prototype and customize
   create(type: string, overrides?: Partial<Notification>): Notification {
     const proto = this.prototypes.get(type);
     if (!proto) throw new Error(`Unknown notification type: ${type}`);
@@ -953,13 +953,13 @@ class NotificationFactory {
     return notification;
   }
 
-  // 新しいテンプレートを動的に登録
+  // Dynamically register a new template
   registerTemplate(name: string, prototype: Notification): void {
     this.prototypes.set(name, prototype);
   }
 }
 
-// 使用例
+// Usage example
 const factory = new NotificationFactory();
 
 const welcome = factory.create("welcome-email", {
@@ -977,10 +977,10 @@ console.log(alert);   // SlackNotification with customized body
 
 ---
 
-### コード例 9: Undo/Redo のための状態クローン（Memento + Prototype）
+### Code Example 9: State Cloning for Undo/Redo (Memento + Prototype)
 
 ```typescript
-// エディタの状態をクローンして Undo/Redo スタックに保存
+// Clone editor state and save it to the Undo/Redo stack
 
 interface EditorState {
   content: string;
@@ -1015,13 +1015,13 @@ class TextEditor {
     this.state = new TextEditorState("", 0, []);
   }
 
-  // 状態変更前にクローンを保存
+  // Save a clone before modifying state
   private saveState(): void {
     this.undoStack.push(this.state.clone());
     if (this.undoStack.length > this.maxHistory) {
-      this.undoStack.shift(); // 古い履歴を削除
+      this.undoStack.shift(); // remove oldest history
     }
-    this.redoStack = []; // Redo スタックをクリア
+    this.redoStack = []; // clear Redo stack
   }
 
   type(text: string): void {
@@ -1053,7 +1053,7 @@ class TextEditor {
   }
 }
 
-// 使用例
+// Usage example
 const editor = new TextEditor();
 editor.type("Hello");
 editor.type(", World!");
@@ -1071,10 +1071,10 @@ console.log(editor.getContent()); // "Hello"
 
 ---
 
-### コード例 10: 循環参照を含むオブジェクトの Deep Copy
+### Code Example 10: Deep Copy of Objects with Circular References
 
 ```typescript
-// 循環参照がある場合の Deep Copy は特別な処理が必要
+// Deep Copy of objects with circular references requires special handling
 
 class TreeNode {
   children: TreeNode[] = [];
@@ -1087,19 +1087,19 @@ class TreeNode {
     this.children.push(child);
   }
 
-  // 循環参照対応の Deep Copy
-  // visited マップで既にクローン済みのノードを追跡
+  // Deep Copy with circular reference support
+  // Track already-cloned nodes with a visited map
   clone(visited = new Map<TreeNode, TreeNode>()): TreeNode {
-    // 既にクローン済みならそれを返す（循環参照の解決）
+    // If already cloned, return it (resolves circular reference)
     if (visited.has(this)) {
       return visited.get(this)!;
     }
 
-    // 新しいノードを作成し、visited に登録
+    // Create a new node and register it in visited
     const cloned = new TreeNode(this.name, this.value);
     visited.set(this, cloned);
 
-    // 子ノードを再帰的にクローン
+    // Recursively clone child nodes
     for (const child of this.children) {
       const clonedChild = child.clone(visited);
       clonedChild.parent = cloned;
@@ -1119,7 +1119,7 @@ class TreeNode {
   }
 }
 
-// 使用例
+// Usage example
 const root = new TreeNode("root", 0);
 const a = new TreeNode("A", 1);
 const b = new TreeNode("B", 2);
@@ -1141,63 +1141,63 @@ console.log(root.toString());
 
 console.log(clonedRoot.toString());
 // root(0)
-//   A-modified(999)  ← 独立
+//   A-modified(999)  ← independent
 //     C(3)
 //   B(2)
 
-// 親子関係の確認
+// Verify parent-child relationships
 console.log(clonedRoot.children[0].parent === clonedRoot); // true
-console.log(clonedRoot.children[0].parent === root);       // false（独立）
+console.log(clonedRoot.children[0].parent === root);       // false (independent)
 ```
 
 ---
 
-## 4. 比較表
+## 4. Comparison Tables
 
-### 比較表 1: Shallow Copy vs Deep Copy
+### Comparison Table 1: Shallow Copy vs Deep Copy
 
-| 観点 | Shallow Copy | Deep Copy |
+| Aspect | Shallow Copy | Deep Copy |
 |------|:---:|:---:|
-| コピー速度 | **高速**（O(n) フィールド数） | **低速**（O(N) 全ノード数） |
-| メモリ使用量 | **少ない**（参照共有） | **多い**（全て複製） |
-| 参照共有 | **する**（副作用リスク） | **しない**（完全独立） |
-| 安全性 | **低い**（変更が波及） | **高い**（完全独立） |
-| 実装難易度 | **低い** | **中〜高**（循環参照対応等） |
-| 不変データでの使用 | **安全**（変更しないため） | **不要**（コピー自体が無駄） |
-| 使用場面 | 不変データ、読み取り専用、パフォーマンス重視 | 可変データ、独立した変更が必要 |
+| Copy speed | **Fast** (O(n) field count) | **Slow** (O(N) total node count) |
+| Memory usage | **Less** (shared references) | **More** (everything duplicated) |
+| Reference sharing | **Yes** (side-effect risk) | **No** (fully independent) |
+| Safety | **Low** (changes propagate) | **High** (fully independent) |
+| Implementation difficulty | **Low** | **Medium to High** (circular ref handling, etc.) |
+| Use with immutable data | **Safe** (no modifications) | **Unnecessary** (copying itself is wasteful) |
+| Use cases | Immutable data, read-only, performance-critical | Mutable data, independent modifications needed |
 
-### 比較表 2: Prototype vs Factory vs Constructor vs Copy Constructor
+### Comparison Table 2: Prototype vs Factory vs Constructor vs Copy Constructor
 
-| 観点 | Prototype(clone) | Factory Method | Constructor | Copy Constructor |
+| Aspect | Prototype(clone) | Factory Method | Constructor | Copy Constructor |
 |------|:---:|:---:|:---:|:---:|
-| 生成コスト | 低い（コピー） | 中 | 高い（初期化） | 低い（コピー） |
-| 事前設定の保持 | **Yes** | 要設定 | No | **Yes** |
-| 動的な型決定 | **Yes** | **Yes** | No | No |
-| 型安全性 | 中 | 高 | 高 | 高 |
-| private フィールド | **アクセス可** | 要 getter | N/A | **アクセス可** |
-| 言語サポート | 全言語 | 全言語 | 全言語 | Java/C++/Kotlin |
-| 推奨度 | 中 | 高 | 基本 | 高（Java） |
+| Creation cost | Low (copy) | Medium | High (initialization) | Low (copy) |
+| Retains pre-configured state | **Yes** | Requires setup | No | **Yes** |
+| Dynamic type determination | **Yes** | **Yes** | No | No |
+| Type safety | Medium | High | High | High |
+| Private field access | **Accessible** | Requires getter | N/A | **Accessible** |
+| Language support | All languages | All languages | All languages | Java/C++/Kotlin |
+| Recommendation | Medium | High | Basic | High (Java) |
 
-### 比較表 3: 言語別クローン実装の比較
+### Comparison Table 3: Clone Implementation Comparison by Language
 
-| 言語 | 標準手法 | Deep Copy サポート | 推奨アプローチ |
+| Language | Standard Approach | Deep Copy Support | Recommended Approach |
 |------|---------|:---:|---------|
-| TypeScript | カスタム clone() | structuredClone | 手動 clone() + structuredClone 併用 |
-| Python | copy.copy/deepcopy | **組み込み** | copy.deepcopy + __deepcopy__ カスタマイズ |
-| Java | Cloneable.clone() | Serialization | **Copy Constructor**（Effective Java推奨） |
-| Go | 手動実装 | なし | 構造体ごとに Clone() メソッド |
-| Kotlin | data class copy() | なし | data class copy() + 不変設計 |
-| C# | ICloneable.Clone() | なし | 手動 Deep Copy + record 型 |
+| TypeScript | Custom clone() | structuredClone | Manual clone() + structuredClone combined |
+| Python | copy.copy/deepcopy | **Built-in** | copy.deepcopy + __deepcopy__ customization |
+| Java | Cloneable.clone() | Serialization | **Copy Constructor** (recommended by Effective Java) |
+| Go | Manual implementation | None | Clone() method per struct |
+| Kotlin | data class copy() | None | data class copy() + immutable design |
+| C# | ICloneable.Clone() | None | Manual Deep Copy + record types |
 | Rust | Clone trait | Clone derive | `#[derive(Clone)]` |
 
 ---
 
-## 5. アンチパターン
+## 5. Anti-Patterns
 
-### アンチパターン 1: Shallow Copy で可変オブジェクトを共有
+### Anti-Pattern 1: Sharing Mutable Objects with Shallow Copy
 
 ```typescript
-// NG: Shallow Copy で配列・オブジェクトを共有してしまう
+// NG: Shallow Copy shares arrays and objects
 class Config {
   constructor(
     public name: string,
@@ -1206,9 +1206,9 @@ class Config {
   ) {}
 
   clone(): Config {
-    // Object.assign は Shallow Copy！
+    // Object.assign is a Shallow Copy!
     return Object.assign(new Config("", [], {}), this);
-    // plugins と settings は同じ参照を共有
+    // plugins and settings share the same reference
   }
 }
 
@@ -1217,12 +1217,12 @@ const b = a.clone();
 b.plugins.push("cache");
 b.settings.debug = true;
 
-console.log(a.plugins);        // ["auth", "logger", "cache"] ← 意図しない変更！
-console.log(a.settings.debug); // true ← 意図しない変更！
+console.log(a.plugins);        // ["auth", "logger", "cache"] ← unintended modification!
+console.log(a.settings.debug); // true ← unintended modification!
 ```
 
 ```typescript
-// OK: 参照型フィールドを明示的に Deep Copy
+// OK: Explicitly Deep Copy reference-type fields
 class Config {
   constructor(
     public name: string,
@@ -1233,8 +1233,8 @@ class Config {
   clone(): Config {
     return new Config(
       this.name,
-      [...this.plugins],                    // 配列のスプレッドコピー
-      structuredClone(this.settings)        // ネストされたオブジェクトの Deep Copy
+      [...this.plugins],                    // spread copy of array
+      structuredClone(this.settings)        // Deep Copy of nested object
     );
   }
 }
@@ -1242,10 +1242,10 @@ class Config {
 
 ---
 
-### アンチパターン 2: clone() でコンストラクタの不変条件（invariant）を迂回
+### Anti-Pattern 2: Bypassing Constructor Invariants with clone()
 
 ```typescript
-// NG: clone() がバリデーションをスキップ
+// NG: clone() skips validation
 class PositiveNumber {
   private value: number;
 
@@ -1257,18 +1257,18 @@ class PositiveNumber {
   getValue(): number { return this.value; }
 
   clone(): PositiveNumber {
-    // Object.create でコンストラクタを迂回
+    // Bypass constructor with Object.create
     const copy = Object.create(PositiveNumber.prototype);
     copy.value = this.value;
     return copy;
-    // 問題: 将来 value を変更する setter が追加された場合、
-    // バリデーションなしでオブジェクトが作成される可能性
+    // Problem: if a setter that modifies value is added in the future,
+    // objects could be created without validation
   }
 }
 ```
 
 ```typescript
-// OK: コンストラクタ経由で不変条件を維持
+// OK: Maintain invariants by going through the constructor
 class PositiveNumber {
   private value: number;
 
@@ -1280,7 +1280,7 @@ class PositiveNumber {
   getValue(): number { return this.value; }
 
   clone(): PositiveNumber {
-    // コンストラクタを通すことでバリデーションが実行される
+    // Validation runs because the constructor is called
     return new PositiveNumber(this.value);
   }
 }
@@ -1288,26 +1288,26 @@ class PositiveNumber {
 
 ---
 
-### アンチパターン 3: clone() で一意識別子もコピーしてしまう
+### Anti-Pattern 3: Copying Unique Identifiers in clone()
 
 ```typescript
-// NG: ID もそのままコピー → 一意性が壊れる
+// NG: ID is also copied → uniqueness is broken
 class Entity {
   constructor(
-    public id: string,     // UUID — 一意であるべき
+    public id: string,     // UUID — should be unique
     public name: string,
     public data: unknown
   ) {}
 
   clone(): Entity {
     return new Entity(this.id, this.name, structuredClone(this.data));
-    // id が同じ → データベースで衝突！
+    // same id → collision in the database!
   }
 }
 ```
 
 ```typescript
-// OK: clone() で新しい ID を生成
+// OK: Generate a new ID in clone()
 import { randomUUID } from "crypto";
 
 class Entity {
@@ -1319,48 +1319,48 @@ class Entity {
 
   clone(): Entity {
     return new Entity(
-      randomUUID(),  // 新しい ID を生成
+      randomUUID(),  // generate a new ID
       this.name,
       structuredClone(this.data)
     );
   }
 
-  // 「どのフィールドをコピーし、どのフィールドを新規生成するか」を
-  // 明示的に設計することが重要
+  // It is important to explicitly design
+  // "which fields to copy, and which fields to regenerate"
 }
 ```
 
 ---
 
-## 6. エッジケースと注意点
+## 6. Edge Cases and Caveats
 
-### エッジケース 1: structuredClone の制約
+### Edge Case 1: Limitations of structuredClone
 
 ```typescript
-// structuredClone がコピーできないもの
+// Things structuredClone cannot copy
 class Example {
-  method(): void {}  // 関数 → コピーされない
+  method(): void {}  // function → not copied
 }
 
 const obj = {
-  fn: () => "hello",           // ❌ 関数
+  fn: () => "hello",           // ❌ function
   symbol: Symbol("id"),        // ❌ Symbol
-  dom: document.createElement("div"), // ❌ DOM ノード
-  error: new Error("test"),    // ✅ コピー可能
-  date: new Date(),            // ✅ コピー可能
-  regex: /test/gi,             // ✅ コピー可能
-  set: new Set([1, 2, 3]),     // ✅ コピー可能
-  arrayBuffer: new ArrayBuffer(8), // ✅ コピー可能
+  dom: document.createElement("div"), // ❌ DOM node
+  error: new Error("test"),    // ✅ can be copied
+  date: new Date(),            // ✅ can be copied
+  regex: /test/gi,             // ✅ can be copied
+  set: new Set([1, 2, 3]),     // ✅ can be copied
+  arrayBuffer: new ArrayBuffer(8), // ✅ can be copied
 };
 
-// クラスインスタンスの場合
+// For class instances
 const instance = new Example();
 const cloned = structuredClone(instance);
-console.log(typeof cloned.method); // "undefined" — メソッドが失われる！
-console.log(cloned instanceof Example); // false — 型情報も失われる！
+console.log(typeof cloned.method); // "undefined" — method is lost!
+console.log(cloned instanceof Example); // false — type info is also lost!
 ```
 
-### エッジケース 2: イベントリスナーやコールバックの扱い
+### Edge Case 2: Handling Event Listeners and Callbacks
 
 ```typescript
 class EventEmitterWidget {
@@ -1373,16 +1373,16 @@ class EventEmitterWidget {
     this.listeners.get(event)!.push(handler);
   }
 
-  // clone() でリスナーはどうするか？
-  // 選択肢1: リスナーもコピー → 同じハンドラが2つのオブジェクトで発火
-  // 選択肢2: リスナーをリセット → クローン後に再登録が必要
-  // 選択肢3: リスナーの浅いコピー → 同じ関数参照を共有（通常はOK）
+  // What to do with listeners in clone()?
+  // Option 1: Copy listeners too → same handler fires on two objects
+  // Option 2: Reset listeners → must re-register after cloning
+  // Option 3: Shallow copy listeners → shared function references (usually OK)
 
   clone(copyListeners = false): EventEmitterWidget {
     const cloned = new EventEmitterWidget();
     if (copyListeners) {
       for (const [event, handlers] of this.listeners) {
-        cloned.listeners.set(event, [...handlers]); // 浅いコピー
+        cloned.listeners.set(event, [...handlers]); // shallow copy
       }
     }
     return cloned;
@@ -1390,32 +1390,32 @@ class EventEmitterWidget {
 }
 ```
 
-### エッジケース 3: 循環参照の検出と処理
+### Edge Case 3: Detecting and Handling Circular References
 
 ```typescript
-// 循環参照があるとスタックオーバーフローを起こす
+// Circular references cause stack overflow
 const a: any = { name: "A" };
 const b: any = { name: "B", ref: a };
-a.ref = b; // 循環参照
+a.ref = b; // circular reference
 
-// NG: 無限再帰
+// NG: infinite recursion
 function naiveDeepCopy(obj: any): any {
   const copy: any = {};
   for (const key of Object.keys(obj)) {
     copy[key] = typeof obj[key] === "object"
-      ? naiveDeepCopy(obj[key]) // ← 無限ループ！
+      ? naiveDeepCopy(obj[key]) // ← infinite loop!
       : obj[key];
   }
   return copy;
 }
 
-// OK: visited マップで循環を検出
+// OK: detect cycles with a visited map
 function safeDeepCopy(obj: any, visited = new WeakMap()): any {
   if (obj === null || typeof obj !== "object") return obj;
-  if (visited.has(obj)) return visited.get(obj); // 既訪問なら返す
+  if (visited.has(obj)) return visited.get(obj); // return if already visited
 
   const copy: any = Array.isArray(obj) ? [] : {};
-  visited.set(obj, copy); // 先に登録（循環参照対策）
+  visited.set(obj, copy); // register early (circular reference guard)
 
   for (const key of Object.keys(obj)) {
     copy[key] = safeDeepCopy(obj[key], visited);
@@ -1423,104 +1423,110 @@ function safeDeepCopy(obj: any, visited = new WeakMap()): any {
   return copy;
 }
 
-// structuredClone は循環参照を自動で処理する
-const cloned = structuredClone(a); // OK！
-console.log(cloned.ref.ref === cloned); // true — 循環参照が正しく再現
+// structuredClone handles circular references automatically
+const cloned = structuredClone(a); // OK!
+console.log(cloned.ref.ref === cloned); // true — circular reference correctly reproduced
 ```
 
-### エッジケース 4: Prototype チェーンとシリアライゼーション
+### Edge Case 4: Prototype Chain and Serialization
 
 ```typescript
-// JSON.stringify/parse で失われるもの一覧
+// A list of things lost with JSON.stringify/parse
 const original = {
-  date: new Date("2024-01-01"),         // → 文字列になる
-  undefined: undefined,                  // → 消える
-  nan: NaN,                              // → null になる
-  infinity: Infinity,                    // → null になる
-  regex: /test/g,                        // → {} になる
-  set: new Set([1, 2]),                  // → {} になる
-  fn: () => "hello",                     // → 消える
-  symbol: Symbol("id"),                  // → 消える
+  date: new Date("2024-01-01"),         // → becomes a string
+  undefined: undefined,                  // → disappears
+  nan: NaN,                              // → becomes null
+  infinity: Infinity,                    // → becomes null
+  regex: /test/g,                        // → becomes {}
+  set: new Set([1, 2]),                  // → becomes {}
+  fn: () => "hello",                     // → disappears
+  symbol: Symbol("id"),                  // → disappears
   bigint: BigInt(42),                    // → TypeError!
 };
 ```
 
 ---
 
-## 7. トレードオフ分析
+## 7. Trade-off Analysis
 
-### Prototype パターンを使うべき場面
+### When to Use the Prototype Pattern
 
 ```
-✅ 使うべき場面:
+✅ When to use:
 ┌─────────────────────────────────────────────────┐
-│ 1. 初期化コストが高いオブジェクトを多数生成する   │
-│    例: DB接続設定、ML モデル設定、ゲームキャラ     │
+│ 1. Creating many objects with high init cost      │
+│    e.g.: DB connection config, ML model config,   │
+│          game characters                          │
 │                                                  │
-│ 2. 実行時に型が決まるオブジェクトのコピーが必要   │
-│    例: プラグインシステム、設定テンプレート       │
+│ 2. Copying objects whose type is determined       │
+│    at runtime                                     │
+│    e.g.: plugin systems, configuration templates │
 │                                                  │
-│ 3. オブジェクトの状態をスナップショットとして保存  │
-│    例: Undo/Redo、バージョン管理、テスト fixture  │
+│ 3. Saving object state as a snapshot             │
+│    e.g.: Undo/Redo, version control, test fixture│
 │                                                  │
-│ 4. プロトタイプレジストリでテンプレート管理       │
-│    例: UIコンポーネント、通知テンプレート         │
+│ 4. Template management via a prototype registry  │
+│    e.g.: UI components, notification templates   │
 │                                                  │
-│ 5. 外部ライブラリのオブジェクトのコピーが必要     │
-│    例: 非公開フィールドを含むオブジェクトの複製   │
+│ 5. Copying objects from external libraries       │
+│    e.g.: duplicating objects with private fields │
 └─────────────────────────────────────────────────┘
 
-❌ 使うべきでない場面:
+❌ When NOT to use:
 ┌─────────────────────────────────────────────────┐
-│ 1. 生成コストが低いオブジェクト                   │
-│    → new で十分。clone() の実装コストが上回る     │
+│ 1. Objects with low creation cost                │
+│    → new is sufficient; cost of implementing     │
+│      clone() outweighs the benefit               │
 │                                                  │
-│ 2. 不変データ構造を使っている場合                 │
-│    → 構造共有（structural sharing）が効率的       │
-│    例: Immutable.js, Immer                       │
+│ 2. When using immutable data structures          │
+│    → structural sharing is more efficient        │
+│    e.g.: Immutable.js, Immer                     │
 │                                                  │
-│ 3. 循環参照が複雑すぎるオブジェクトグラフ         │
-│    → Deep Copy の実装が困難、バグの温床           │
+│ 3. Object graphs with overly complex             │
+│    circular references                           │
+│    → Hard to implement Deep Copy, a source of    │
+│      bugs                                        │
 │                                                  │
-│ 4. クローン後にほとんどのフィールドを変更する     │
-│    → コンストラクタで直接生成した方が明確         │
+│ 4. Most fields are changed after cloning         │
+│    → Creating directly with a constructor is     │
+│      clearer                                     │
 └─────────────────────────────────────────────────┘
 ```
 
-### パフォーマンス特性
+### Performance Characteristics
 
 ```
-生成方式のパフォーマンス比較（概算）:
+Performance comparison of creation methods (approximate):
 
-方式              | 小オブジェクト | 大オブジェクト | ネストあり
-                  | (5 fields)     | (50 fields)    | (3 levels deep)
+Method            | Small object  | Large object  | With nesting
+                  | (5 fields)    | (50 fields)   | (3 levels deep)
 ─────────────────|────────────────|────────────────|────────────────
-new + 初期化      |     基準       |     基準       |     基準
-Shallow Clone     |    0.1x        |    0.1x        |    0.1x
-Deep Clone(手動)  |    0.3x        |    0.5x        |    0.8x
-structuredClone   |    2.0x        |    1.5x        |    1.2x
-JSON parse/strfy  |    5.0x        |    3.0x        |    2.5x
+new + init        |    baseline   |    baseline   |    baseline
+Shallow Clone     |    0.1x       |    0.1x       |    0.1x
+Deep Clone(manual)|    0.3x       |    0.5x       |    0.8x
+structuredClone   |    2.0x       |    1.5x       |    1.2x
+JSON parse/strfy  |    5.0x       |    3.0x       |    2.5x
 
-※ new + 初期化 に DB接続やAPI呼び出しが含まれる場合、
-  clone は圧倒的に高速（100x〜1000x以上の差）
+* When new + init includes DB connections or API calls,
+  clone is overwhelmingly faster (100x to 1000x or more)
 ```
 
 ---
 
-## 8. 演習問題
+## 8. Exercises
 
-### 演習 1（基礎）: Shape の Clone 実装
+### Exercise 1 (Basic): Implement Clone for Shape
 
-以下の要件を満たす Shape クラス階層を実装してください。
+Implement a Shape class hierarchy that meets the following requirements.
 
-**要件**:
-- `Shape` 基底クラスに `clone()` メソッドを定義
-- `Circle`、`Rectangle`、`Triangle` のサブクラスを作成
-- 各クラスの `clone()` が正しく Deep Copy を返すことを確認
-- `describe()` メソッドで図形の情報を文字列で返す
+**Requirements**:
+- Define a `clone()` method on the `Shape` base class
+- Create subclasses: `Circle`, `Rectangle`, `Triangle`
+- Verify that `clone()` in each class correctly returns a Deep Copy
+- Return shape information as a string via a `describe()` method
 
 ```typescript
-// テスト
+// Test
 const circle = new Circle(0, 0, "red", 25);
 const clonedCircle = circle.clone();
 clonedCircle.color = "blue";
@@ -1530,7 +1536,7 @@ console.log(clonedCircle.describe()); // "Circle(x=0, y=0, color=blue, r=25)"
 console.log(circle !== clonedCircle); // true
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 Circle(x=0, y=0, color=red, r=25)
 Circle(x=0, y=0, color=blue, r=25)
@@ -1538,7 +1544,7 @@ true
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample solution</summary>
 
 ```typescript
 interface Cloneable<T> {
@@ -1604,7 +1610,7 @@ class Triangle extends Shape {
   }
 }
 
-// テスト
+// Test
 const circle = new Circle(0, 0, "red", 25);
 const clonedCircle = circle.clone();
 clonedCircle.color = "blue";
@@ -1617,18 +1623,18 @@ console.log(circle !== clonedCircle); // true
 
 ---
 
-### 演習 2（応用）: Prototype Registry + Deep Copy
+### Exercise 2 (Applied): Prototype Registry + Deep Copy
 
-ゲームのキャラクターテンプレートを管理する Prototype Registry を実装してください。
+Implement a Prototype Registry to manage game character templates.
 
-**要件**:
-- `Character` クラス: name, hp, mp, skills(配列), equipment(オブジェクト)
-- `CharacterRegistry`: テンプレートの登録・クローン取得
-- Deep Copy であること（skills と equipment が独立）
-- クローン時に新しい ID を自動付与
+**Requirements**:
+- `Character` class: name, hp, mp, skills (array), equipment (object)
+- `CharacterRegistry`: register templates and retrieve clones
+- Must be a Deep Copy (skills and equipment are independent)
+- Automatically assign a new ID upon cloning
 
 ```typescript
-// テスト
+// Test
 const registry = new CharacterRegistry();
 
 registry.register("warrior", new Character(
@@ -1648,11 +1654,11 @@ console.log(player1.name);            // "Hero Taro"
 console.log(player2.name);            // "Hero Jiro"
 console.log(player1.id !== player2.id); // true
 console.log(player1.skills);          // ["slash", "block", "charge"]
-console.log(player2.skills);          // ["slash", "block"] ← 独立
-console.log(player2.equipment.weapon); // "sword" ← 独立
+console.log(player2.skills);          // ["slash", "block"] ← independent
+console.log(player2.equipment.weapon); // "sword" ← independent
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 Hero Taro
 Hero Jiro
@@ -1663,7 +1669,7 @@ sword
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample solution</summary>
 
 ```typescript
 import { randomUUID } from "crypto";
@@ -1690,10 +1696,10 @@ class Character implements Cloneable<Character> {
       this.name,
       this.hp,
       this.mp,
-      [...this.skills],          // 配列の Deep Copy
-      { ...this.equipment }      // オブジェクトの Shallow Copy（値が string なので十分）
+      [...this.skills],          // Deep Copy of array
+      { ...this.equipment }      // Shallow Copy of object (sufficient since values are strings)
     );
-    // id は new Character() 内で自動生成される
+    // id is automatically generated inside new Character()
     return cloned;
   }
 }
@@ -1722,7 +1728,7 @@ class CharacterRegistry {
   }
 }
 
-// テスト
+// Test
 const registry = new CharacterRegistry();
 
 registry.register("warrior", new Character(
@@ -1754,20 +1760,20 @@ console.log(player2.equipment.weapon);  // "sword"
 
 ---
 
-### 演習 3（上級）: 汎用 Deep Clone ユーティリティ
+### Exercise 3 (Advanced): General-Purpose Deep Clone Utility
 
-以下の全てのデータ型を正しく Deep Clone できる汎用ユーティリティ関数を実装してください。
+Implement a general-purpose utility function that can correctly Deep Clone all of the following data types.
 
-**要件**:
-- プリミティブ型（string, number, boolean, null, undefined）
+**Requirements**:
+- Primitive types (string, number, boolean, null, undefined)
 - Date, RegExp, Map, Set
-- 配列とプレーンオブジェクト
-- 循環参照の検出と正しい処理
-- `clone()` メソッドを持つオブジェクトはそれを優先使用
-- TypeScript の型安全な実装
+- Arrays and plain objects
+- Circular reference detection and correct handling
+- Objects with a `clone()` method should use it preferentially
+- Type-safe TypeScript implementation
 
 ```typescript
-// テスト
+// Test
 const original = {
   str: "hello",
   num: 42,
@@ -1778,7 +1784,7 @@ const original = {
   arr: [1, [2, [3]]],
   circular: null as any,
 };
-original.circular = original; // 循環参照
+original.circular = original; // circular reference
 
 const cloned = deepClone(original);
 
@@ -1787,11 +1793,11 @@ console.log(cloned.date !== original.date);   // true
 console.log(cloned.regex instanceof RegExp);  // true
 console.log(cloned.map.get("a")!.nested);     // true
 console.log(cloned.map.get("a") !== original.map.get("a")); // true
-console.log(cloned.circular === cloned);      // true（循環参照が正しく再現）
-console.log(cloned.circular !== original);    // true（独立）
+console.log(cloned.circular === cloned);      // true (circular reference correctly reproduced)
+console.log(cloned.circular !== original);    // true (independent)
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 true
 true
@@ -1803,20 +1809,20 @@ true
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample solution</summary>
 
 ```typescript
 function deepClone<T>(obj: T, visited = new WeakMap()): T {
-  // プリミティブと null/undefined はそのまま返す
+  // Return primitives and null/undefined as-is
   if (obj === null || obj === undefined) return obj;
   if (typeof obj !== "object" && typeof obj !== "function") return obj;
 
-  // 循環参照チェック
+  // Circular reference check
   if (visited.has(obj as any)) {
     return visited.get(obj as any);
   }
 
-  // clone() メソッドを持つオブジェクトはそれを使う
+  // Use clone() method if the object has one
   if (typeof (obj as any).clone === "function") {
     const cloned = (obj as any).clone();
     visited.set(obj as any, cloned);
@@ -1843,7 +1849,7 @@ function deepClone<T>(obj: T, visited = new WeakMap()): T {
   // Map
   if (obj instanceof Map) {
     result = new Map();
-    visited.set(obj as any, result); // 先に登録（循環参照対策）
+    visited.set(obj as any, result); // register early (circular reference guard)
     for (const [key, value] of obj) {
       result.set(deepClone(key, visited), deepClone(value, visited));
     }
@@ -1885,7 +1891,7 @@ function deepClone<T>(obj: T, visited = new WeakMap()): T {
     return result;
   }
 
-  // プレーンオブジェクト
+  // Plain object
   result = Object.create(Object.getPrototypeOf(obj));
   visited.set(obj as any, result);
 
@@ -1902,7 +1908,7 @@ function deepClone<T>(obj: T, visited = new WeakMap()): T {
   return result;
 }
 
-// テスト
+// Test
 const original = {
   str: "hello",
   num: 42,
@@ -1931,73 +1937,73 @@ console.log(cloned.circular !== original);    // true
 
 ## 9. FAQ
 
-### Q1: JavaScript の `structuredClone` はいつ使うべきですか？
+### Q1: When should I use JavaScript's `structuredClone`?
 
-DOM ノードや関数、Symbol を含まないプレーンなデータオブジェクトを深くコピーしたい場合に最適です。クラスインスタンスのメソッドやプロトタイプチェーンは失われるため、メソッドを持つオブジェクトにはカスタム `clone()` を実装してください。`structuredClone` は循環参照を自動で処理できる点が `JSON.parse(JSON.stringify(...))` より優れています。
+It is ideal when you want to deeply copy plain data objects that do not contain DOM nodes, functions, or Symbols. Since class instance methods and prototype chains are lost, implement a custom `clone()` for objects with methods. `structuredClone` is superior to `JSON.parse(JSON.stringify(...))` in that it automatically handles circular references.
 
-### Q2: Prototype パターンと JavaScript の prototype チェーンは同じですか？
+### Q2: Is the Prototype pattern the same as JavaScript's prototype chain?
 
-名前は似ていますが**全く別の概念**です。
+The names are similar, but they are **completely different concepts**.
 
-| | GoF Prototype パターン | JavaScript prototype チェーン |
+| | GoF Prototype Pattern | JavaScript prototype chain |
 |--|--|--|
-| 目的 | オブジェクトの**クローン生成** | プロパティの**委譲検索** |
-| 操作 | clone() で新しいオブジェクトを作る | `obj.prop` でプロトタイプを辿る |
-| 結果 | 独立したコピー | 共有された振る舞い |
+| Purpose | **Clone generation** of objects | **Delegated lookup** of properties |
+| Operation | Creates a new object with clone() | Traverses the prototype with `obj.prop` |
+| Result | Independent copy | Shared behavior |
 
-JavaScript の `Object.create()` は GoF Prototype パターンに近い概念ですが、プロパティのコピーではなくプロトタイプチェーンの設定を行う点が異なります。
+JavaScript's `Object.create()` is conceptually close to the GoF Prototype pattern, but differs in that it sets up the prototype chain rather than copying properties.
 
-### Q3: 不変データ構造（Immutable Data Structure）を使えば clone() は不要ですか？
+### Q3: If I use immutable data structures, is clone() unnecessary?
 
-多くの場合、不変データ構造を使えば明示的な `clone()` は不要になります。Immutable.js や Immer では、**構造共有（structural sharing）** により変更されていない部分の参照を共有するため、Deep Copy よりも遥かに効率的です。ただし、以下のケースでは依然として Prototype パターンが有用です:
-- 既存のミュータブルなクラスとの互換性が必要
-- 構造共有のオーバーヘッドが問題になる小さなオブジェクト
-- サードパーティライブラリのオブジェクトのコピー
+In many cases, using immutable data structures eliminates the need for explicit `clone()`. Libraries like Immutable.js and Immer use **structural sharing** to share references to unchanged parts, making it far more efficient than Deep Copy. However, the Prototype pattern is still useful in the following cases:
+- Compatibility with existing mutable classes is required
+- Small objects where structural sharing overhead is a concern
+- Copying objects from third-party libraries
 
-### Q4: Java の `Cloneable` はなぜ「壊れた」インタフェースと言われるのですか？
+### Q4: Why is Java's `Cloneable` called a "broken" interface?
 
-Josh Bloch（`java.util.Collection` の設計者）が Effective Java で詳細に指摘しています:
+Josh Bloch (designer of `java.util.Collection`) detailed this in Effective Java:
 
-1. **マーカーインタフェース**なのにメソッドがない: `clone()` は `Object` に定義されており、`Cloneable` にはない
-2. **protected**: `Object.clone()` は protected なので、外部から呼べない（public にオーバーライドが必要）
-3. **Shallow Copy のみ**: `super.clone()` は Shallow Copy しか行わない
-4. **final フィールド非互換**: `clone()` 後に final フィールドを再設定できない
-5. **例外が不適切**: `CloneNotSupportedException` はチェック例外だが、実際にはほぼ発生しない
+1. **Marker interface** with no methods: `clone()` is defined on `Object`, not `Cloneable`
+2. **protected**: `Object.clone()` is protected, so it cannot be called from outside (must override as public)
+3. **Shallow Copy only**: `super.clone()` only performs a Shallow Copy
+4. **Incompatible with final fields**: Cannot reassign final fields after `clone()`
+5. **Inappropriate exception**: `CloneNotSupportedException` is a checked exception but almost never actually thrown
 
-**結論**: Java では Copy Constructor か static factory method(`copyOf()`) を使うべきです。
+**Conclusion**: In Java, use a Copy Constructor or static factory method (`copyOf()`).
 
-### Q5: Prototype パターンと Flyweight パターンの関係は？
+### Q5: What is the relationship between the Prototype pattern and the Flyweight pattern?
 
 | | Prototype | Flyweight |
 |--|--|--|
-| 目的 | オブジェクトの**複製** | オブジェクトの**共有** |
-| メモリ | **増加**（コピー分） | **削減**（共有分） |
-| 独立性 | **完全に独立** | 内在状態を共有 |
+| Purpose | **Duplicating** objects | **Sharing** objects |
+| Memory | **Increases** (by copies) | **Decreases** (by sharing) |
+| Independence | **Fully independent** | Shares intrinsic state |
 
-両者は対照的ですが、組み合わせることもあります。例えば、Prototype でクローンしたオブジェクトの内部で Flyweight を使って重いデータ（テクスチャ、フォントなど）を共有する設計です。
+The two are contrasting, but can be combined. For example, objects cloned with Prototype may internally use Flyweight to share heavy data (textures, fonts, etc.).
 
-### Q6: テストでの Prototype パターンの活用方法は？
+### Q6: How is the Prototype pattern used in testing?
 
-テストでは「テストフィクスチャ（test fixture）」の作成に Prototype パターンが非常に有効です:
+In testing, the Prototype pattern is very useful for creating **test fixtures**:
 
 ```typescript
-// テストの基本フィクスチャをプロトタイプとして定義
+// Define base fixture as a prototype
 const baseUser = new User("test-user", "test@example.com", {
   role: "user",
   settings: { theme: "dark", notifications: true }
 });
 
-// 各テストケースでクローンしてカスタマイズ
+// Clone and customize for each test case
 test("admin can access settings", () => {
   const admin = baseUser.clone();
   admin.role = "admin";
-  // ... テスト
+  // ... test
 });
 
 test("user with notifications off", () => {
   const user = baseUser.clone();
   user.settings.notifications = false;
-  // ... テスト
+  // ... test
 });
 ```
 
@@ -2006,50 +2012,50 @@ test("user with notifications off", () => {
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just from theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the fundamentals and jumping to advanced topics. We recommend thoroughly understanding the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | ポイント |
+| Item | Key Points |
 |------|---------|
-| **目的** | 既存オブジェクトをクローンして新規生成（コンストラクタコストを回避） |
-| **Shallow Copy** | 高速だが参照型フィールドを共有する（不変データなら安全） |
-| **Deep Copy** | 完全独立だがコスト高（循環参照に注意） |
-| **Registry** | プロトタイプをカタログ管理し、キーでクローンを取得 |
-| **JS/TS 推奨** | 手動 clone() + structuredClone の併用 |
-| **Python 推奨** | copy.deepcopy + __deepcopy__ カスタマイズ |
-| **Java 推奨** | Copy Constructor（Cloneable は非推奨） |
-| **Go 推奨** | 構造体ごとに Clone() メソッドを実装 |
-| **Kotlin 推奨** | data class copy() + 不変設計 |
-| **最重要注意** | clone() でも不変条件を維持する、一意IDは再生成する |
-| **活用場面** | Undo/Redo、テストフィクスチャ、設定テンプレート、ゲーム状態保存 |
+| **Purpose** | Clone existing objects to create new ones (avoids constructor cost) |
+| **Shallow Copy** | Fast but shares reference-type fields (safe for immutable data) |
+| **Deep Copy** | Fully independent but costly (watch out for circular references) |
+| **Registry** | Catalog-manage prototypes and retrieve clones by key |
+| **JS/TS recommendation** | Combine manual clone() with structuredClone |
+| **Python recommendation** | copy.deepcopy + __deepcopy__ customization |
+| **Java recommendation** | Copy Constructor (Cloneable is deprecated) |
+| **Go recommendation** | Implement a Clone() method per struct |
+| **Kotlin recommendation** | data class copy() + immutable design |
+| **Most important caution** | Maintain invariants in clone(); regenerate unique IDs |
+| **Use cases** | Undo/Redo, test fixtures, config templates, game state saving |
 
 ---
 
-## 次に読むべきガイド
+## What to Read Next
 
-- [Singleton パターン](./00-singleton.md) — インスタンス数の制御と Prototype との対比
-- [Factory パターン](./01-factory.md) — オブジェクト生成の抽象化（Prototype と併用可能）
-- [Builder パターン](./02-builder.md) — 複雑なオブジェクトの段階的構築
-- [Decorator パターン](../01-structural/01-decorator.md) — 動的な機能追加
-- Memento パターン — 状態の保存と復元（Prototype と関連）
-- 不変性 — イミュータブルデータ構造
+- [Singleton Pattern](./00-singleton.md) — Controlling instance count and contrast with Prototype
+- [Factory Pattern](./01-factory.md) — Abstraction of object creation (can be used alongside Prototype)
+- [Builder Pattern](./02-builder.md) — Step-by-step construction of complex objects
+- [Decorator Pattern](../01-structural/01-decorator.md) — Dynamic feature addition
+- Memento Pattern — Saving and restoring state (related to Prototype)
+- Immutability — Immutable data structures
 
 ---
 
-## 参考文献
+## References
 
 1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley.
 2. Bloch, J. (2018). *Effective Java* (3rd ed.). Addison-Wesley. — Item 13: Override clone judiciously

--- a/03-software-design/design-patterns-guide/docs/01-structural/00-adapter.md
+++ b/03-software-design/design-patterns-guide/docs/01-structural/00-adapter.md
@@ -1,71 +1,71 @@
-# Adapter パターン
+# Adapter Pattern
 
-> 互換性のないインタフェースを持つクラスを **ラッパー** で包み、クライアントが期待するインタフェースに変換する構造パターン。
+> A structural pattern that wraps a class with an incompatible interface in a **wrapper**, converting it to the interface the client expects.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| オブジェクト指向プログラミング | 基礎 | OOP基礎 |
-| インタフェースと抽象クラス | 基礎 | インタフェース設計 |
-| 委譲（Delegation）と継承 | 理解 | 合成優先の原則 |
-| SOLID 原則（特に DIP, ISP） | 基礎 | SOLID |
-| TypeScript / Python の型システム | 基礎 | 各言語ガイド |
+| Object-Oriented Programming | Basic | OOP Basics |
+| Interfaces and Abstract Classes | Basic | Interface Design |
+| Delegation and Inheritance | Understanding | Composition Over Inheritance |
+| SOLID Principles (especially DIP, ISP) | Basic | SOLID |
+| TypeScript / Python Type System | Basic | Language Guides |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. Adapter パターンの**目的**と、なぜインタフェース変換が必要なのか
-2. **オブジェクトアダプタ（委譲）** と **クラスアダプタ（継承）** の2つの形態と選択基準
-3. 既存ライブラリ・レガシーコード・外部APIとの統合における実践的なアダプタの活用
-4. **関数アダプタ（高階関数）** による軽量なインタフェース変換
-5. Adapter と Facade・Decorator・Proxy の違い、過剰適用の回避
+1. The **purpose** of the Adapter pattern and why interface conversion is necessary
+2. The two forms — **Object Adapter (delegation)** and **Class Adapter (inheritance)** — and criteria for choosing between them
+3. Practical use of adapters for integrating existing libraries, legacy code, and external APIs
+4. Lightweight interface conversion using **function adapters (higher-order functions)**
+5. Differences between Adapter and Facade, Decorator, and Proxy — and how to avoid over-application
 
 ---
 
-## なぜ Adapter パターンが必要なのか（WHY）
+## Why the Adapter Pattern Is Necessary (WHY)
 
-### 問題: インタフェースの不一致
+### Problem: Interface Mismatch
 
-現実のソフトウェア開発では、「使いたいクラスやライブラリがあるが、自分のコードが期待するインタフェースと合わない」という状況が頻繁に発生します。
-
-```
-[問題1: 外部ライブラリの統合]
-  あなたのアプリは DataParser インタフェースを使っている
-  だが、導入したい XML パーサーライブラリは全く別のメソッド名・引数を持つ
-  → ライブラリのソースコードは変更できない
-
-[問題2: レガシーコードとの共存]
-  新しいシステムは NewOrderService を使う設計
-  だが、旧システムの LegacyOrderService はメソッド名も引数も違う
-  → 旧システムを全面書き換えする余裕がない
-
-[問題3: サードパーティの切り替え]
-  決済処理に Stripe を使っていたが、PayPal も追加したい
-  各SDKのインタフェースは全く異なる
-  → ビジネスロジックを決済SDKに依存させたくない
-
-[問題4: テストの容易化]
-  外部サービスに依存するコードをテストしたい
-  モックに差し替えたいが、外部SDKのインタフェースは複雑すぎる
-  → テスタブルなインタフェースに変換したい
-```
-
-### 解決: Adapter によるインタフェース変換
+In real-world software development, you frequently encounter situations where "there is a class or library you want to use, but it doesn't match the interface your code expects."
 
 ```
-Before（直接依存 — 変更に弱い）:
+[Problem 1: Integrating an external library]
+  Your app uses the DataParser interface
+  But the XML parser library you want to adopt has completely different method names and arguments
+  → You cannot modify the library's source code
+
+[Problem 2: Coexisting with legacy code]
+  The new system is designed to use NewOrderService
+  But the legacy LegacyOrderService has different method names and arguments
+  → There is no time to fully rewrite the old system
+
+[Problem 3: Switching third-party providers]
+  You were using Stripe for payment processing, but want to add PayPal as well
+  Each SDK has a completely different interface
+  → You don't want business logic to depend on the payment SDK
+
+[Problem 4: Easing testing]
+  You want to test code that depends on an external service
+  You want to swap in a mock, but the external SDK's interface is too complex
+  → You want to convert it to a testable interface
+```
+
+### Solution: Interface Conversion via Adapter
+
+```
+Before (direct dependency — fragile to change):
 ┌──────────┐         ┌───────────────┐
 │  Client  │────────>│ LegacyXmlParser│
-│          │  直接依存 │ .parseXml()   │
+│          │  direct │ .parseXml()   │
 └──────────┘         └───────────────┘
-  ↑ Client が LegacyXmlParser の具象インタフェースに依存
-  ↑ ライブラリを変更すると Client も変更が必要
+  ↑ Client depends on the concrete interface of LegacyXmlParser
+  ↑ Changing the library also requires changing the Client
 
-After（Adapter を介在 — 変更に強い）:
+After (Adapter as intermediary — resilient to change):
 ┌──────────┐   uses    ┌──────────────┐  delegates  ┌───────────────┐
 │  Client  │──────────>│  Adapter     │────────────>│ LegacyXmlParser│
 │          │           │ .parse()     │             │ .parseXml()   │
@@ -78,21 +78,21 @@ After（Adapter を介在 — 変更に強い）:
 │  (interface) │
 │  .parse()    │
 └──────────────┘
-  ↑ Client は DataParser インタフェースのみに依存
-  ↑ ライブラリを変更しても Adapter だけ修正すれば OK
+  ↑ Client depends only on the DataParser interface
+  ↑ Even if the library changes, only the Adapter needs to be updated
 ```
 
-このパターンにより:
-- **既存コードを変更せず**に互換性のないコンポーネントを統合できる
-- クライアントが**具象クラスに依存しない**（依存性逆転の原則: DIP）
-- サードパーティライブラリの**差し替えが容易**
-- テストでモックに差し替えることが容易
+This pattern allows you to:
+- Integrate incompatible components **without modifying existing code**
+- Keep the client from **depending on concrete classes** (Dependency Inversion Principle: DIP)
+- Easily **swap out third-party libraries**
+- Easily substitute mocks during testing
 
 ---
 
-## 1. Adapter の構造
+## 1. Adapter Structure
 
-### オブジェクトアダプタ（委譲ベース） — 推奨
+### Object Adapter (Delegation-based) — Recommended
 
 ```
 +----------------+
@@ -119,7 +119,7 @@ Client ──uses──> Target(interface)
                  Adapter ──delegates──> Adaptee
 ```
 
-### クラスアダプタ（継承ベース） — 非推奨
+### Class Adapter (Inheritance-based) — Not Recommended
 
 ```
 +----------------+         +----------------+
@@ -136,13 +136,13 @@ Client ──uses──> Target(interface)
               |    Adapter     |
               +----------------+
               | + request() {  |
-              |   legacyOp()  }|  ← 自身の継承メソッドを呼ぶ
+              |   legacyOp()  }|  ← calls own inherited method
               +----------------+
 
-問題: 多重継承が必要（Java/TS では不可）、密結合
+Problem: Requires multiple inheritance (not possible in Java/TS), tight coupling
 ```
 
-### シーケンス図
+### Sequence Diagram
 
 ```
 Client          Adapter              Adaptee
@@ -152,40 +152,40 @@ Client          Adapter              Adaptee
   |                |                    |
   |                |<--result-----------|
   |                |                    |
-  |                |  [データ変換]       |
+  |                |  [data conversion] |
   |                |  convertResult()   |
   |                |                    |
-  |<--変換済result--|                    |
-  |                |                    |
+  |<--converted----|                    |
+  |    result      |                    |
 ```
 
 ---
 
-## 2. オブジェクトアダプタ vs クラスアダプタ
+## 2. Object Adapter vs Class Adapter
 
-### 詳細比較
+### Detailed Comparison
 
-| 観点 | オブジェクトアダプタ | クラスアダプタ |
+| Aspect | Object Adapter | Class Adapter |
 |------|:---:|:---:|
-| 実現方法 | **委譲（has-a）** | 継承（is-a） |
-| 複数 Adaptee 対応 | **Yes**（コンストラクタで注入） | No（単一継承） |
-| Adaptee のメソッド上書き | No（private のため） | Yes（protected にアクセス可） |
-| 言語制約 | **なし** | 多重継承が必要（Java/TS で不可） |
-| 結合度 | **低い** | 高い |
-| テスト容易性 | **高い**（モック注入可） | 低い |
-| 推奨度 | **高い** | 低い |
-| SOLID 準拠 | **DIP, ISP 準拠** | OCP 違反リスク |
+| Implementation | **Delegation (has-a)** | Inheritance (is-a) |
+| Multiple Adaptees | **Yes** (injected via constructor) | No (single inheritance) |
+| Overriding Adaptee methods | No (private access) | Yes (can access protected) |
+| Language restrictions | **None** | Requires multiple inheritance (not possible in Java/TS) |
+| Coupling | **Low** | High |
+| Testability | **High** (mock injection possible) | Low |
+| Recommendation | **High** | Low |
+| SOLID compliance | **DIP, ISP compliant** | Risk of OCP violation |
 
-**結論**: ほぼ全てのケースでオブジェクトアダプタを使うべきです。クラスアダプタは Adaptee の protected メソッドにアクセスする必要がある場合にのみ検討してください。
+**Conclusion**: You should use object adapters in almost all cases. Class adapters should only be considered when you need access to protected methods of the Adaptee.
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: 外部ライブラリの Adapter（基本形）
+### Code Example 1: External Library Adapter (Basic Form)
 
 ```typescript
-// === Adaptee: 既存の外部ライブラリ（変更不可）===
+// === Adaptee: Existing external library (cannot be modified) ===
 interface XmlDocument {
   root: string;
   format: string;
@@ -193,7 +193,7 @@ interface XmlDocument {
 
 class LegacyXmlParser {
   parseXml(xmlString: string): XmlDocument {
-    // XML をパースして独自形式で返す
+    // Parse XML and return in a proprietary format
     return { root: xmlString, format: "xml" };
   }
 
@@ -202,13 +202,13 @@ class LegacyXmlParser {
   }
 }
 
-// === Target: クライアントが期待するインタフェース ===
+// === Target: Interface expected by the client ===
 interface DataParser {
   parse(input: string): Record<string, unknown>;
   validate(input: string): boolean;
 }
 
-// === Adapter: インタフェースを変換 ===
+// === Adapter: Converts the interface ===
 class XmlParserAdapter implements DataParser {
   private legacyParser: LegacyXmlParser;
 
@@ -217,7 +217,7 @@ class XmlParserAdapter implements DataParser {
   }
 
   parse(input: string): Record<string, unknown> {
-    // Adaptee のメソッドを呼び、結果を変換
+    // Call the Adaptee's method and convert the result
     const xmlDoc = this.legacyParser.parseXml(input);
     return this.convertToRecord(xmlDoc);
   }
@@ -235,7 +235,7 @@ class XmlParserAdapter implements DataParser {
   }
 }
 
-// === Client: DataParser インタフェースだけを知っている ===
+// === Client: Only knows the DataParser interface ===
 function processData(parser: DataParser, input: string): void {
   if (parser.validate(input)) {
     const result = parser.parse(input);
@@ -245,20 +245,20 @@ function processData(parser: DataParser, input: string): void {
   }
 }
 
-// 使用: クライアントは Adapter を DataParser として受け取る
+// Usage: Client receives the Adapter as a DataParser
 const adapter = new XmlParserAdapter();
 processData(adapter, "<user>Taro</user>");
 // Parsed: { data: "<user>Taro</user>", format: "xml", parsedAt: "..." }
 ```
 
-**ポイント**: Client は `DataParser` インタフェースだけに依存し、`LegacyXmlParser` の存在を知りません。将来 JSON パーサーに切り替えても Client のコードは変更不要です。
+**Key point**: The Client depends only on the `DataParser` interface and has no knowledge of `LegacyXmlParser`. Even if you switch to a JSON parser in the future, the Client code requires no changes.
 
 ---
 
-### コード例 2: ログライブラリの統一 Adapter
+### Code Example 2: Unified Logger Adapter
 
 ```typescript
-// === Target: アプリ内の統一ログインタフェース ===
+// === Target: Unified logging interface used within the app ===
 interface AppLogger {
   debug(message: string, context?: Record<string, unknown>): void;
   info(message: string, context?: Record<string, unknown>): void;
@@ -319,7 +319,7 @@ class PinoAdapter implements AppLogger {
   }
 }
 
-// === Adaptee 3: Console（開発用） ===
+// === Adaptee 3: Console (for development) ===
 class ConsoleAdapter implements AppLogger {
   debug(message: string, context?: Record<string, unknown>): void {
     console.debug(`[DEBUG] ${message}`, context ?? "");
@@ -338,7 +338,7 @@ class ConsoleAdapter implements AppLogger {
   }
 }
 
-// === Factory で適切な Adapter を選択 ===
+// === Select the appropriate Adapter via Factory ===
 function createLogger(env: string): AppLogger {
   switch (env) {
     case "production":
@@ -350,7 +350,7 @@ function createLogger(env: string): AppLogger {
   }
 }
 
-// 使用: アプリケーションコードは AppLogger だけに依存
+// Usage: Application code depends only on AppLogger
 const logger: AppLogger = createLogger(process.env.NODE_ENV ?? "development");
 logger.info("Application started", { port: 3000 });
 logger.error("Database connection failed", new Error("ECONNREFUSED"), { host: "localhost" });
@@ -358,7 +358,7 @@ logger.error("Database connection failed", new Error("ECONNREFUSED"), { host: "l
 
 ---
 
-### コード例 3: Python — 決済ゲートウェイ Adapter
+### Code Example 3: Python — Payment Gateway Adapter
 
 ```python
 from abc import ABC, abstractmethod
@@ -374,7 +374,7 @@ class PaymentStatus(Enum):
 
 @dataclass
 class PaymentResult:
-    """統一された決済結果"""
+    """Unified payment result"""
     status: PaymentStatus
     transaction_id: str
     amount: float
@@ -382,7 +382,7 @@ class PaymentResult:
 
 
 class PaymentGateway(ABC):
-    """Target: 統一決済インタフェース"""
+    """Target: Unified payment interface"""
     @abstractmethod
     def charge(self, amount: float, currency: str, token: str) -> PaymentResult: ...
 
@@ -390,7 +390,7 @@ class PaymentGateway(ABC):
     def refund(self, transaction_id: str, amount: float) -> PaymentResult: ...
 
 
-# === Adaptee 1: Stripe SDK（変更不可）===
+# === Adaptee 1: Stripe SDK (cannot be modified) ===
 class StripeSDK:
     def create_charge(self, amount_cents: int, cur: str, source: str) -> dict:
         return {"id": "ch_123", "status": "succeeded", "amount": amount_cents}
@@ -400,13 +400,13 @@ class StripeSDK:
 
 
 class StripeAdapter(PaymentGateway):
-    """Stripe SDK を統一インタフェースに変換"""
+    """Converts Stripe SDK to the unified interface"""
 
     def __init__(self, sdk: StripeSDK):
         self._sdk = sdk
 
     def charge(self, amount: float, currency: str, token: str) -> PaymentResult:
-        cents = int(amount * 100)  # ドル → セント変換
+        cents = int(amount * 100)  # Convert dollars to cents
         result = self._sdk.create_charge(cents, currency, token)
         return PaymentResult(
             status=self._convert_status(result["status"]),
@@ -435,7 +435,7 @@ class StripeAdapter(PaymentGateway):
         return mapping.get(stripe_status, PaymentStatus.FAILED)
 
 
-# === Adaptee 2: PayPal SDK（変更不可）===
+# === Adaptee 2: PayPal SDK (cannot be modified) ===
 class PayPalSDK:
     def execute_payment(self, payment_data: dict) -> dict:
         return {"payment_id": "PAY-789", "state": "approved"}
@@ -445,7 +445,7 @@ class PayPalSDK:
 
 
 class PayPalAdapter(PaymentGateway):
-    """PayPal SDK を統一インタフェースに変換"""
+    """Converts PayPal SDK to the unified interface"""
 
     def __init__(self, sdk: PayPalSDK):
         self._sdk = sdk
@@ -485,9 +485,9 @@ class PayPalAdapter(PaymentGateway):
         return mapping.get(paypal_state, PaymentStatus.FAILED)
 
 
-# === 使用例 ===
+# === Usage example ===
 def process_order(gateway: PaymentGateway, amount: float) -> None:
-    """ビジネスロジックは PaymentGateway インタフェースだけに依存"""
+    """Business logic depends only on the PaymentGateway interface"""
     result = gateway.charge(amount, "USD", "tok_test")
     if result.status == PaymentStatus.SUCCESS:
         print(f"Payment successful: {result.transaction_id}")
@@ -495,28 +495,28 @@ def process_order(gateway: PaymentGateway, amount: float) -> None:
         print(f"Payment failed: {result.status}")
 
 
-# Stripe を使う場合
+# Using Stripe
 stripe_gateway = StripeAdapter(StripeSDK())
 process_order(stripe_gateway, 29.99)
 
-# PayPal に切り替える場合 — ビジネスロジックは変更不要
+# Switching to PayPal — no changes needed in business logic
 paypal_gateway = PayPalAdapter(PayPalSDK())
 process_order(paypal_gateway, 29.99)
 ```
 
 ---
 
-### コード例 4: DOM イベントと独自イベントシステムの橋渡し
+### Code Example 4: Bridging DOM Events and a Custom Event System
 
 ```typescript
-// === Target: アプリ内の統一イベントシステム ===
+// === Target: Unified event system used within the app ===
 interface AppEventEmitter {
-  on<T = unknown>(event: string, handler: (data: T) => void): () => void; // unsubscribe 関数を返す
+  on<T = unknown>(event: string, handler: (data: T) => void): () => void; // returns unsubscribe function
   emit<T = unknown>(event: string, data: T): void;
   off(event: string, handler: Function): void;
 }
 
-// === Adapter 1: DOM イベント → AppEventEmitter ===
+// === Adapter 1: DOM events → AppEventEmitter ===
 class DOMEventAdapter implements AppEventEmitter {
   private handlers = new Map<Function, EventListener>();
 
@@ -529,7 +529,7 @@ class DOMEventAdapter implements AppEventEmitter {
     this.handlers.set(handler, listener);
     this.element.addEventListener(event, listener);
 
-    // クリーンアップ関数を返す
+    // Return cleanup function
     return () => this.off(event, handler);
   }
 
@@ -603,23 +603,23 @@ class WebSocketEventAdapter implements AppEventEmitter {
   }
 }
 
-// 使用: クライアントコードは AppEventEmitter だけに依存
+// Usage: Client code depends only on AppEventEmitter
 function setupNotifications(emitter: AppEventEmitter): void {
   const unsubscribe = emitter.on<{ message: string }>("notification", (data) => {
     console.log("Notification:", data.message);
   });
 
-  // 後でクリーンアップ
+  // Clean up later
   // unsubscribe();
 }
 ```
 
 ---
 
-### コード例 5: 関数アダプタ（高階関数）
+### Code Example 5: Function Adapter (Higher-Order Functions)
 
 ```typescript
-// === コールバック形式 → Promise 形式のアダプタ ===
+// === Adapter: callback style → Promise style ===
 type NodeCallback<T> = (err: Error | null, result: T) => void;
 type CallbackFn<T> = (callback: NodeCallback<T>) => void;
 
@@ -635,7 +635,7 @@ function promisify(fn: Function): (...args: any[]) => Promise<any> {
     });
 }
 
-// === イテレータ → 配列のアダプタ ===
+// === Adapter: iterator → array ===
 function iteratorToArray<T>(iterator: Iterator<T>): T[] {
   const result: T[] = [];
   let next = iterator.next();
@@ -646,7 +646,7 @@ function iteratorToArray<T>(iterator: Iterator<T>): T[] {
   return result;
 }
 
-// === Observable → Promise のアダプタ ===
+// === Adapter: Observable → Promise ===
 function observableToPromise<T>(observable: { subscribe: Function }): Promise<T> {
   return new Promise((resolve, reject) => {
     let lastValue: T;
@@ -658,12 +658,12 @@ function observableToPromise<T>(observable: { subscribe: Function }): Promise<T>
   });
 }
 
-// === 引数の順序を変えるアダプタ ===
+// === Adapter: reverses argument order ===
 function flip<A, B, R>(fn: (a: A, b: B) => R): (b: B, a: A) => R {
   return (b, a) => fn(a, b);
 }
 
-// === 複数引数 → 単一オブジェクト引数のアダプタ ===
+// === Adapter: multiple arguments → single object argument ===
 type ParamsOf<F> = F extends (...args: infer P) => any ? P : never;
 
 function objectify<F extends (...args: any[]) => any>(
@@ -676,7 +676,7 @@ function objectify<F extends (...args: any[]) => any>(
   };
 }
 
-// 使用例
+// Usage example
 function createUser(name: string, age: number, email: string): { name: string; age: number; email: string } {
   return { name, age, email };
 }
@@ -685,17 +685,17 @@ const createUserFromObject = objectify(createUser, ["name", "age", "email"]);
 const user = createUserFromObject({ name: "Taro", age: 25, email: "taro@example.com" });
 ```
 
-**関数アダプタのメリット**:
-- クラスを定義する必要がない（軽量）
-- 関数型プログラミングと相性が良い
-- 単純な変換なら一行で済む
+**Benefits of function adapters**:
+- No need to define a class (lightweight)
+- Works well with functional programming
+- Simple conversions can be done in a single line
 
 ---
 
-### コード例 6: Java — ORM と DTO の Adapter
+### Code Example 6: Java — ORM and DTO Adapter
 
 ```java
-// === Target: アプリケーション層の DTO ===
+// === Target: Application layer DTO ===
 public record UserDTO(
     String id,
     String fullName,
@@ -703,7 +703,7 @@ public record UserDTO(
     LocalDateTime createdAt
 ) {}
 
-// === Adaptee 1: JPA Entity（データベース層）===
+// === Adaptee 1: JPA Entity (database layer) ===
 @Entity
 public class UserEntity {
     @Id private Long id;
@@ -720,7 +720,7 @@ public class UserEntity {
     public Timestamp getCreatedTimestamp() { return createdTimestamp; }
 }
 
-// === Adaptee 2: 外部 API レスポンス ===
+// === Adaptee 2: External API response ===
 public class ExternalUserResponse {
     private String user_id;
     private String display_name;
@@ -734,7 +734,7 @@ public class ExternalUserResponse {
     public String getRegisteredAt() { return registered_at; }
 }
 
-// === Adapter インタフェース ===
+// === Adapter interface ===
 public interface UserAdapter<T> {
     UserDTO toDTO(T source);
     T fromDTO(UserDTO dto);
@@ -763,7 +763,7 @@ public class JpaUserAdapter implements UserAdapter<UserEntity> {
     }
 }
 
-// === Adapter 2: 外部 API レスポンス → DTO ===
+// === Adapter 2: External API response → DTO ===
 public class ExternalUserAdapter implements UserAdapter<ExternalUserResponse> {
     @Override
     public UserDTO toDTO(ExternalUserResponse response) {
@@ -777,7 +777,7 @@ public class ExternalUserAdapter implements UserAdapter<ExternalUserResponse> {
 
     @Override
     public ExternalUserResponse fromDTO(UserDTO dto) {
-        // 逆変換は必要に応じて実装
+        // Implement reverse conversion as needed
         throw new UnsupportedOperationException("One-way adapter");
     }
 }
@@ -785,7 +785,7 @@ public class ExternalUserAdapter implements UserAdapter<ExternalUserResponse> {
 
 ---
 
-### コード例 7: Go — インタフェースベースの Adapter
+### Code Example 7: Go — Interface-based Adapter
 
 ```go
 package main
@@ -795,12 +795,12 @@ import (
     "strings"
 )
 
-// === Target: アプリケーションが使うインタフェース ===
+// === Target: Interface used by the application ===
 type MessageSender interface {
     Send(to string, subject string, body string) error
 }
 
-// === Adaptee 1: SMTP ライブラリ（レガシー）===
+// === Adaptee 1: SMTP library (legacy) ===
 type LegacySMTP struct{}
 
 func (s *LegacySMTP) SendMail(recipient string, headers map[string]string, content string) error {
@@ -849,17 +849,17 @@ func (a *SlackAdapter) Send(to string, subject string, body string) error {
     return a.slack.PostMessage(to, text)
 }
 
-// === 使用例 ===
+// === Usage example ===
 func notifyUser(sender MessageSender, to string) error {
     return sender.Send(to, "Welcome", "Hello, welcome to our service!")
 }
 
 func main() {
-    // SMTP で送信
+    // Send via SMTP
     smtpSender := NewSMTPAdapter(&LegacySMTP{})
     notifyUser(smtpSender, "user@example.com")
 
-    // Slack で送信（コードの変更不要）
+    // Send via Slack (no code changes needed)
     slackSender := NewSlackAdapter(&SlackWebhook{WebhookURL: "https://hooks.slack.com/xxx"})
     notifyUser(slackSender, "#general")
 }
@@ -867,10 +867,10 @@ func main() {
 
 ---
 
-### コード例 8: Kotlin — 拡張関数による軽量 Adapter
+### Code Example 8: Kotlin — Lightweight Adapter Using Extension Functions
 
 ```kotlin
-// === Adaptee: サードパーティの天気API ===
+// === Adaptee: Third-party weather API ===
 data class WeatherApiResponse(
     val temp_c: Double,
     val humidity_pct: Int,
@@ -878,7 +878,7 @@ data class WeatherApiResponse(
     val condition_code: Int
 )
 
-// === Target: アプリケーションのドメインモデル ===
+// === Target: Application domain model ===
 data class WeatherInfo(
     val temperatureCelsius: Double,
     val temperatureFahrenheit: Double,
@@ -887,7 +887,7 @@ data class WeatherInfo(
     val condition: String
 )
 
-// === Adapter: 拡張関数で変換 ===
+// === Adapter: Conversion via extension function ===
 fun WeatherApiResponse.toWeatherInfo(): WeatherInfo {
     return WeatherInfo(
         temperatureCelsius = this.temp_c,
@@ -907,7 +907,7 @@ private fun mapCondition(code: Int): String = when (code) {
     else -> "Unknown"
 }
 
-// === 使用例 ===
+// === Usage example ===
 fun displayWeather(info: WeatherInfo) {
     println("${info.temperatureCelsius}°C (${info.temperatureFahrenheit}°F)")
     println("Humidity: ${info.humidityPercent}%")
@@ -915,7 +915,7 @@ fun displayWeather(info: WeatherInfo) {
 }
 
 fun main() {
-    // API レスポンスを取得
+    // Fetch API response
     val apiResponse = WeatherApiResponse(
         temp_c = 22.5,
         humidity_pct = 65,
@@ -923,7 +923,7 @@ fun main() {
         condition_code = 2
     )
 
-    // 拡張関数で変換（Adapter）
+    // Convert using extension function (Adapter)
     val weatherInfo = apiResponse.toWeatherInfo()
     displayWeather(weatherInfo)
 }
@@ -931,11 +931,11 @@ fun main() {
 
 ---
 
-### コード例 9: Adapter + Strategy パターンの組み合わせ
+### Code Example 9: Combining Adapter + Strategy Patterns
 
 ```typescript
-// 複数の通知チャネルを Adapter で統一し、
-// Strategy パターンでチャネルを動的に切り替える
+// Multiple notification channels are unified via Adapter,
+// and the Strategy pattern is used to switch channels dynamically
 
 // === Target ===
 interface NotificationChannel {
@@ -960,7 +960,7 @@ class EmailAdapter implements NotificationChannel {
   getName(): string { return "email"; }
 
   private async resolveEmail(userId: string): Promise<string> {
-    return `${userId}@example.com`; // 実際はDB検索
+    return `${userId}@example.com`; // In practice, look up from DB
   }
 }
 
@@ -980,7 +980,7 @@ class SMSAdapter implements NotificationChannel {
   getName(): string { return "sms"; }
 
   private async resolvePhone(userId: string): Promise<string> {
-    return "+8190XXXXXXXX"; // 実際はDB検索
+    return "+8190XXXXXXXX"; // In practice, look up from DB
   }
 }
 
@@ -1000,11 +1000,11 @@ class PushNotificationAdapter implements NotificationChannel {
   getName(): string { return "push"; }
 
   private async resolveToken(userId: string): Promise<string> {
-    return "fcm-token-xxx"; // 実際はDB検索
+    return "fcm-token-xxx"; // In practice, look up from DB
   }
 }
 
-// === Strategy: 通知チャネルを動的に選択 ===
+// === Strategy: Dynamically select notification channel ===
 class NotificationService {
   private channels = new Map<string, NotificationChannel>();
 
@@ -1032,25 +1032,25 @@ class NotificationService {
   }
 }
 
-// 使用例
+// Usage example
 const service = new NotificationService();
 service.registerChannel(new EmailAdapter(smtpClient));
 service.registerChannel(new SMSAdapter(twilioClient));
 service.registerChannel(new PushNotificationAdapter(fcmClient));
 
-// ユーザー設定に応じてチャネルを選択
+// Select channel based on user preferences
 await service.notify("user-123", "Your order has shipped!", "email");
 await service.notifyAll("user-456", "System maintenance in 1 hour");
 ```
 
 ---
 
-### コード例 10: Two-Way Adapter（双方向アダプタ）
+### Code Example 10: Two-Way Adapter (Bidirectional Adapter)
 
 ```typescript
-// 2つの異なるシステム間でデータを相互変換する双方向アダプタ
+// A bidirectional adapter that converts data between two different systems
 
-// === System A: REST API 形式 ===
+// === System A: REST API format ===
 interface RestApiUser {
   id: string;
   first_name: string;
@@ -1059,7 +1059,7 @@ interface RestApiUser {
   created_at: string; // ISO 8601
 }
 
-// === System B: GraphQL 形式 ===
+// === System B: GraphQL format ===
 interface GraphQLUser {
   userId: string;
   fullName: string;
@@ -1099,7 +1099,7 @@ class UserFormatAdapter {
     };
   }
 
-  // バッチ変換
+  // Batch conversion
   restListToGraphQL(users: RestApiUser[]): GraphQLUser[] {
     return users.map(u => this.restToGraphQL(u));
   }
@@ -1109,7 +1109,7 @@ class UserFormatAdapter {
   }
 }
 
-// 使用例: マイクロサービス間のデータ同期
+// Usage example: Data synchronization between microservices
 const adapter = new UserFormatAdapter();
 
 const restUser: RestApiUser = {
@@ -1131,59 +1131,59 @@ console.log(backToRest.last_name);   // "Yamada"
 
 ---
 
-## 4. 比較表
+## 4. Comparison Tables
 
-### 比較表 1: Adapter vs Facade vs Decorator vs Proxy
+### Comparison Table 1: Adapter vs Facade vs Decorator vs Proxy
 
-| 観点 | Adapter | Facade | Decorator | Proxy |
+| Aspect | Adapter | Facade | Decorator | Proxy |
 |------|---------|--------|-----------|-------|
-| **目的** | インタフェース**変換** | 複雑さの**隠蔽** | 機能の**追加** | アクセスの**制御** |
-| **対象** | 1つのクラス/API | 複数のクラス群 | 1つのオブジェクト | 1つのオブジェクト |
-| **インタフェース** | **変換**する | **単純化**する | **同じまま** | **同じまま** |
-| **既存コード** | 変更不可 | 変更不要 | 変更不要 | 変更不要 |
-| **使用場面** | ライブラリ統合 | サブシステム公開 | ログ/キャッシュ追加 | 遅延/権限/キャッシュ |
-| **GoF 分類** | 構造 | 構造 | 構造 | 構造 |
+| **Purpose** | Interface **conversion** | **Hiding** complexity | **Adding** functionality | **Controlling** access |
+| **Target** | One class/API | Multiple classes | One object | One object |
+| **Interface** | **Converts** it | **Simplifies** it | **Stays the same** | **Stays the same** |
+| **Existing code** | Cannot be changed | No need to change | No need to change | No need to change |
+| **Use case** | Library integration | Exposing subsystems | Adding logging/caching | Lazy loading/authorization/caching |
+| **GoF category** | Structural | Structural | Structural | Structural |
 
 ```
-視覚的な違い:
+Visual differences:
 
-Adapter:   Client ──> [A→B変換] ──> Adaptee
-Facade:    Client ──> [簡易窓口] ──> SubSystem1 + SubSystem2 + SubSystem3
-Decorator: Client ──> [追加処理] ──> [追加処理] ──> Original
-Proxy:     Client ──> [アクセス制御] ──> RealSubject
+Adapter:   Client ──> [A→B conversion] ──> Adaptee
+Facade:    Client ──> [simplified interface] ──> SubSystem1 + SubSystem2 + SubSystem3
+Decorator: Client ──> [added behavior] ──> [added behavior] ──> Original
+Proxy:     Client ──> [access control] ──> RealSubject
 ```
 
-### 比較表 2: オブジェクトアダプタ vs クラスアダプタ（詳細）
+### Comparison Table 2: Object Adapter vs Class Adapter (Detailed)
 
-| 観点 | オブジェクトアダプタ | クラスアダプタ |
+| Aspect | Object Adapter | Class Adapter |
 |------|:---:|:---:|
-| 実現方法 | **委譲（has-a）** | 継承（is-a） |
-| 複数 Adaptee 対応 | **Yes** | No |
-| Adaptee のメソッド上書き | No | Yes |
-| 言語制約 | **なし** | 多重継承が必要 |
-| 結合度 | **低い** | 高い |
-| テスト容易性 | **高い** | 低い |
-| DI 対応 | **Yes** | No |
-| 推奨度 | **高い** | 低い |
-| SOLID 準拠 | **DIP/ISP準拠** | LSP/OCP違反リスク |
+| Implementation | **Delegation (has-a)** | Inheritance (is-a) |
+| Multiple Adaptees | **Yes** | No |
+| Overriding Adaptee methods | No | Yes |
+| Language restrictions | **None** | Requires multiple inheritance |
+| Coupling | **Low** | High |
+| Testability | **High** | Low |
+| DI support | **Yes** | No |
+| Recommendation | **High** | Low |
+| SOLID compliance | **DIP/ISP compliant** | Risk of LSP/OCP violation |
 
-### 比較表 3: Adapter の実装アプローチ比較
+### Comparison Table 3: Adapter Implementation Approach Comparison
 
-| アプローチ | 適用場面 | 複雑度 | 型安全性 | 再利用性 |
+| Approach | Use case | Complexity | Type safety | Reusability |
 |-----------|---------|:---:|:---:|:---:|
-| クラスアダプタ | 大規模な変換、状態管理あり | 中 | **高** | **高** |
-| 関数アダプタ | 単純な変換、状態なし | **低** | 中 | 中 |
-| 拡張関数（Kotlin） | データ変換、DTO マッピング | **低** | **高** | 中 |
-| ジェネリックアダプタ | 共通パターンの抽象化 | 高 | **高** | **最高** |
+| Class adapter | Large-scale conversion, stateful | Medium | **High** | **High** |
+| Function adapter | Simple conversion, stateless | **Low** | Medium | Medium |
+| Extension function (Kotlin) | Data conversion, DTO mapping | **Low** | **High** | Medium |
+| Generic adapter | Abstracting common patterns | High | **High** | **Highest** |
 
 ---
 
-## 5. アンチパターン
+## 5. Anti-patterns
 
-### アンチパターン 1: 薄すぎるアダプタ（不要な間接層）
+### Anti-pattern 1: Overly Thin Adapter (Unnecessary Indirection Layer)
 
 ```typescript
-// NG: 単にメソッド名を変えただけ、インタフェースが実質同じ
+// Bad: Only renaming a method — the interface is essentially the same
 interface Logger {
   log(message: string): void;
 }
@@ -1194,35 +1194,35 @@ class ConsoleLogger {
   }
 }
 
-// ← このアダプタは不要！ConsoleLogger が直接 Logger を implements すればよい
+// ← This adapter is unnecessary! ConsoleLogger can directly implement Logger
 class UselessAdapter implements Logger {
   constructor(private logger: ConsoleLogger) {}
   log(message: string): void {
-    this.logger.log(message);  // シグネチャが完全に同じ
+    this.logger.log(message);  // Signature is completely identical
   }
 }
 ```
 
 ```typescript
-// OK: ConsoleLogger に直接インタフェースを実装
+// Good: Implement the interface directly on ConsoleLogger
 class ConsoleLogger implements Logger {
   log(message: string): void {
     console.log(message);
   }
 }
 
-// または TypeScript では構造的部分型なので、
-// ConsoleLogger は Logger と互換性があればそのまま使える
+// Or, since TypeScript uses structural subtyping,
+// ConsoleLogger can be used directly if it is compatible with Logger
 ```
 
-**判断基準**: インタフェースが同じなら Adapter は不要です。Adapter は「変換が必要な場合」にのみ使うべきです。
+**Decision criterion**: If the interfaces are already the same, an Adapter is unnecessary. An Adapter should only be used "when conversion is needed."
 
 ---
 
-### アンチパターン 2: アダプタにビジネスロジックを追加
+### Anti-pattern 2: Adding Business Logic to the Adapter
 
 ```typescript
-// NG: Adapter が変換以上の責任を持つ
+// Bad: Adapter takes on more responsibility than just conversion
 class OrderAdapter implements NewOrderService {
   constructor(private legacyService: LegacyOrderService) {}
 
@@ -1230,7 +1230,7 @@ class OrderAdapter implements NewOrderService {
     const legacyData = this.convertData(data);
     const order = this.legacyService.createLegacyOrder(legacyData);
 
-    // ビジネスロジック — Adapter の責務ではない！
+    // Business logic — not the Adapter's responsibility!
     order.applyTax(this.calculateTax(order));
     order.validateInventory();
     this.sendNotification(order);
@@ -1242,19 +1242,19 @@ class OrderAdapter implements NewOrderService {
 ```
 
 ```typescript
-// OK: Adapter は変換のみ。ビジネスロジックはサービス層に配置
+// Good: Adapter handles conversion only. Business logic belongs in the service layer
 class OrderAdapter implements NewOrderService {
   constructor(private legacyService: LegacyOrderService) {}
 
   createOrder(data: NewOrderData): LegacyOrder {
-    // 変換のみ
+    // Conversion only
     const legacyData = this.convertToLegacyFormat(data);
     const result = this.legacyService.createLegacyOrder(legacyData);
     return this.convertToNewFormat(result);
   }
 }
 
-// ビジネスロジックはサービス層
+// Business logic belongs in the service layer
 class OrderService {
   constructor(
     private orderAdapter: NewOrderService,
@@ -1273,10 +1273,10 @@ class OrderService {
 
 ---
 
-### アンチパターン 3: God Adapter（万能アダプタ）
+### Anti-pattern 3: God Adapter (All-in-one Adapter)
 
 ```typescript
-// NG: 1つのアダプタが複数の異なるシステムを扱う
+// Bad: A single adapter handles multiple different systems
 class UniversalPaymentAdapter {
   constructor(
     private stripe: StripeSDK,
@@ -1297,12 +1297,12 @@ class UniversalPaymentAdapter {
         break;
     }
   }
-  // OCP 違反: 新しいプロバイダ追加のたびに switch を修正
+  // OCP violation: the switch must be modified every time a new provider is added
 }
 ```
 
 ```typescript
-// OK: プロバイダごとに個別の Adapter を作成
+// Good: Create individual Adapters per provider
 interface PaymentGateway {
   charge(amount: number, currency: string): Promise<PaymentResult>;
 }
@@ -1311,7 +1311,7 @@ class StripeAdapter implements PaymentGateway { /* ... */ }
 class PayPalAdapter implements PaymentGateway { /* ... */ }
 class SquareAdapter implements PaymentGateway { /* ... */ }
 
-// Factory で選択
+// Select via Factory
 class PaymentGatewayFactory {
   private adapters = new Map<string, PaymentGateway>();
 
@@ -1329,27 +1329,27 @@ class PaymentGatewayFactory {
 
 ---
 
-## 6. エッジケースと注意点
+## 6. Edge Cases and Considerations
 
-### エッジケース 1: 双方向変換でのデータロス
+### Edge Case 1: Data Loss in Bidirectional Conversion
 
 ```typescript
-// REST → GraphQL 変換時に情報が失われる場合がある
+// Information may be lost when converting REST → GraphQL
 interface DetailedRestUser {
   id: string;
   first_name: string;
-  middle_name: string;      // GraphQL 側にはこのフィールドがない
+  middle_name: string;      // This field does not exist on the GraphQL side
   last_name: string;
   email: string;
-  internal_notes: string;   // 変換先に該当フィールドがない
+  internal_notes: string;   // No corresponding field in the conversion target
 }
 
-// 対策1: 変換時に警告ログを出力
-// 対策2: 拡張フィールド（extras: Map）を用意
-// 対策3: 双方向変換のテストで roundtrip を検証
+// Mitigation 1: Output a warning log during conversion
+// Mitigation 2: Prepare an extension field (extras: Map)
+// Mitigation 3: Verify roundtrip in tests for bidirectional conversion
 ```
 
-### エッジケース 2: 非同期アダプタのエラーハンドリング
+### Edge Case 2: Error Handling in Async Adapters
 
 ```typescript
 class AsyncAdapter implements DataParser {
@@ -1360,7 +1360,7 @@ class AsyncAdapter implements DataParser {
       const result = await this.asyncParser.parseAsync(input);
       return this.convert(result);
     } catch (error) {
-      // Adaptee 固有のエラーを統一エラーに変換
+      // Convert Adaptee-specific errors to a unified error type
       if (error instanceof LegacyParseError) {
         throw new ParseError(error.message, error.line, error.column);
       }
@@ -1370,92 +1370,96 @@ class AsyncAdapter implements DataParser {
 }
 ```
 
-### エッジケース 3: アダプタのライフサイクル管理
+### Edge Case 3: Adapter Lifecycle Management
 
 ```typescript
-// Adaptee がリソースを持つ場合、cleanup が必要
+// When the Adaptee holds resources, cleanup is required
 class DatabaseAdapter implements DataStore {
   constructor(private connection: LegacyDBConnection) {}
 
   async get(key: string): Promise<string> { /* ... */ }
   async set(key: string, value: string): Promise<void> { /* ... */ }
 
-  // Adapter が Dispose パターンも実装する必要がある
+  // The Adapter must also implement the Dispose pattern
   async close(): Promise<void> {
     await this.connection.disconnect();
   }
 }
 
-// using 文（TC39 Stage 3）で自動クリーンアップ
+// Automatic cleanup using the using statement (TC39 Stage 3)
 // await using adapter = new DatabaseAdapter(connection);
 ```
 
 ---
 
-## 7. トレードオフ分析
+## 7. Trade-off Analysis
 
-### Adapter パターンを使うべき場面
+### When to Use the Adapter Pattern
 
 ```
-[使うべき場面] ✅
+[When to use] ✅
 ┌─────────────────────────────────────────────────────────┐
-│ 1. 外部ライブラリの統合                                   │
-│    変更できないサードパーティコードとの接続                 │
+│ 1. Integrating external libraries                        │
+│    Connecting to third-party code you cannot change      │
 │                                                          │
-│ 2. レガシーシステムの段階的移行                            │
-│    旧APIと新APIの橋渡し（Strangler Fig パターンと併用）    │
+│ 2. Gradual migration of legacy systems                   │
+│    Bridging old and new APIs (use with Strangler Fig)    │
 │                                                          │
-│ 3. テストの容易化                                         │
-│    外部依存を統一インタフェースに変換してモック可能にする    │
+│ 3. Easing testing                                        │
+│    Convert external dependencies to a unified interface  │
+│    to enable mocking                                     │
 │                                                          │
-│ 4. 複数プロバイダの統一                                    │
-│    決済、通知、ストレージ等の複数ベンダー対応              │
+│ 4. Unifying multiple providers                           │
+│    Supporting multiple vendors for payments, notifications│
+│    storage, etc.                                         │
 │                                                          │
-│ 5. データフォーマットの変換                                │
-│    REST/GraphQL/gRPC 間、DTO/Entity 間のマッピング        │
+│ 5. Data format conversion                                │
+│    Mapping between REST/GraphQL/gRPC, DTO/Entity, etc.  │
 └─────────────────────────────────────────────────────────┘
 
-[使うべきでない場面] ❌
+[When not to use] ❌
 ┌─────────────────────────────────────────────────────────┐
-│ 1. インタフェースが既に一致している                       │
-│    → 不要な間接層はコードの可読性を下げる                 │
+│ 1. Interfaces already match                              │
+│    → Unnecessary indirection reduces code readability    │
 │                                                          │
-│ 2. Adaptee を直接変更できる場合                           │
-│    → 直接インタフェースを修正する方がシンプル             │
+│ 2. When you can modify the Adaptee directly              │
+│    → Directly modifying the interface is simpler         │
 │                                                          │
-│ 3. 変換だけでなく大量のビジネスロジックが必要な場合       │
-│    → Adapter ではなく専用のサービス層を作る               │
+│ 3. When large amounts of business logic are needed       │
+│    beyond just conversion                                │
+│    → Create a dedicated service layer instead            │
 │                                                          │
-│ 4. パフォーマンスが最優先の場合                           │
-│    → 間接層のオーバーヘッドが問題になることがある          │
+│ 4. When performance is the top priority                  │
+│    → The overhead of the indirection layer can be an     │
+│       issue                                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### コスト分析
+### Cost Analysis
 
-| 項目 | Adapter あり | Adapter なし |
+| Item | With Adapter | Without Adapter |
 |------|:---:|:---:|
-| 初期実装コスト | 中（Adapter クラス作成） | **低** |
-| ライブラリ変更時のコスト | **低**（Adapter のみ修正） | 高（全呼び出し元を修正） |
-| テスト容易性 | **高** | 低 |
-| コードの複雑度 | やや増加 | **シンプル** |
-| 長期保守コスト | **低** | 高 |
+| Initial implementation cost | Medium (create Adapter class) | **Low** |
+| Cost when changing libraries | **Low** (modify Adapter only) | High (modify all call sites) |
+| Testability | **High** | Low |
+| Code complexity | Slightly increased | **Simple** |
+| Long-term maintenance cost | **Low** | High |
 
 ---
 
-## 8. 演習問題
+## 8. Exercises
 
-### 演習 1（基礎）: ファイルシステム Adapter
+### Exercise 1 (Basic): File System Adapter
 
-以下のインタフェースと既存クラスに対して Adapter を実装してください。
+Implement an Adapter for the following interface and existing class.
 
-**要件**:
-- `Storage` インタフェース: `read(key)`, `write(key, value)`, `delete(key)`, `exists(key)`
-- `LegacyFileSystem` クラス: `loadFile(path)`, `saveFile(path, content)`, `removeFile(path)`, `fileExists(path)`
-- メソッド名とパラメータ名の違いを吸収する Adapter を作成
+**Requirements**:
+- `Storage` interface: `read(key)`, `write(key, value)`, `delete(key)`, `exists(key)`
+- `LegacyFileSystem` class: `loadFile(path)`, `saveFile(path, content)`, `removeFile(path)`, `fileExists(path)`
+- Create an Adapter that bridges the differences in method names and parameter names
 
 ```typescript
-// テスト
+// Test
 const adapter: Storage = new FileSystemAdapter(new LegacyFileSystem("/data"));
 await adapter.write("config", '{"debug": true}');
 console.log(await adapter.exists("config"));   // true
@@ -1464,7 +1468,7 @@ await adapter.delete("config");
 console.log(await adapter.exists("config"));   // false
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 true
 {"debug": true}
@@ -1472,7 +1476,7 @@ false
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample answer</summary>
 
 ```typescript
 interface Storage {
@@ -1510,7 +1514,7 @@ class FileSystemAdapter implements Storage {
   constructor(private fs: LegacyFileSystem) {}
 
   private toPath(key: string): string {
-    return key; // 必要に応じてパス変換
+    return key; // Apply path conversion as needed
   }
 
   async read(key: string): Promise<string> {
@@ -1530,7 +1534,7 @@ class FileSystemAdapter implements Storage {
   }
 }
 
-// テスト
+// Test
 const adapter: Storage = new FileSystemAdapter(new LegacyFileSystem("/data"));
 await adapter.write("config", '{"debug": true}');
 console.log(await adapter.exists("config"));   // true
@@ -1542,17 +1546,17 @@ console.log(await adapter.exists("config"));   // false
 
 ---
 
-### 演習 2（応用）: マルチプロバイダ Adapter + Factory
+### Exercise 2 (Applied): Multi-provider Adapter + Factory
 
-複数のクラウドストレージプロバイダに対応する Adapter と Factory を実装してください。
+Implement Adapters and a Factory that support multiple cloud storage providers.
 
-**要件**:
-- `CloudStorage` インタフェース: `upload(key, data)`, `download(key)`, `delete(key)`, `list(prefix)`
-- AWS S3, Google Cloud Storage, Azure Blob Storage の3つの Adapter
-- `CloudStorageFactory` でプロバイダ名から Adapter を選択
+**Requirements**:
+- `CloudStorage` interface: `upload(key, data)`, `download(key)`, `delete(key)`, `list(prefix)`
+- Three Adapters for AWS S3, Google Cloud Storage, and Azure Blob Storage
+- `CloudStorageFactory` selects an Adapter based on provider name
 
 ```typescript
-// テスト
+// Test
 const factory = new CloudStorageFactory();
 factory.register("s3", new S3Adapter(s3Client));
 factory.register("gcs", new GCSAdapter(gcsClient));
@@ -1564,7 +1568,7 @@ console.log(files); // ["reports/2024.pdf"]
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample answer</summary>
 
 ```typescript
 interface CloudStorage {
@@ -1649,18 +1653,18 @@ class CloudStorageFactory {
 
 ---
 
-### 演習 3（上級）: 型安全なジェネリック Adapter フレームワーク
+### Exercise 3 (Advanced): Type-safe Generic Adapter Framework
 
-任意の2つのインタフェース間のマッピングを型安全に定義できるジェネリック Adapter フレームワークを実装してください。
+Implement a generic Adapter framework that allows you to define type-safe mappings between any two interfaces.
 
-**要件**:
-- フィールドマッピングを宣言的に定義
-- 変換関数をフィールドごとに指定可能
-- 双方向変換をサポート
-- TypeScript の型推論で変換結果の型が保証される
+**Requirements**:
+- Declaratively define field mappings
+- Allow specifying a conversion function per field
+- Support bidirectional conversion
+- TypeScript type inference guarantees the type of conversion results
 
 ```typescript
-// テスト
+// Test
 const userMapper = createMapper<RestUser, DomainUser>({
   id: (src) => src.user_id,
   name: (src) => `${src.first_name} ${src.last_name}`,
@@ -1682,7 +1686,7 @@ console.log(domainUser.email);     // "taro@example.com"
 console.log(domainUser.createdAt instanceof Date); // true
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 Taro Yamada
 taro@example.com
@@ -1690,26 +1694,26 @@ true
 ```
 
 <details>
-<summary>解答例</summary>
+<summary>Sample answer</summary>
 
 ```typescript
-// マッピング定義の型
+// Type for mapping definition
 type MappingConfig<Source, Target> = {
   [K in keyof Target]: (source: Source) => Target[K];
 };
 
-// リバースマッピングの型
+// Type for reverse mapping
 type ReverseMappingConfig<Source, Target> = {
   [K in keyof Source]: (target: Target) => Source[K];
 };
 
-// Mapper インタフェース
+// Mapper interface
 interface Mapper<Source, Target> {
   map(source: Source): Target;
   mapMany(sources: Source[]): Target[];
 }
 
-// 双方向 Mapper
+// Bidirectional Mapper
 interface BiMapper<A, B> {
   mapAtoB(a: A): B;
   mapBtoA(b: B): A;
@@ -1717,7 +1721,7 @@ interface BiMapper<A, B> {
   mapManyBtoA(bs: B[]): A[];
 }
 
-// Mapper 作成関数
+// Mapper factory function
 function createMapper<Source, Target>(
   config: MappingConfig<Source, Target>
 ): Mapper<Source, Target> {
@@ -1735,7 +1739,7 @@ function createMapper<Source, Target>(
   };
 }
 
-// 双方向 Mapper 作成関数
+// Bidirectional Mapper factory function
 function createBiMapper<A, B>(
   aToB: MappingConfig<A, B>,
   bToA: MappingConfig<B, A>
@@ -1751,7 +1755,7 @@ function createBiMapper<A, B>(
   };
 }
 
-// === 使用例 ===
+// === Usage example ===
 
 interface RestUser {
   user_id: string;
@@ -1794,32 +1798,32 @@ console.log(domainUser.createdAt instanceof Date); // true
 
 ## 9. FAQ
 
-### Q1: Adapter はレガシーコード以外でも使いますか？
+### Q1: Is the Adapter pattern used outside of legacy code?
 
-はい。Adapter は以下の場面で頻繁に使われます:
-- **外部 API**: REST/GraphQL/gRPC の各APIクライアントの統一
-- **サードパーティライブラリ**: ログ、決済、通知、ストレージ等のベンダー統一
-- **異なるチーム間のモジュール統合**: 内部API のインタフェース不一致の解消
-- **テスト**: 外部依存をモック可能なインタフェースに変換
-- **データ変換**: DTO/Entity/ViewModel 間のマッピング
+Yes. The Adapter is frequently used in the following situations:
+- **External APIs**: Unifying clients for REST/GraphQL/gRPC APIs
+- **Third-party libraries**: Unifying vendors for logging, payments, notifications, storage, etc.
+- **Module integration across different teams**: Resolving interface mismatches in internal APIs
+- **Testing**: Converting external dependencies to mockable interfaces
+- **Data transformation**: Mapping between DTO/Entity/ViewModel
 
-### Q2: TypeScript でアダプタを書くとき、クラスと関数のどちらが良いですか？
+### Q2: When writing an adapter in TypeScript, which is better — a class or a function?
 
-| 条件 | 推奨 |
+| Condition | Recommendation |
 |------|------|
-| 状態管理が不要 | **関数**（高階関数、ラッパー） |
-| 複数メソッドの変換 | **クラス** |
-| ライフサイクル管理が必要 | **クラス** |
-| DI コンテナで管理 | **クラス** |
-| 単純な型変換 | **関数**（`toXxx()` 関数） |
+| No state management needed | **Function** (higher-order function, wrapper) |
+| Converting multiple methods | **Class** |
+| Lifecycle management required | **Class** |
+| Managed by DI container | **Class** |
+| Simple type conversion | **Function** (`toXxx()` function) |
 
-### Q3: Adapter が多数になった場合の管理方法は？
+### Q3: How do you manage a large number of Adapters?
 
-1. **ディレクトリ構成**: `adapters/` ディレクトリに集約
-2. **命名規則**: `XxxAdapter` で統一
-3. **Factory パターン**: 適切な Adapter を自動選択
-4. **DI コンテナ**: インタフェースに対して Adapter を登録
-5. **テスト**: 各 Adapter の変換を単体テストで検証
+1. **Directory structure**: Consolidate in an `adapters/` directory
+2. **Naming conventions**: Use `XxxAdapter` consistently
+3. **Factory pattern**: Automatically select the appropriate Adapter
+4. **DI container**: Register Adapters against their interfaces
+5. **Testing**: Verify each Adapter's conversion with unit tests
 
 ```
 src/
@@ -1837,44 +1841,46 @@ src/
       gcs-adapter.ts
 ```
 
-### Q4: Adapter パターンと依存性逆転の原則（DIP）の関係は？
+### Q4: What is the relationship between the Adapter pattern and the Dependency Inversion Principle (DIP)?
 
-Adapter パターンは DIP の実践そのものです。
+The Adapter pattern is DIP in practice.
 
 ```
-DIP なし（高レベルモジュールが低レベルモジュールに依存）:
-OrderService ──直接依存──> StripeSDK
+Without DIP (high-level module depends on low-level module):
+OrderService ──direct dependency──> StripeSDK
 
-DIP あり（両方が抽象に依存）:
-OrderService ──依存──> PaymentGateway(interface)
-                           △
-                           |  implements
-                     StripeAdapter ──委譲──> StripeSDK
+With DIP (both depend on abstraction):
+OrderService ──depends on──> PaymentGateway(interface)
+                                 △
+                                 |  implements
+                           StripeAdapter ──delegates──> StripeSDK
 ```
 
-高レベルモジュール（OrderService）は抽象（PaymentGateway）にのみ依存し、具象実装（StripeSDK）の詳細を知りません。
+The high-level module (OrderService) depends only on the abstraction (PaymentGateway) and has no knowledge of the concrete implementation details (StripeSDK).
 
-### Q5: Adapter と Bridge パターンの違いは？
+### Q5: What is the difference between Adapter and Bridge pattern?
 
 | | Adapter | Bridge |
 |--|--|--|
-| 目的 | 既存のインタフェースを**事後的に**変換 | 抽象と実装を**事前に**分離 |
-| タイミング | 既存コードに対して適用 | 設計段階で適用 |
-| 変更対象 | Adaptee は変更しない | 実装側を自由に変更 |
-| 関係 | 1:1（1つのAdapteeに1つのAdapter） | 1:N（1つの抽象に複数の実装） |
+| Purpose | **Retroactively** converts an existing interface | **Proactively** separates abstraction from implementation |
+| Timing | Applied to existing code | Applied at the design stage |
+| Change target | Does not change the Adaptee | Implementation side can be freely changed |
+| Relationship | 1:1 (one Adapter per Adaptee) | 1:N (one abstraction, multiple implementations) |
 
-### Q6: マイクロサービス間の通信で Adapter はどう使いますか？
+### Q6: How is the Adapter used in inter-microservice communication?
 
-マイクロサービスでは各サービスが独自のデータフォーマットを持つことが多く、Adapter は Anti-Corruption Layer（腐敗防止層）として機能します:
+In microservices, each service often has its own data format, and the Adapter functions as an Anti-Corruption Layer (ACL):
 
 ```
 Service A                    ACL                    Service B
 ┌──────────┐    REST     ┌──────────────┐    gRPC   ┌──────────┐
 │          │ ──────────> │  Adapter     │ ────────> │          │
-│ Order    │             │ (format変換) │           │ Inventory│
-│ Service  │ <────────── │ (protocol変換)│ <──────── │ Service  │
-└──────────┘             └──────────────┘           └──────────┘
-  JSON format              変換レイヤー               Protobuf format
+│ Order    │             │ (format      │           │ Inventory│
+│ Service  │ <────────── │  conversion) │ <──────── │ Service  │
+└──────────┘             │ (protocol    │           └──────────┘
+  JSON format            │  conversion) │           Protobuf format
+                         └──────────────┘
+                           conversion layer
 ```
 
 ---
@@ -1882,46 +1888,46 @@ Service A                    ACL                    Service B
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just through theory, but by actually writing code and verifying behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this applied in professional practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| **目的** | 互換性のないインタフェースを変換して統合する |
-| **オブジェクトアダプタ** | 委譲ベース（has-a）、**推奨** |
-| **クラスアダプタ** | 継承ベース（is-a）、非推奨 |
-| **適用場面** | 外部ライブラリ、レガシー統合、マルチプロバイダ、テスト |
-| **責務** | **変換のみ** — ビジネスロジックは入れない |
-| **関連パターン** | Factory（Adapter選択）、Strategy（動的切替）、DIP（依存性逆転） |
-| **注意点** | 不要な間接層は避ける、変換は確実にテストする |
+| **Purpose** | Convert and integrate incompatible interfaces |
+| **Object Adapter** | Delegation-based (has-a), **recommended** |
+| **Class Adapter** | Inheritance-based (is-a), not recommended |
+| **Use cases** | External libraries, legacy integration, multi-provider, testing |
+| **Responsibility** | **Conversion only** — do not include business logic |
+| **Related patterns** | Factory (Adapter selection), Strategy (dynamic switching), DIP (dependency inversion) |
+| **Caution** | Avoid unnecessary indirection; always test conversions thoroughly |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [Decorator パターン](./01-decorator.md) — 動的な機能追加（Adapter と構造が似ているが目的が異なる）
-- [Facade パターン](./02-facade.md) — 複雑なサブシステムの単純化
-- [Proxy パターン](./03-proxy.md) — アクセス制御（Adapter と構造が似ている）
-- [Strategy パターン](../02-behavioral/01-strategy.md) — アルゴリズムの交換（Adapter と組み合わせて使う）
-- [Factory パターン](../00-creational/01-factory.md) — 適切な Adapter の選択に使う
-- Bridge パターン — 抽象と実装の分離（Adapter と目的が異なる）
+- [Decorator Pattern](./01-decorator.md) — Dynamic feature addition (similar structure to Adapter, but different purpose)
+- [Facade Pattern](./02-facade.md) — Simplifying complex subsystems
+- [Proxy Pattern](./03-proxy.md) — Access control (similar structure to Adapter)
+- [Strategy Pattern](../02-behavioral/01-strategy.md) — Algorithm replacement (used in combination with Adapter)
+- [Factory Pattern](../00-creational/01-factory.md) — Used to select the appropriate Adapter
+- Bridge Pattern — Separation of abstraction and implementation (different purpose from Adapter)
 
 ---
 
-## 参考文献
+## References
 
 1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley.
 2. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media.

--- a/03-software-design/design-patterns-guide/docs/01-structural/01-decorator.md
+++ b/03-software-design/design-patterns-guide/docs/01-structural/01-decorator.md
@@ -1,39 +1,39 @@
-# Decorator パターン
+# Decorator Pattern
 
-> オブジェクトに **動的に** 新しい機能を追加するための構造パターン。サブクラス化の代替として合成（コンポジション）を用い、機能の自由な組み合わせを実現する。
+> A structural pattern for **dynamically** adding new functionality to objects. It uses composition instead of subclassing to enable flexible combinations of features.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| オブジェクト指向プログラミング | 基礎 | OOP基礎 |
-| インタフェースと抽象クラス | 基礎 | インタフェース設計 |
-| 合成（Composition）と委譲 | 理解 | 合成優先の原則 |
-| 開放閉鎖原則（OCP） | 理解 | SOLID |
-| TypeScript / Python のデコレータ構文 | 基礎 | 各言語ガイド |
+| Object-Oriented Programming | Basic | OOP Basics |
+| Interfaces and Abstract Classes | Basic | Interface Design |
+| Composition and Delegation | Understanding | Composition Over Inheritance |
+| Open/Closed Principle (OCP) | Understanding | SOLID |
+| TypeScript / Python decorator syntax | Basic | Language-specific guides |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. Decorator パターンの**目的**と、なぜ継承ではなく合成で機能拡張するのか
-2. デコレータの**積み重ね（チェーン）** の仕組みと実行順序
-3. GoF の Decorator パターンと言語組み込みのデコレータ構文（TypeScript/Python）の関係
-4. HTTP クライアント・ストリーム処理・React HOC など実践的な活用パターン
-5. デコレータの過剰な積み重ねやインタフェース外依存などのアンチパターン
+1. The **purpose** of the Decorator pattern and why composition is used instead of inheritance for feature extension
+2. The mechanism and execution order of **decorator chaining (stacking)**
+3. The relationship between the GoF Decorator pattern and language-built-in decorator syntax (TypeScript/Python)
+4. Practical usage patterns such as HTTP clients, stream processing, and React HOCs
+5. Anti-patterns such as excessive decorator stacking and dependencies on methods outside the interface
 
 ---
 
-## なぜ Decorator パターンが必要なのか（WHY）
+## Why the Decorator Pattern Is Needed (WHY)
 
-### 問題: 継承による機能追加のクラス爆発
+### Problem: Class Explosion When Adding Features via Inheritance
 
-機能の組み合わせを全て継承で表現すると、クラスの数が爆発的に増加します。
+If you represent every combination of features using inheritance, the number of classes grows exponentially.
 
 ```
-[継承で機能追加する場合 — クラス爆発]
+[When adding features via inheritance — class explosion]
 
                      DataSource
                     /    |     \
@@ -43,10 +43,10 @@
           |
   CompressedEncryptedFileDS
 
-3つの機能の全組み合わせ → 2^3 = 8 クラスが必要
-N個の機能なら 2^N クラスが必要！
+All combinations of 3 features → 2^3 = 8 classes needed
+With N features, 2^N classes are needed!
 
-[Decorator で機能追加する場合 — 線形]
+[When adding features via Decorator — linear]
 
   DataSource (interface)
       △
@@ -60,48 +60,48 @@ N個の機能なら 2^N クラスが必要！
       |─── CompressionDecorator
       |─── LoggingDecorator
 
-3つの機能 → 3+1 = 4 クラスで全組み合わせをカバー
-N個の機能なら N+1 クラスで済む！
+3 features → 3+1 = 4 classes cover all combinations
+With N features, only N+1 classes are needed!
 ```
 
-### Decorator の本質: 入れ子構造による機能合成
+### The Essence of Decorator: Feature Composition via Nesting
 
 ```
-Client の呼び出し:
+Client call:
   source.write("Hello")
 
-実行時のオブジェクト構造:
+Runtime object structure:
 ┌───────────────────────────┐
-│    LoggingDecorator       │  ← ログ出力
+│    LoggingDecorator       │  ← Logging output
 │  ┌───────────────────┐    │
-│  │ CompressionDeco   │    │  ← 圧縮
+│  │ CompressionDeco   │    │  ← Compression
 │  │  ┌─────────────┐  │    │
-│  │  │ EncryptDeco │  │    │  ← 暗号化
+│  │  │ EncryptDeco │  │    │  ← Encryption
 │  │  │  ┌───────┐  │  │    │
-│  │  │  │FileDS │  │  │    │  ← 実処理
+│  │  │  │FileDS │  │  │    │  ← Actual processing
 │  │  │  └───────┘  │  │    │
 │  │  └─────────────┘  │    │
 │  └───────────────────┘    │
 └───────────────────────────┘
 
-write("Hello") の実行順序:
+Execution order for write("Hello"):
   Logging.write()
     → Compression.write()
       → Encryption.write()
-        → FileDS.write()  ← 実際のファイル書き込み
+        → FileDS.write()  ← Actual file write
 ```
 
-このパターンにより:
-- **開放閉鎖原則（OCP）**: 既存コードを変更せずに機能を追加
-- **単一責任原則（SRP）**: 各デコレータが1つの責務だけを担う
-- **実行時の柔軟性**: 機能の組み合わせと順序を実行時に変更可能
-- **テスト容易性**: 各デコレータを個別にテスト可能
+This pattern enables:
+- **Open/Closed Principle (OCP)**: Add features without modifying existing code
+- **Single Responsibility Principle (SRP)**: Each decorator has only one responsibility
+- **Runtime flexibility**: Feature combinations and ordering can be changed at runtime
+- **Testability**: Each decorator can be tested independently
 
 ---
 
-## 1. Decorator の構造
+## 1. Decorator Structure
 
-### クラス図
+### Class Diagram
 
 ```
 +------------------+
@@ -129,37 +129,37 @@ write("Hello") の実行順序:
        +-------------+  +-------------+
        | + operation |  | + operation |
        |  {          |  |  {          |
-       |   // 前処理 |  |   // 前処理 |
+       |   // pre    |  |   // pre    |
        |   super     |  |   super     |
        |   .operation|  |   .operation|
-       |   // 後処理 |  |   // 後処理 |
+       |   // post   |  |   // post   |
        |  }          |  |  }          |
        +-------------+  +-------------+
 ```
 
-### シーケンス図
+### Sequence Diagram
 
 ```
 Client    DecoratorA      DecoratorB      ConcreteComponent
   |           |                |                |
   |--op()---->|                |                |
-  |           |--前処理A       |                |
+  |           |--pre-process A |                |
   |           |--op()--------->|                |
-  |           |                |--前処理B       |
+  |           |                |--pre-process B |
   |           |                |--op()--------->|
-  |           |                |                |--実処理
+  |           |                |                |--actual processing
   |           |                |                |
   |           |                |<--result-------|
-  |           |                |--後処理B       |
+  |           |                |--post-process B|
   |           |<--result-------|                |
-  |           |--後処理A       |                |
+  |           |--post-process A|                |
   |<--result--|                |                |
 ```
 
-### Decorator チェーンの構築
+### Building a Decorator Chain
 
 ```
-// 構築方法1: コンストラクタのネスト
+// Approach 1: Nested constructors
 const source = new LoggingDecorator(
   new CompressionDecorator(
     new EncryptionDecorator(
@@ -168,7 +168,7 @@ const source = new LoggingDecorator(
   )
 );
 
-// 構築方法2: Builder パターンとの組み合わせ
+// Approach 2: Combining with the Builder pattern
 const source = DataSourceBuilder
   .from(new FileDataSource("data.txt"))
   .withEncryption()
@@ -176,7 +176,7 @@ const source = DataSourceBuilder
   .withLogging()
   .build();
 
-// 構築方法3: 関数パイプライン
+// Approach 3: Function pipeline
 const source = pipe(
   new FileDataSource("data.txt"),
   withEncryption,
@@ -187,12 +187,12 @@ const source = pipe(
 
 ---
 
-## 2. コード例
+## 2. Code Examples
 
-### コード例 1: データソース Decorator（基本形）
+### Code Example 1: Data Source Decorator (Basic Form)
 
 ```typescript
-// === Component インタフェース ===
+// === Component Interface ===
 interface DataSource {
   read(): string;
   write(data: string): void;
@@ -215,7 +215,7 @@ class FileDataSource implements DataSource {
   }
 }
 
-// === BaseDecorator（オプション: 共通の委譲ロジック）===
+// === BaseDecorator (optional: common delegation logic) ===
 abstract class DataSourceDecorator implements DataSource {
   constructor(protected wrapped: DataSource) {}
 
@@ -228,7 +228,7 @@ abstract class DataSourceDecorator implements DataSource {
   }
 }
 
-// === ConcreteDecorator 1: 暗号化 ===
+// === ConcreteDecorator 1: Encryption ===
 class EncryptionDecorator extends DataSourceDecorator {
   read(): string {
     const data = super.read();
@@ -252,7 +252,7 @@ class EncryptionDecorator extends DataSourceDecorator {
   }
 }
 
-// === ConcreteDecorator 2: 圧縮 ===
+// === ConcreteDecorator 2: Compression ===
 class CompressionDecorator extends DataSourceDecorator {
   read(): string {
     const data = super.read();
@@ -276,7 +276,7 @@ class CompressionDecorator extends DataSourceDecorator {
   }
 }
 
-// === ConcreteDecorator 3: ログ ===
+// === ConcreteDecorator 3: Logging ===
 class LoggingDecorator extends DataSourceDecorator {
   read(): string {
     console.log("[LOG] read() called");
@@ -294,7 +294,7 @@ class LoggingDecorator extends DataSourceDecorator {
   }
 }
 
-// === 使用例: デコレータの積み重ね ===
+// === Usage: Stacking decorators ===
 const source: DataSource = new LoggingDecorator(
   new CompressionDecorator(
     new EncryptionDecorator(
@@ -320,7 +320,7 @@ const data = source.read();
 
 ---
 
-### コード例 2: HTTP クライアント Decorator
+### Code Example 2: HTTP Client Decorator
 
 ```typescript
 // === Component ===
@@ -334,7 +334,7 @@ class FetchClient implements HttpClient {
   }
 }
 
-// === Decorator 1: リトライ ===
+// === Decorator 1: Retry ===
 class RetryDecorator implements HttpClient {
   constructor(
     private client: HttpClient,
@@ -362,7 +362,7 @@ class RetryDecorator implements HttpClient {
   }
 }
 
-// === Decorator 2: タイムアウト ===
+// === Decorator 2: Timeout ===
 class TimeoutDecorator implements HttpClient {
   constructor(private client: HttpClient, private timeoutMs = 5000) {}
 
@@ -381,7 +381,7 @@ class TimeoutDecorator implements HttpClient {
   }
 }
 
-// === Decorator 3: ロギング ===
+// === Decorator 3: Logging ===
 class LoggingHttpDecorator implements HttpClient {
   constructor(private client: HttpClient) {}
 
@@ -401,7 +401,7 @@ class LoggingHttpDecorator implements HttpClient {
   }
 }
 
-// === Decorator 4: 認証ヘッダー追加 ===
+// === Decorator 4: Add auth header ===
 class AuthDecorator implements HttpClient {
   constructor(
     private client: HttpClient,
@@ -416,7 +416,7 @@ class AuthDecorator implements HttpClient {
   }
 }
 
-// === Decorator 5: サーキットブレーカー ===
+// === Decorator 5: Circuit Breaker ===
 class CircuitBreakerDecorator implements HttpClient {
   private failures = 0;
   private lastFailure = 0;
@@ -462,7 +462,7 @@ class CircuitBreakerDecorator implements HttpClient {
   }
 }
 
-// === 組み立て ===
+// === Assembly ===
 const httpClient: HttpClient = new LoggingHttpDecorator(
   new CircuitBreakerDecorator(
     new RetryDecorator(
@@ -478,18 +478,18 @@ const httpClient: HttpClient = new LoggingHttpDecorator(
   )
 );
 
-// 実行順: Logging → CircuitBreaker → Retry → Timeout → Auth → Fetch
+// Execution order: Logging → CircuitBreaker → Retry → Timeout → Auth → Fetch
 ```
 
 ---
 
-### コード例 3: TypeScript TC39 デコレータ構文（Stage 3）
+### Code Example 3: TypeScript TC39 Decorator Syntax (Stage 3)
 
 ```typescript
 // TC39 Stage 3 Decorators (TypeScript 5+)
-// GoF の Decorator パターンとは異なるが、動機は共通
+// Different from the GoF Decorator pattern, but shares the same motivation
 
-// === メソッドデコレータ: ログ出力 ===
+// === Method decorator: Logging ===
 function logged(
   target: any,
   context: ClassMethodDecoratorContext
@@ -503,7 +503,7 @@ function logged(
   };
 }
 
-// === メソッドデコレータ: パフォーマンス計測 ===
+// === Method decorator: Performance measurement ===
 function timed(
   target: any,
   context: ClassMethodDecoratorContext
@@ -518,7 +518,7 @@ function timed(
   };
 }
 
-// === メソッドデコレータ: メモ化 ===
+// === Method decorator: Memoization ===
 function memoize(
   target: any,
   context: ClassMethodDecoratorContext
@@ -533,14 +533,14 @@ function memoize(
   };
 }
 
-// === メソッドデコレータ: バリデーション ===
+// === Method decorator: Validation ===
 function validate(schema: Record<string, (v: any) => boolean>) {
   return function (
     target: any,
     context: ClassMethodDecoratorContext
   ) {
     return function (this: any, ...args: any[]) {
-      // 最初の引数がオブジェクトの場合バリデーション
+      // Validate if first argument is an object
       const input = args[0];
       if (typeof input === "object" && input !== null) {
         for (const [key, validator] of Object.entries(schema)) {
@@ -554,7 +554,7 @@ function validate(schema: Record<string, (v: any) => boolean>) {
   };
 }
 
-// === 使用例 ===
+// === Usage ===
 class Calculator {
   @logged
   @timed
@@ -582,7 +582,7 @@ class UserService {
 
 ---
 
-### コード例 4: Python デコレータ（関数デコレータ + クラスデコレータ）
+### Code Example 4: Python Decorators (Function Decorators + Class Decorators)
 
 ```python
 import functools
@@ -593,9 +593,9 @@ from typing import Callable, TypeVar, ParamSpec
 P = ParamSpec("P")
 R = TypeVar("R")
 
-# === 関数デコレータ: リトライ ===
+# === Function decorator: Retry ===
 def retry(max_retries: int = 3, delay: float = 1.0, exceptions: tuple = (Exception,)):
-    """指定回数までリトライするデコレータ"""
+    """Decorator that retries up to the specified number of times"""
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -617,9 +617,9 @@ def retry(max_retries: int = 3, delay: float = 1.0, exceptions: tuple = (Excepti
     return decorator
 
 
-# === 関数デコレータ: 実行時間計測 ===
+# === Function decorator: Execution time measurement ===
 def timed(func: Callable[P, R]) -> Callable[P, R]:
-    """実行時間を計測するデコレータ"""
+    """Decorator that measures execution time"""
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         start = time.perf_counter()
@@ -630,9 +630,9 @@ def timed(func: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
-# === 関数デコレータ: キャッシュ（TTL付き）===
+# === Function decorator: Cache with TTL ===
 def cache_with_ttl(ttl_seconds: float = 60.0):
-    """TTL付きキャッシュデコレータ"""
+    """Cache decorator with TTL"""
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         _cache: dict[str, tuple[R, float]] = {}
 
@@ -650,9 +650,9 @@ def cache_with_ttl(ttl_seconds: float = 60.0):
     return decorator
 
 
-# === 関数デコレータ: 入力バリデーション ===
+# === Function decorator: Input validation ===
 def validate_args(**validators: Callable):
-    """引数のバリデーションデコレータ"""
+    """Argument validation decorator"""
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -673,11 +673,11 @@ def validate_args(**validators: Callable):
     return decorator
 
 
-# === 使用例 ===
+# === Usage ===
 @retry(max_retries=3, delay=0.5, exceptions=(ConnectionError, TimeoutError))
 @timed
 def fetch_data(url: str) -> dict:
-    """外部APIからデータを取得"""
+    """Fetch data from an external API"""
     import urllib.request
     response = urllib.request.urlopen(url)
     return {"status": response.status}
@@ -685,7 +685,7 @@ def fetch_data(url: str) -> dict:
 
 @cache_with_ttl(ttl_seconds=300)
 def get_config(key: str) -> str:
-    """設定値を取得（キャッシュ付き）"""
+    """Retrieve a configuration value (with cache)"""
     return f"value_for_{key}"
 
 
@@ -697,9 +697,9 @@ def create_user(name: str, age: int) -> dict:
     return {"name": name, "age": age}
 
 
-# クラスデコレータ: Singleton
+# Class decorator: Singleton
 def singleton(cls):
-    """シングルトンにするクラスデコレータ"""
+    """Class decorator that makes a class a singleton"""
     instances: dict = {}
 
     @functools.wraps(cls)
@@ -720,12 +720,12 @@ class DatabaseConnection:
 
 ---
 
-### コード例 5: React Higher-Order Component（HOC）as Decorator
+### Code Example 5: React Higher-Order Component (HOC) as Decorator
 
 ```typescript
 import React, { ComponentType, useEffect, useState } from "react";
 
-// === HOC 1: ローディング状態の追加 ===
+// === HOC 1: Adding loading state ===
 function withLoading<P extends object>(
   WrappedComponent: ComponentType<P>
 ): ComponentType<P & { isLoading?: boolean }> {
@@ -738,7 +738,7 @@ function withLoading<P extends object>(
   };
 }
 
-// === HOC 2: 認証ガード ===
+// === HOC 2: Auth guard ===
 function withAuth<P extends object>(
   WrappedComponent: ComponentType<P>
 ): ComponentType<P> {
@@ -751,7 +751,7 @@ function withAuth<P extends object>(
   };
 }
 
-// === HOC 3: エラーバウンダリ ===
+// === HOC 3: Error boundary ===
 function withErrorBoundary<P extends object>(
   WrappedComponent: ComponentType<P>,
   FallbackComponent: ComponentType<{ error: Error }>
@@ -772,7 +772,7 @@ function withErrorBoundary<P extends object>(
   };
 }
 
-// === HOC 4: パフォーマンストラッキング ===
+// === HOC 4: Performance tracking ===
 function withPerformanceTracking<P extends object>(
   WrappedComponent: ComponentType<P>,
   componentName: string
@@ -789,12 +789,12 @@ function withPerformanceTracking<P extends object>(
   };
 }
 
-// === 積み重ね ===
+// === Stacking ===
 const UserList: React.FC<{ users: User[] }> = ({ users }) => (
   <ul>{users.map(u => <li key={u.id}>{u.name}</li>)}</ul>
 );
 
-// デコレータの積み重ね（外側から内側へ適用）
+// Stacking decorators (applied from outer to inner)
 const EnhancedUserList = withErrorBoundary(
   withAuth(
     withLoading(
@@ -804,13 +804,13 @@ const EnhancedUserList = withErrorBoundary(
   ErrorFallback
 );
 
-// 現代の React では Hooks が主流だが、
-// HOC は条件付きレンダリングや Provider ラッピングでは依然有効
+// In modern React, Hooks are mainstream, but
+// HOCs remain valid for conditional rendering and Provider wrapping
 ```
 
 ---
 
-### コード例 6: Go — ミドルウェアパターン（Decorator の変形）
+### Code Example 6: Go — Middleware Pattern (Variant of Decorator)
 
 ```go
 package main
@@ -822,10 +822,10 @@ import (
     "time"
 )
 
-// === Middleware 型（Decorator の Go イディオム）===
+// === Middleware type (Go idiom for Decorator) ===
 type Middleware func(http.Handler) http.Handler
 
-// === Middleware 1: ロギング ===
+// === Middleware 1: Logging ===
 func LoggingMiddleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         start := time.Now()
@@ -835,7 +835,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
     })
 }
 
-// === Middleware 2: 認証 ===
+// === Middleware 2: Authentication ===
 func AuthMiddleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         token := r.Header.Get("Authorization")
@@ -847,7 +847,7 @@ func AuthMiddleware(next http.Handler) http.Handler {
     })
 }
 
-// === Middleware 3: リカバリ ===
+// === Middleware 3: Recovery ===
 func RecoveryMiddleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         defer func() {
@@ -860,22 +860,22 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
     })
 }
 
-// === Middleware チェーン ===
+// === Middleware chain ===
 func Chain(handler http.Handler, middlewares ...Middleware) http.Handler {
-    // 逆順に適用（最初に指定したミドルウェアが最外側）
+    // Apply in reverse order (first specified middleware is outermost)
     for i := len(middlewares) - 1; i >= 0; i-- {
         handler = middlewaresi
     }
     return handler
 }
 
-// === 使用例 ===
+// === Usage ===
 func main() {
     handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         fmt.Fprintln(w, "Hello, World!")
     })
 
-    // デコレータの積み重ね
+    // Stacking decorators
     enhanced := Chain(handler,
         RecoveryMiddleware,
         LoggingMiddleware,
@@ -889,18 +889,18 @@ func main() {
 
 ---
 
-### コード例 7: Java — I/O Streams（標準ライブラリの Decorator）
+### Code Example 7: Java — I/O Streams (Decorator in the Standard Library)
 
 ```java
 import java.io.*;
 
-// Java の I/O ストリームは Decorator パターンの典型例
+// Java's I/O streams are a classic example of the Decorator pattern
 
 public class JavaIODecoratorExample {
 
-    // === 読み込みの Decorator チェーン ===
+    // === Read Decorator chain ===
     public static void readExample() throws IOException {
-        // InputStream 階層:
+        // InputStream hierarchy:
         //   BufferedInputStream(Decorator)
         //     → DataInputStream(Decorator)
         //       → FileInputStream(ConcreteComponent)
@@ -914,9 +914,9 @@ public class JavaIODecoratorExample {
         }
     }
 
-    // === 書き込みの Decorator チェーン ===
+    // === Write Decorator chain ===
     public static void writeExample() throws IOException {
-        // OutputStream 階層:
+        // OutputStream hierarchy:
         //   BufferedOutputStream(Decorator)
         //     → GZIPOutputStream(Decorator)
         //       → FileOutputStream(ConcreteComponent)
@@ -928,7 +928,7 @@ public class JavaIODecoratorExample {
         }
     }
 
-    // === カスタム Decorator ===
+    // === Custom Decorator ===
     static class CountingInputStream extends FilterInputStream {
         private long bytesRead = 0;
 
@@ -959,10 +959,10 @@ public class JavaIODecoratorExample {
 
 ---
 
-### コード例 8: Kotlin — 拡張関数とデコレータ
+### Code Example 8: Kotlin — Extension Functions and Decorator
 
 ```kotlin
-// Kotlin のデリゲーションパターンで Decorator を実装
+// Implementing Decorator with Kotlin's delegation pattern
 
 interface Logger {
     fun log(level: String, message: String)
@@ -976,7 +976,7 @@ class ConsoleLogger : Logger {
     override fun close() {}
 }
 
-// Kotlin の by キーワードによるデリゲーション
+// Delegation via Kotlin's by keyword
 class TimestampLogger(private val inner: Logger) : Logger by inner {
     override fun log(level: String, message: String) {
         val timestamp = java.time.LocalDateTime.now()
@@ -997,29 +997,29 @@ class FilterLogger(
     }
 }
 
-// 積み重ね
+// Stacking
 fun main() {
     val logger: Logger = FilterLogger(
         TimestampLogger(ConsoleLogger()),
         "INFO"
     )
 
-    logger.log("DEBUG", "This will be filtered")  // 出力なし
-    logger.log("INFO", "Application started")      // 出力あり
-    logger.log("ERROR", "Something went wrong")    // 出力あり
+    logger.log("DEBUG", "This will be filtered")  // No output
+    logger.log("INFO", "Application started")      // Output
+    logger.log("ERROR", "Something went wrong")    // Output
 }
 ```
 
 ---
 
-### コード例 9: 関数合成による軽量 Decorator
+### Code Example 9: Lightweight Decorator via Function Composition
 
 ```typescript
-// クラスを使わず、関数合成でデコレータを実現
+// Achieving decorators via function composition without classes
 
 type AsyncFn<T> = (...args: any[]) => Promise<T>;
 
-// === Decorator Factory 関数 ===
+// === Decorator Factory functions ===
 function withRetry<T>(fn: AsyncFn<T>, maxRetries = 3): AsyncFn<T> {
   return async (...args) => {
     for (let i = 0; i <= maxRetries; i++) {
@@ -1058,7 +1058,7 @@ function withLogging<T>(fn: AsyncFn<T>, name: string): AsyncFn<T> {
   };
 }
 
-// === pipe ユーティリティ ===
+// === pipe utility ===
 function pipe<T>(
   fn: AsyncFn<T>,
   ...decorators: Array<(fn: AsyncFn<T>) => AsyncFn<T>>
@@ -1066,13 +1066,13 @@ function pipe<T>(
   return decorators.reduce((acc, decorator) => decorator(acc), fn);
 }
 
-// === 使用例 ===
+// === Usage ===
 async function fetchUser(id: string): Promise<{ name: string }> {
   const res = await fetch(`/api/users/${id}`);
   return res.json();
 }
 
-// 関数合成でデコレータを積み重ね
+// Stacking decorators via function composition
 const enhancedFetchUser = pipe(
   fetchUser,
   fn => withTimeout(fn, 5000),
@@ -1085,7 +1085,7 @@ const user = await enhancedFetchUser("123");
 
 ---
 
-### コード例 10: Node.js Stream Transform（実践的 Decorator）
+### Code Example 10: Node.js Stream Transform (Practical Decorator)
 
 ```typescript
 import { Transform, TransformCallback, Readable, pipeline } from "stream";
@@ -1093,7 +1093,7 @@ import { promisify } from "util";
 
 const pipelineAsync = promisify(pipeline);
 
-// === Transform 1: JSON パース ===
+// === Transform 1: JSON parsing ===
 class JsonParseTransform extends Transform {
   constructor() {
     super({ objectMode: true });
@@ -1110,7 +1110,7 @@ class JsonParseTransform extends Transform {
   }
 }
 
-// === Transform 2: フィルタリング ===
+// === Transform 2: Filtering ===
 class FilterTransform extends Transform {
   constructor(private predicate: (item: any) => boolean) {
     super({ objectMode: true });
@@ -1124,7 +1124,7 @@ class FilterTransform extends Transform {
   }
 }
 
-// === Transform 3: マッピング ===
+// === Transform 3: Mapping ===
 class MapTransform extends Transform {
   constructor(private mapper: (item: any) => any) {
     super({ objectMode: true });
@@ -1140,7 +1140,7 @@ class MapTransform extends Transform {
   }
 }
 
-// === Transform 4: バッチ集約 ===
+// === Transform 4: Batch aggregation ===
 class BatchTransform extends Transform {
   private buffer: any[] = [];
 
@@ -1165,70 +1165,70 @@ class BatchTransform extends Transform {
   }
 }
 
-// === パイプラインでデコレータをチェーン ===
+// === Chaining decorators with a pipeline ===
 async function processLogs(): Promise<void> {
   await pipelineAsync(
-    Readable.from(logLines),           // ソース
-    new JsonParseTransform(),           // JSON パース（Decorator 1）
-    new FilterTransform(                // フィルタ（Decorator 2）
+    Readable.from(logLines),           // Source
+    new JsonParseTransform(),           // JSON parsing (Decorator 1)
+    new FilterTransform(                // Filtering (Decorator 2)
       log => log.level === "error"
     ),
-    new MapTransform(                   // 変換（Decorator 3）
+    new MapTransform(                   // Transformation (Decorator 3)
       log => ({ message: log.message, timestamp: log.ts })
     ),
-    new BatchTransform(100),            // バッチ（Decorator 4）
-    createWriteStream("errors.jsonl")   // 出力先
+    new BatchTransform(100),            // Batching (Decorator 4)
+    createWriteStream("errors.jsonl")   // Output destination
   );
 }
 ```
 
 ---
 
-## 3. 比較表
+## 3. Comparison Tables
 
-### 比較表 1: Decorator vs 継承
+### Comparison Table 1: Decorator vs Inheritance
 
-| 観点 | Decorator（合成） | 継承 |
+| Aspect | Decorator (Composition) | Inheritance |
 |------|:---:|:---:|
-| 機能追加タイミング | **実行時（動的）** | コンパイル時（静的） |
-| 組み合わせ | **自由に積み重ね可能** | クラス爆発 |
-| 既存コード変更 | **不要** | サブクラス追加 |
-| OCP 準拠 | **Yes** | 部分的 |
-| SRP 準拠 | **Yes**（1デコレータ=1責務） | 違反しやすい |
-| デバッグ | スタックトレースが深い | **直感的** |
-| パフォーマンス | 間接呼び出しコスト | **直接呼び出し** |
-| 型安全性 | **インタフェースで保証** | 継承階層で保証 |
+| When features are added | **Runtime (dynamic)** | Compile time (static) |
+| Combinations | **Freely stackable** | Class explosion |
+| Modifying existing code | **Not required** | Subclass must be added |
+| OCP compliance | **Yes** | Partial |
+| SRP compliance | **Yes** (1 decorator = 1 responsibility) | Easily violated |
+| Debugging | Stack traces are deep | **Intuitive** |
+| Performance | Indirect call overhead | **Direct calls** |
+| Type safety | **Guaranteed by interface** | Guaranteed by inheritance hierarchy |
 
-### 比較表 2: GoF Decorator vs 言語デコレータ構文
+### Comparison Table 2: GoF Decorator vs Language Decorator Syntax
 
-| 観点 | GoF Decorator パターン | TypeScript/Python デコレータ |
+| Aspect | GoF Decorator Pattern | TypeScript/Python Decorators |
 |------|:---:|:---:|
-| **適用対象** | オブジェクト（インスタンス） | クラス/メソッド/プロパティ |
-| **適用タイミング** | **実行時**（動的） | **定義時**（静的） |
-| **インタフェース維持** | **明示的に保証** | 暗黙的 |
-| **積み重ね** | コンストラクタのネスト | `@` 構文の積み重ね |
-| **主な用途** | 機能のラッピング | メタプログラミング、AOP |
-| **状態管理** | デコレータがフィールドを持てる | クロージャで保持 |
-| **テスト** | 個別にテスト可能 | 関数単位でテスト |
+| **Target** | Objects (instances) | Classes/methods/properties |
+| **When applied** | **Runtime** (dynamic) | **Definition time** (static) |
+| **Interface preservation** | **Explicitly guaranteed** | Implicit |
+| **Stacking** | Nested constructors | `@` syntax stacking |
+| **Primary use** | Feature wrapping | Metaprogramming, AOP |
+| **State management** | Decorator can hold fields | Held via closure |
+| **Testing** | Each testable individually | Testable per function |
 
-### 比較表 3: Decorator vs Proxy vs Adapter
+### Comparison Table 3: Decorator vs Proxy vs Adapter
 
-| 観点 | Decorator | Proxy | Adapter |
+| Aspect | Decorator | Proxy | Adapter |
 |------|:---:|:---:|:---:|
-| **目的** | 機能**追加** | アクセス**制御** | インタフェース**変換** |
-| **インタフェース** | **同じ** | **同じ** | **変換** |
-| **積み重ね** | **可能** | 通常1層 | 通常1層 |
-| **RealSubject管理** | 外部から受け取る | **自身で管理** | 外部から受け取る |
-| **OCP** | **準拠** | 準拠 | 準拠 |
+| **Purpose** | Feature **addition** | Access **control** | Interface **conversion** |
+| **Interface** | **Same** | **Same** | **Converted** |
+| **Stacking** | **Possible** | Usually 1 layer | Usually 1 layer |
+| **RealSubject management** | Received from outside | **Managed internally** | Received from outside |
+| **OCP** | **Compliant** | Compliant | Compliant |
 
 ---
 
-## 4. アンチパターン
+## 4. Anti-Patterns
 
-### アンチパターン 1: デコレータの過剰な積み重ね
+### Anti-Pattern 1: Excessive Decorator Stacking
 
 ```typescript
-// NG: 5層以上のデコレータ → デバッグ困難
+// NG: 5+ layers of decorators → hard to debug
 const client = new MetricsDecorator(
   new CircuitBreakerDecorator(
     new RetryDecorator(
@@ -1244,11 +1244,11 @@ const client = new MetricsDecorator(
     )
   )
 );
-// 7層のネスト → スタックトレースが非常に深い
+// 7 layers of nesting → very deep stack traces
 ```
 
 ```typescript
-// OK: ミドルウェアパターンやパイプラインで宣言的に構成
+// OK: Declare configuration using middleware pattern or pipeline
 const client = createHttpClient({
   middlewares: [
     metrics(),
@@ -1264,15 +1264,15 @@ const client = createHttpClient({
 
 ---
 
-### アンチパターン 2: デコレータがインタフェース外のメソッドに依存
+### Anti-Pattern 2: Decorator Depending on Methods Outside the Interface
 
 ```typescript
-// NG: Component インタフェースにない getFilename() にキャストしてアクセス
+// NG: Accessing getFilename() by casting to a type not in the Component interface
 class BadCachingDecorator implements DataSource {
   constructor(private wrapped: DataSource) {}
 
   read(): string {
-    // 具象クラスに依存 → Decorator パターンの利点が失われる
+    // Depends on concrete class → loses the benefits of the Decorator pattern
     const name = (this.wrapped as FileDataSource).getFilename();
     const cached = this.cache.get(name);
     if (cached) return cached;
@@ -1286,7 +1286,7 @@ class BadCachingDecorator implements DataSource {
 ```
 
 ```typescript
-// OK: Component インタフェースのみに依存
+// OK: Depend only on the Component interface
 class GoodCachingDecorator implements DataSource {
   private cachedData: string | null = null;
 
@@ -1299,7 +1299,7 @@ class GoodCachingDecorator implements DataSource {
   }
 
   write(data: string): void {
-    this.cachedData = null; // キャッシュ無効化
+    this.cachedData = null; // Invalidate cache
     this.wrapped.write(data);
   }
 }
@@ -1307,31 +1307,31 @@ class GoodCachingDecorator implements DataSource {
 
 ---
 
-### アンチパターン 3: デコレータ順序の暗黙的な依存
+### Anti-Pattern 3: Implicit Order Dependencies Between Decorators
 
 ```typescript
-// NG: デコレータの順序を間違えると壊れる
-// 暗号化してから圧縮すると、暗号化データは圧縮効率が悪い
+// NG: Wrong decorator order causes breakage
+// Compressing after encryption yields poor compression efficiency
 
-// 悪い順序（暗号化 → 圧縮: 圧縮効率が悪い）
+// Bad order (encrypt → compress: poor compression)
 const bad = new CompressionDecorator(
   new EncryptionDecorator(new FileDataSource("data.txt"))
 );
 
-// 良い順序（圧縮 → 暗号化: 圧縮効率が良い）
+// Good order (compress → encrypt: better compression)
 const good = new EncryptionDecorator(
   new CompressionDecorator(new FileDataSource("data.txt"))
 );
 ```
 
 ```typescript
-// OK: Builder パターンで順序を制御し、ドキュメント化する
+// OK: Control order with the Builder pattern and document it
 class DataSourceBuilder {
   private decorators: Array<(ds: DataSource) => DataSource> = [];
 
   constructor(private base: DataSource) {}
 
-  // 圧縮 → 暗号化の順序を Builder が保証
+  // Builder guarantees the order: compress → encrypt
   withCompressionAndEncryption(): this {
     this.decorators.push(ds => new CompressionDecorator(ds));
     this.decorators.push(ds => new EncryptionDecorator(ds));
@@ -1354,12 +1354,12 @@ class DataSourceBuilder {
 
 ---
 
-## 5. エッジケースと注意点
+## 5. Edge Cases and Caveats
 
-### エッジケース 1: デコレータ内での例外処理
+### Edge Case 1: Exception Handling Inside a Decorator
 
 ```typescript
-// デコレータが例外を握りつぶすと、デバッグが困難になる
+// Swallowing exceptions in a decorator makes debugging very difficult
 class SafeDecorator implements DataSource {
   constructor(private wrapped: DataSource) {}
 
@@ -1367,10 +1367,10 @@ class SafeDecorator implements DataSource {
     try {
       return this.wrapped.read();
     } catch (error) {
-      // NG: 例外を握りつぶして空文字を返す
+      // NG: Swallow the exception and return an empty string
       // return "";
 
-      // OK: ログを出力してから再 throw
+      // OK: Log the error and re-throw
       console.error("Read failed:", error);
       throw error;
     }
@@ -1382,34 +1382,34 @@ class SafeDecorator implements DataSource {
 }
 ```
 
-### エッジケース 2: デコレータの等価性とアイデンティティ
+### Edge Case 2: Decorator Equality and Identity
 
 ```typescript
 const base = new FileDataSource("data.txt");
 const decorated = new LoggingDecorator(base);
 
-// デコレータは元のオブジェクトとは別のインスタンス
+// The decorator is a separate instance from the original object
 console.log(decorated === base);           // false
 console.log(decorated instanceof FileDataSource); // false
 
-// Set や Map のキーとして使う場合に注意
+// Be careful when using as keys in Set or Map
 const set = new Set<DataSource>();
 set.add(base);
 set.add(decorated);
-console.log(set.size); // 2（同じ base を指すが別オブジェクト）
+console.log(set.size); // 2 (points to same base but different objects)
 ```
 
-### エッジケース 3: 非同期デコレータの順序保証
+### Edge Case 3: Ordering Guarantees in Async Decorators
 
 ```typescript
-// 非同期デコレータでは、前後処理の順序に注意
+// Be careful about the order of pre/post processing in async decorators
 class AsyncLoggingDecorator implements AsyncDataSource {
   constructor(private wrapped: AsyncDataSource) {}
 
   async read(): Promise<string> {
     console.log("Before read");
     const result = await this.wrapped.read();
-    console.log("After read"); // await の後なので確実に後処理
+    console.log("After read"); // After await, so post-processing is guaranteed
     return result;
   }
 }
@@ -1417,56 +1417,59 @@ class AsyncLoggingDecorator implements AsyncDataSource {
 
 ---
 
-## 6. トレードオフ分析
+## 6. Trade-off Analysis
 
 ```
-[使うべき場面] ✅
+[When to use] ✅
 ┌─────────────────────────────────────────────────┐
-│ 1. 機能の自由な組み合わせが必要                   │
-│    例: ストリーム処理、HTTP ミドルウェア           │
+│ 1. Need free combinations of features            │
+│    e.g., stream processing, HTTP middleware      │
 │                                                  │
-│ 2. 既存コードを変更せずに機能追加したい           │
-│    例: サードパーティライブラリの拡張             │
+│ 2. Want to add features without changing         │
+│    existing code                                 │
+│    e.g., extending third-party libraries         │
 │                                                  │
-│ 3. 横断的関心事の分離                             │
-│    例: ログ、キャッシュ、認証、リトライ           │
+│ 3. Separation of cross-cutting concerns          │
+│    e.g., logging, caching, auth, retry           │
 │                                                  │
-│ 4. 実行時に機能の ON/OFF を切り替えたい           │
-│    例: フィーチャーフラグ、設定ベースの切替       │
+│ 4. Want to toggle features ON/OFF at runtime     │
+│    e.g., feature flags, config-based switching   │
 └─────────────────────────────────────────────────┘
 
-[使うべきでない場面] ❌
+[When not to use] ❌
 ┌─────────────────────────────────────────────────┐
-│ 1. 機能の組み合わせが固定的                       │
-│    → 継承やメソッドの直接追加の方がシンプル       │
+│ 1. Feature combinations are fixed                │
+│    → Inheritance or direct method addition       │
+│      is simpler                                  │
 │                                                  │
-│ 2. デコレータの順序が重要で間違えやすい           │
-│    → 順序を強制する仕組み（Builder等）が必要     │
+│ 2. Decorator order is critical and error-prone   │
+│    → Need a mechanism to enforce order           │
+│      (e.g., Builder)                             │
 │                                                  │
-│ 3. パフォーマンスが最重要                         │
-│    → 間接呼び出しのオーバーヘッドが問題          │
+│ 3. Performance is the top priority               │
+│    → Indirect call overhead is a concern         │
 │                                                  │
-│ 4. チーム全員がパターンを理解していない           │
-│    → 可読性が低下する                            │
+│ 4. Not all team members understand the pattern   │
+│    → Readability may decrease                    │
 └─────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 7. 演習問題
+## 7. Exercises
 
-### 演習 1（基礎）: テキスト変換 Decorator
+### Exercise 1 (Basic): Text Transformation Decorator
 
-`TextProcessor` インタフェースに対して3つのデコレータを実装してください。
+Implement three decorators for the `TextProcessor` interface.
 
-**要件**:
+**Requirements**:
 - `TextProcessor`: `process(text: string): string`
-- `UpperCaseDecorator`: 全て大文字に変換
-- `TrimDecorator`: 前後の空白を除去
-- `CensorDecorator`: 指定した単語を `***` に置換
+- `UpperCaseDecorator`: Convert all characters to uppercase
+- `TrimDecorator`: Remove leading and trailing whitespace
+- `CensorDecorator`: Replace specified words with `***`
 
 ```typescript
-// テスト
+// Test
 const processor: TextProcessor = new CensorDecorator(
   new TrimDecorator(
     new UpperCaseDecorator(
@@ -1480,10 +1483,10 @@ console.log(processor.process("  Hello bad World  "));
 // "HELLO *** WORLD"
 ```
 
-**期待される出力**: `HELLO *** WORLD`
+**Expected output**: `HELLO *** WORLD`
 
 <details>
-<summary>解答例</summary>
+<summary>Sample Solution</summary>
 
 ```typescript
 interface TextProcessor {
@@ -1531,19 +1534,19 @@ console.log(processor.process("  Hello bad World  ")); // "HELLO *** WORLD"
 
 ---
 
-### 演習 2（応用）: HTTP クライアント Decorator チェーン
+### Exercise 2 (Applied): HTTP Client Decorator Chain
 
-以下のデコレータを組み合わせて堅牢な HTTP クライアントを構築してください。
+Build a robust HTTP client by combining the following decorators.
 
-**要件**:
-- `HttpClient` インタフェース: `get(url): Promise<Response>`
-- `RetryDecorator`: 指数バックオフでリトライ
-- `CacheDecorator`: TTL 付きキャッシュ
-- `LoggingDecorator`: リクエスト/レスポンスログ
-- 適切な順序で積み重ねること
+**Requirements**:
+- `HttpClient` interface: `get(url): Promise<Response>`
+- `RetryDecorator`: Retry with exponential backoff
+- `CacheDecorator`: Cache with TTL
+- `LoggingDecorator`: Request/response logging
+- Stack them in the appropriate order
 
 <details>
-<summary>解答例</summary>
+<summary>Sample Solution</summary>
 
 ```typescript
 interface HttpClient {
@@ -1606,18 +1609,18 @@ const client = new LoggingDecorator(
 
 ---
 
-### 演習 3（上級）: 型安全な Decorator Builder
+### Exercise 3 (Advanced): Type-Safe Decorator Builder
 
-デコレータの積み重ねを型安全に構築できる Builder を実装してください。
+Implement a Builder that can construct a stack of decorators in a type-safe manner.
 
-**要件**:
-- `DecoratorBuilder<T>` クラス
-- `wrap(decorator)` メソッドでデコレータを追加
-- `build()` で最終的なデコレートされたオブジェクトを返す
-- TypeScript の型推論で、build() の戻り値型が正しく推論される
+**Requirements**:
+- `DecoratorBuilder<T>` class
+- `wrap(decorator)` method to add a decorator
+- `build()` returns the final decorated object
+- TypeScript type inference correctly infers the return type of `build()`
 
 <details>
-<summary>解答例</summary>
+<summary>Sample Solution</summary>
 
 ```typescript
 class DecoratorBuilder<T> {
@@ -1642,7 +1645,7 @@ class DecoratorBuilder<T> {
   }
 }
 
-// 使用例
+// Usage
 const source = DecoratorBuilder.from<DataSource>(new FileDataSource("data.txt"))
   .wrap(ds => new EncryptionDecorator(ds))
   .wrap(ds => new CompressionDecorator(ds))
@@ -1655,93 +1658,93 @@ const source = DecoratorBuilder.from<DataSource>(new FileDataSource("data.txt"))
 
 ## 8. FAQ
 
-### Q1: Decorator と Proxy の違いは何ですか？
+### Q1: What is the difference between Decorator and Proxy?
 
-構造は同じ（wrapped オブジェクトに委譲）ですが、**意図が異なります**:
-- **Decorator**: 機能を**追加**する（ログ、圧縮、暗号化）
-- **Proxy**: アクセスを**制御**する（遅延初期化、権限チェック、キャッシュ）
+The structure is the same (delegation to a wrapped object), but **the intent differs**:
+- **Decorator**: **Adds** functionality (logging, compression, encryption)
+- **Proxy**: **Controls** access (lazy initialization, permission checks, caching)
 
-実用上は区別が曖昧になることもあります。キャッシュは「機能追加」とも「アクセス制御」とも解釈できます。
+In practice, the distinction can become blurry. Caching can be interpreted as either "adding functionality" or "controlling access."
 
-### Q2: TypeScript のデコレータ構文は GoF の Decorator パターンですか？
+### Q2: Is TypeScript's decorator syntax the same as the GoF Decorator pattern?
 
-厳密には異なります。GoF Decorator はオブジェクトレベルの合成パターンで、実行時に動的に適用します。TypeScript/Python のデコレータ構文はクラス/メソッド定義へのメタプログラミングで、定義時に静的に適用されます。ただし「既存の振る舞いを非侵入的に拡張する」という動機は共通しています。
+Strictly speaking, they are different. The GoF Decorator is an object-level composition pattern applied dynamically at runtime. TypeScript/Python decorator syntax is metaprogramming applied to class/method definitions statically at definition time. However, they share the common motivation of "extending existing behavior non-invasively."
 
-### Q3: React Hooks が登場して HOC（Decorator）は不要になりましたか？
+### Q3: Now that React Hooks exist, are HOCs (Decorators) obsolete?
 
-多くのユースケースで Hooks が HOC を置き換えましたが、以下では HOC が依然有効です:
-- **条件付きレンダリング**: 認証ガード（未認証ならリダイレクト）
-- **Provider ラッピング**: テーマ、国際化などのコンテキスト提供
-- **エラーバウンダリ**: クラスコンポーネントのライフサイクルが必要
-- **クロスカッティング**: 複数コンポーネントへの一括適用
+Hooks have replaced HOCs in many use cases, but HOCs remain effective in the following:
+- **Conditional rendering**: Auth guards (redirect if unauthenticated)
+- **Provider wrapping**: Providing contexts such as themes, internationalization
+- **Error boundaries**: Requires class component lifecycle methods
+- **Cross-cutting concerns**: Bulk application to multiple components
 
-### Q4: デコレータの積み重ね順序はどう決めるべきですか？
+### Q4: How should I decide the stacking order of decorators?
 
-一般的な原則:
-1. **外側**: 横断的関心事（ログ、メトリクス）
-2. **中間**: 回復力（リトライ、サーキットブレーカー、タイムアウト）
-3. **内側**: ビジネス寄りの処理（認証、バリデーション）
-4. **最内側**: ConcreteComponent
+General principles:
+1. **Outermost**: Cross-cutting concerns (logging, metrics)
+2. **Middle**: Resilience (retry, circuit breaker, timeout)
+3. **Inner**: Business-related processing (authentication, validation)
+4. **Innermost**: ConcreteComponent
 
-### Q5: Decorator パターンとミドルウェアパターンの関係は？
+### Q5: What is the relationship between the Decorator pattern and the middleware pattern?
 
-ミドルウェアパターンは Decorator パターンの宣言的な変形です。Express.js、Koa、Go の net/http など、多くの Web フレームワークがミドルウェアパターンを採用しています。本質は同じですが、ミドルウェアは配列ベースの設定が可能で、動的な追加・削除が容易です。
+The middleware pattern is a declarative variant of the Decorator pattern. Many web frameworks such as Express.js, Koa, and Go's net/http adopt the middleware pattern. The essence is the same, but middleware allows array-based configuration and makes dynamic addition and removal easier.
 
-### Q6: Java の I/O ストリームが Decorator パターンの代表例とされるのはなぜですか？
+### Q6: Why are Java's I/O streams considered a classic example of the Decorator pattern?
 
-Java の `java.io` パッケージは GoF Decorator パターンの最も有名な実装例です:
+Java's `java.io` package is the most well-known implementation of the GoF Decorator pattern:
 - `InputStream`/`OutputStream` = Component
 - `FileInputStream`/`FileOutputStream` = ConcreteComponent
 - `FilterInputStream`/`FilterOutputStream` = BaseDecorator
 - `BufferedInputStream`, `DataInputStream`, `GZIPInputStream` = ConcreteDecorator
 
-機能を自由に組み合わせられる一方で、ネストが深くなるという Decorator パターンのトレードオフも体現しています。
+It embodies both the benefit of freely combining features and the trade-off of deep nesting characteristic of the Decorator pattern.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not just through theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world development?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architectural design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| **目的** | 動的に機能を追加する（継承の代替） |
-| **手段** | 合成（has-a）でラッピング、同一インタフェースを維持 |
-| **利点** | 柔軟な組み合わせ、OCP/SRP 準拠、実行時の動的構成 |
-| **欠点** | 多層化でデバッグ困難、順序依存の可能性 |
-| **GoF vs 言語** | GoF = オブジェクトレベル、TS/Python = メソッド/クラスレベル |
-| **実装バリエーション** | クラス、関数合成、HOC、ミドルウェア、Stream Transform |
-| **注意** | 過剰な積み重ね回避、インタフェース外依存禁止、順序の明文化 |
+| **Purpose** | Add features dynamically (alternative to inheritance) |
+| **Approach** | Wrapping via composition (has-a), maintaining the same interface |
+| **Benefits** | Flexible combinations, OCP/SRP compliance, dynamic runtime configuration |
+| **Drawbacks** | Difficult debugging with many layers, potential order dependencies |
+| **GoF vs Language** | GoF = object level, TS/Python = method/class level |
+| **Implementation variants** | Classes, function composition, HOC, middleware, Stream Transform |
+| **Cautions** | Avoid excessive stacking, no out-of-interface dependencies, document ordering |
 
 ---
 
-## 次に読むべきガイド
+## Further Reading
 
-- [Proxy パターン](./03-proxy.md) — アクセス制御（Decorator と構造が同じだが目的が異なる）
-- [Adapter パターン](./00-adapter.md) — インタフェース変換
-- [Strategy パターン](../02-behavioral/01-strategy.md) — アルゴリズムの交換
-- [Composite パターン](./04-composite.md) — ツリー構造
-- 合成優先の原則 — 継承より合成
-- Chain of Responsibility — 処理チェーン
+- [Proxy Pattern](./03-proxy.md) — Access control (same structure as Decorator but different purpose)
+- [Adapter Pattern](./00-adapter.md) — Interface conversion
+- [Strategy Pattern](../02-behavioral/01-strategy.md) — Algorithm swapping
+- [Composite Pattern](./04-composite.md) — Tree structures
+- Composition Over Inheritance — Prefer composition over inheritance
+- Chain of Responsibility — Processing chains
 
 ---
 
-## 参考文献
+## References
 
 1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley.
 2. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media. — Chapter 3: Decorator Pattern

--- a/03-software-design/design-patterns-guide/docs/01-structural/02-facade.md
+++ b/03-software-design/design-patterns-guide/docs/01-structural/02-facade.md
@@ -1,40 +1,40 @@
-# Facade パターン
+# Facade Pattern
 
-> 複雑なサブシステム群に対する **統一された簡潔なインタフェース** を提供し、利用側の負担を軽減する構造パターン。
+> A structural pattern that provides a **unified, simplified interface** to a set of complex subsystems, reducing the burden on clients.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| クラスとインタフェース | 基本 | TypeScript / Java / Python の OOP |
-| 依存性注入 (DI) | 基本 | [DI パターン](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) |
-| 単一責任原則 (SRP) | 基本 | SOLID 原則 |
-| モジュール設計 | 基本 | ES Modules / Python packages |
-| async/await | 基本 | JavaScript / Python の非同期処理 |
+| Classes and Interfaces | Basic | OOP in TypeScript / Java / Python |
+| Dependency Injection (DI) | Basic | [DI Pattern](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) |
+| Single Responsibility Principle (SRP) | Basic | SOLID Principles |
+| Module Design | Basic | ES Modules / Python packages |
+| async/await | Basic | Asynchronous processing in JavaScript / Python |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn in This Chapter
 
-1. Facade パターンが解決する「サブシステム結合の爆発」問題と、その根本原因
-2. Facade の構造と 4 つの適用レベル（モジュール / サービス / アプリケーション / インフラ）
-3. Facade と Adapter / Mediator / Controller の明確な違い
-4. 5 言語（TypeScript, Python, Java, Go, Kotlin）での実装パターン
-5. God Facade / Leaky Facade / Rigid Facade の 3 大アンチパターンとその回避策
+1. The "subsystem coupling explosion" problem that the Facade pattern solves, and its root cause
+2. The structure of a Facade and 4 levels of application (module / service / application / infrastructure)
+3. Clear distinctions between Facade, Adapter, Mediator, and Controller
+4. Implementation patterns in 5 languages (TypeScript, Python, Java, Go, Kotlin)
+5. The 3 major anti-patterns — God Facade / Leaky Facade / Rigid Facade — and how to avoid them
 
 ---
 
-## 1. なぜ Facade が必要なのか（WHY）
+## 1. Why Facade Is Necessary (WHY)
 
-### 1.1 Facade なしの世界
+### 1.1 A World Without Facade
 
-複雑なシステムでは、クライアントが複数のサブシステムを直接操作しなければならない。
+In complex systems, clients must directly manipulate multiple subsystems.
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  Facade なし: クライアントがサブシステムを直接操作        │
+│  Without Facade: Client directly operates subsystems     │
 │                                                          │
 │   Client A ──┬──▶ SubSystem1.init()                     │
 │              ├──▶ SubSystem2.configure()                 │
@@ -42,35 +42,36 @@
 │              ├──▶ SubSystem1.validate()                  │
 │              └──▶ SubSystem2.execute()                   │
 │                                                          │
-│   Client B ──┬──▶ SubSystem1.init()       ← 同じ手順を  │
-│              ├──▶ SubSystem2.configure()    繰り返す     │
+│   Client B ──┬──▶ SubSystem1.init()       ← same steps  │
+│              ├──▶ SubSystem2.configure()    repeated     │
 │              ├──▶ SubSystem3.connect()                   │
 │              ├──▶ SubSystem1.validate()                  │
 │              └──▶ SubSystem2.execute()                   │
 │                                                          │
-│   問題:                                                  │
-│   - クライアントがサブシステムの内部構造を知る必要がある  │
-│   - 操作手順の重複（DRY 違反）                           │
-│   - サブシステム変更時に全クライアントを修正              │
-│   - テストでモック対象が多すぎる                          │
+│   Problems:                                              │
+│   - Clients must know the internal structure of          │
+│     each subsystem                                       │
+│   - Duplicated operation sequences (DRY violation)       │
+│   - All clients must be updated when a subsystem changes │
+│   - Too many mock targets in tests                       │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 現実世界のアナロジー
+### 1.2 Real-World Analogy
 
-**ホテルのコンシェルジュ** を考えてみよう。宿泊客がレストラン予約、タクシー手配、観光チケット購入をそれぞれ自分で行う代わりに、コンシェルジュに「今晩のディナーと明日の観光を手配してください」と言えば、すべてを調整してくれる。
+Consider a **hotel concierge**. Instead of a guest making a restaurant reservation, booking a taxi, and purchasing sightseeing tickets themselves, they can simply tell the concierge "please arrange dinner tonight and tomorrow's sightseeing," and the concierge handles everything.
 
-- コンシェルジュ = **Facade**
-- レストラン、タクシー会社、チケット窓口 = **サブシステム**
-- 宿泊客 = **クライアント**
+- Concierge = **Facade**
+- Restaurant, taxi company, ticket office = **Subsystems**
+- Guest = **Client**
 
-宿泊客はレストランの予約システムの使い方を知らなくてもよい。しかし、自分で直接レストランに電話することも可能である（Facade はアクセスを遮断しない）。
+The guest does not need to know how the restaurant's reservation system works. However, they can still call the restaurant directly if they wish (the Facade does not block access).
 
-### 1.3 Facade ありの世界
+### 1.3 A World With Facade
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  Facade あり: クライアントは Facade だけを知る            │
+│  With Facade: Clients only need to know the Facade       │
 │                                                          │
 │   Client A ──▶ Facade.doOperation()                     │
 │                    │                                     │
@@ -82,34 +83,34 @@
 │                    ├──▶ SubSystem1.validate()            │
 │                    └──▶ SubSystem2.execute()             │
 │                                                          │
-│   利点:                                                  │
-│   - クライアントは内部を知る必要がない                    │
-│   - 手順の一元管理（DRY）                                │
-│   - サブシステム変更の影響が Facade に局所化              │
-│   - テストでは Facade のみモック可能                      │
+│   Benefits:                                              │
+│   - Clients do not need to know internal details         │
+│   - Centralized management of steps (DRY)                │
+│   - Impact of subsystem changes localized to the Facade  │
+│   - Only the Facade needs to be mocked in tests          │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 1.4 Facade パターンの本質
+### 1.4 The Essence of the Facade Pattern
 
-Facade の本質は「**情報隠蔽**」と「**手順のカプセル化**」である。
+The essence of a Facade is **information hiding** and **encapsulation of procedures**.
 
-1. **情報隠蔽**: クライアントはサブシステムの存在すら知らなくてよい
-2. **手順のカプセル化**: 定型的な操作手順を 1 メソッドに集約
-3. **疎結合**: クライアントとサブシステムの結合度を下げる
-4. **ショートカット**: 便利な入口を提供するが、直接アクセスを禁止しない
+1. **Information hiding**: Clients do not even need to know that subsystems exist
+2. **Encapsulation of procedures**: Aggregates routine operation sequences into a single method
+3. **Loose coupling**: Reduces the degree of coupling between clients and subsystems
+4. **Shortcut**: Provides a convenient entry point but does not prohibit direct access
 
-> **重要**: Facade は「壁」ではなく「門」である。高度なユースケースではサブシステムへの直接アクセスを許容すべきである。
+> **Important**: A Facade is a "gate," not a "wall." Direct access to subsystems should be permitted for advanced use cases.
 
 ---
 
-## 2. Facade の構造
+## 2. Facade Structure
 
-### 2.1 クラス図
+### 2.1 Class Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                      UML クラス図                        │
+│                      UML Class Diagram                   │
 │                                                         │
 │  ┌──────────┐         ┌──────────────────┐              │
 │  │  Client  │────────▶│     Facade       │              │
@@ -131,19 +132,20 @@ Facade の本質は「**情報隠蔽**」と「**手順のカプセル化**」�
 │              │ + a2()   ││ + b2()   ││ + c2()   │      │
 │              └──────────┘└──────────┘└──────────┘      │
 │                                                         │
-│  ポイント:                                              │
-│  - Client は Facade のみに依存                          │
-│  - Facade はサブシステム群を集約（has-a）                │
-│  - サブシステムは Facade の存在を知らない                │
-│  - サブシステムへの直接アクセスも可能（optional）        │
+│  Key points:                                            │
+│  - Client depends only on the Facade                    │
+│  - Facade aggregates subsystems (has-a)                 │
+│  - Subsystems are unaware of the Facade's existence     │
+│  - Direct access to subsystems is also possible         │
+│    (optional)                                           │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### 2.2 シーケンス図
+### 2.2 Sequence Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                    シーケンス図                           │
+│                    Sequence Diagram                      │
 │                                                         │
 │  Client        Facade         SubA    SubB    SubC      │
 │    │              │             │       │       │        │
@@ -165,56 +167,58 @@ Facade の本質は「**情報隠蔽**」と「**手順のカプセル化**」�
 │    │◀─────────────│             │       │       │        │
 │    │              │             │       │       │        │
 │                                                         │
-│  ポイント: Facade がオーケストレーションを担当            │
+│  Key point: The Facade is responsible for orchestration │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### 2.3 Facade 適用の判断フロー
+### 2.3 Facade Application Decision Flow
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                  Facade 適用判断フロー                    │
+│              Facade Application Decision Flow            │
 │                                                         │
-│  サブシステムが複数ある？                                │
+│  Are there multiple subsystems?                         │
 │       │                                                 │
-│       ├── No ──▶ 不要（単一サブシステムなら直接呼ぶ）   │
-│       │                                                 │
-│       └── Yes                                           │
-│            │                                            │
-│  クライアントが複数のサブシステムを                      │
-│  直接操作している？                                      │
-│       │                                                 │
-│       ├── No ──▶ 不要（結合度が低い）                   │
+│       ├── No ──▶ Not needed (call directly if only      │
+│       │          one subsystem)                         │
 │       │                                                 │
 │       └── Yes                                           │
 │            │                                            │
-│  操作手順が定型的？                                      │
+│  Is the client directly operating multiple              │
+│  subsystems?                                            │
+│       │                                                 │
+│       ├── No ──▶ Not needed (low coupling)              │
+│       │                                                 │
+│       └── Yes                                           │
+│            │                                            │
+│  Are the operation steps routine/standard?              │
 │       │                  │                              │
 │       ├── Yes            └── No                         │
 │       │                      │                          │
 │       ▼                      ▼                          │
-│   Facade を導入         サブシステムを直接公開           │
-│   （手順を集約）        （柔軟性を重視）                 │
+│   Introduce Facade       Expose subsystems              │
+│   (aggregate steps)      directly (prioritize           │
+│                          flexibility)                   │
 │       │                                                 │
-│  1つの Facade に                                        │
-│  収まる規模？                                            │
+│  Does it fit within                                     │
+│  one Facade?                                            │
 │       │                  │                              │
 │       ├── Yes            └── No                         │
 │       │                      │                          │
 │       ▼                      ▼                          │
-│   単一 Facade           ドメイン別に                     │
-│                         Facade を分割                    │
+│   Single Facade          Split Facade                   │
+│                          by domain                      │
 └─────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: ホームシアター Facade（TypeScript）
+### Code Example 1: Home Theater Facade (TypeScript)
 
 ```typescript
-// === サブシステム群 ===
+// === Subsystems ===
 
 class Projector {
   on(): void { console.log("Projector: ON"); }
@@ -261,7 +265,7 @@ class HomeTheaterFacade {
     private screen: Screen,
   ) {}
 
-  /** 映画鑑賞モード: 6つのサブシステムを正しい順序で操作 */
+  /** Movie mode: operates 6 subsystems in the correct order */
   watchMovie(movie: string): void {
     console.log("=== Setting up movie mode ===");
     this.lights.dim(10);
@@ -277,7 +281,7 @@ class HomeTheaterFacade {
     console.log("=== Enjoy your movie! ===");
   }
 
-  /** 映画終了: 全サブシステムを正しい順序でシャットダウン */
+  /** End movie: shuts down all subsystems in the correct order */
   endMovie(): void {
     console.log("=== Shutting down ===");
     this.player.stop();
@@ -289,7 +293,7 @@ class HomeTheaterFacade {
     console.log("=== Done ===");
   }
 
-  /** 音楽モード: 映像不要、ステレオ音声 */
+  /** Music mode: no video needed, stereo audio */
   listenToMusic(): void {
     console.log("=== Setting up music mode ===");
     this.lights.dim(40);
@@ -299,7 +303,7 @@ class HomeTheaterFacade {
   }
 }
 
-// === 使用例 ===
+// === Usage ===
 
 const theater = new HomeTheaterFacade(
   new Projector(),
@@ -309,9 +313,9 @@ const theater = new HomeTheaterFacade(
   new Screen(),
 );
 
-// クライアントは 1 メソッドを呼ぶだけ
+// Client only needs to call 1 method
 theater.watchMovie("Inception");
-// 出力:
+// Output:
 // === Setting up movie mode ===
 // Lights: Dimmed to 10%
 // Screen: Lowered
@@ -328,14 +332,14 @@ theater.watchMovie("Inception");
 theater.endMovie();
 ```
 
-**ポイント**: 6 つのサブシステムの操作順序（ライト暗転 → スクリーン → プロジェクター → オーディオ → プレーヤー）をクライアントが知る必要がない。
+**Key point**: The client does not need to know the operation order of 6 subsystems (dim lights → screen → projector → audio → player).
 
 ---
 
-### コード例 2: デプロイメントパイプライン Facade（TypeScript）
+### Code Example 2: Deployment Pipeline Facade (TypeScript)
 
 ```typescript
-// === サブシステム群 ===
+// === Subsystems ===
 
 interface DeployResult {
   version: string;
@@ -407,30 +411,30 @@ class DeployFacade {
     private notify: NotifyService,
   ) {}
 
-  /** 本番リリース: 全ステップを自動実行 */
+  /** Production release: automatically executes all steps */
   async release(version: string): Promise<DeployResult> {
     try {
-      // 1. ソースコード取得
+      // 1. Fetch source code
       this.git.pull("main");
 
-      // 2. ビルドパイプライン
+      // 2. Build pipeline
       this.build.install();
       this.build.lint();
       this.build.test();
       const artifact = this.build.build();
 
-      // 3. デプロイ
+      // 3. Deploy
       const url = this.deploy.upload(artifact, "production");
       this.deploy.activate(version);
 
-      // 4. ヘルスチェック
+      // 4. Health check
       const healthy = this.deploy.healthCheck(url);
       if (!healthy) {
         this.deploy.rollback(version);
         throw new Error(`Health check failed for ${version}`);
       }
 
-      // 5. 完了処理
+      // 5. Completion handling
       this.git.tag(version);
       this.notify.sendSlack("#deploys", `v${version} deployed to ${url}`);
       this.notify.sendEmail("team@example.com", `Release v${version} complete`);
@@ -442,7 +446,7 @@ class DeployFacade {
     }
   }
 
-  /** ステージング環境へのデプロイ（テスト・通知なし） */
+  /** Deploy to staging environment (no tests or notifications) */
   async deployToStaging(branch: string): Promise<string> {
     this.git.pull(branch);
     this.build.install();
@@ -451,7 +455,7 @@ class DeployFacade {
   }
 }
 
-// === 使用例 ===
+// === Usage ===
 
 const pipeline = new DeployFacade(
   new GitService(),
@@ -463,11 +467,11 @@ const pipeline = new DeployFacade(
 await pipeline.release("1.2.0");
 ```
 
-**ポイント**: エラーハンドリングを含むオーケストレーション全体が Facade に集約されている。ステージング用の簡易メソッドも提供し、用途に応じて使い分けられる。
+**Key point**: The entire orchestration including error handling is consolidated in the Facade. A simplified method for staging is also provided for flexible use depending on purpose.
 
 ---
 
-### コード例 3: Python -- データ分析パイプライン Facade
+### Code Example 3: Python -- Data Analysis Pipeline Facade
 
 ```python
 from dataclasses import dataclass
@@ -477,13 +481,13 @@ import csv
 import io
 
 
-# === サブシステム群 ===
+# === Subsystems ===
 
 class DataLoader:
-    """様々な形式のデータを読み込む"""
+    """Loads data in various formats"""
     def load_csv(self, path: str) -> list[dict]:
         print(f"DataLoader: Loading CSV from {path}")
-        # 実際の実装では csv.DictReader を使用
+        # Use csv.DictReader in actual implementation
         return [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
 
     def load_json(self, path: str) -> list[dict]:
@@ -496,14 +500,14 @@ class DataLoader:
 
 
 class DataCleaner:
-    """データのクレンジング・正規化"""
+    """Data cleansing and normalization"""
     def remove_nulls(self, data: list[dict]) -> list[dict]:
         print(f"DataCleaner: Removing nulls from {len(data)} records")
         return [row for row in data if all(v is not None for v in row.values())]
 
     def normalize(self, data: list[dict], columns: list[str]) -> list[dict]:
         print(f"DataCleaner: Normalizing columns {columns}")
-        return data  # 実際は正規化処理
+        return data  # Actual normalization processing here
 
     def deduplicate(self, data: list[dict], key: str) -> list[dict]:
         print(f"DataCleaner: Deduplicating by {key}")
@@ -517,7 +521,7 @@ class DataCleaner:
 
 
 class DataAnalyzer:
-    """統計分析・集計"""
+    """Statistical analysis and aggregation"""
     def aggregate(self, data: list[dict], column: str) -> dict:
         print(f"DataAnalyzer: Aggregating column '{column}'")
         values = [row.get(column, 0) for row in data]
@@ -539,7 +543,7 @@ class DataAnalyzer:
 
 
 class ReportGenerator:
-    """レポート生成"""
+    """Report generation"""
     def generate_summary(self, stats: dict) -> str:
         print("ReportGenerator: Generating summary report")
         return json.dumps(stats, indent=2)
@@ -566,7 +570,7 @@ class AnalysisResult:
 
 
 class DataPipelineFacade:
-    """データ分析パイプラインの統一インタフェース"""
+    """Unified interface for the data analysis pipeline"""
 
     def __init__(
         self,
@@ -586,21 +590,21 @@ class DataPipelineFacade:
         target_column: str,
         dedup_key: str | None = None,
     ) -> AnalysisResult:
-        """CSV ファイルを読み込み、クレンジング・分析・レポート生成を一括実行"""
-        # 1. データ読み込み
+        """Loads a CSV file and executes cleansing, analysis, and report generation in one call"""
+        # 1. Load data
         data = self._loader.load_csv(path)
         raw_count = len(data)
 
-        # 2. クレンジング
+        # 2. Cleansing
         data = self._cleaner.remove_nulls(data)
         if dedup_key:
             data = self._cleaner.deduplicate(data, dedup_key)
         clean_count = len(data)
 
-        # 3. 分析
+        # 3. Analysis
         stats = self._analyzer.aggregate(data, target_column)
 
-        # 4. レポート生成
+        # 4. Report generation
         report = self._reporter.generate_summary(stats)
 
         return AnalysisResult(
@@ -611,12 +615,12 @@ class DataPipelineFacade:
         )
 
     def quick_summary(self, path: str, column: str) -> dict:
-        """クレンジングなしの簡易集計"""
+        """Simple aggregation without cleansing"""
         data = self._loader.load_csv(path)
         return self._analyzer.aggregate(data, column)
 
 
-# === 使用例 ===
+# === Usage ===
 
 pipeline = DataPipelineFacade(
     loader=DataLoader(),
@@ -628,7 +632,7 @@ pipeline = DataPipelineFacade(
 result = pipeline.analyze_csv("sales.csv", target_column="age", dedup_key="name")
 print(f"Raw: {result.raw_count}, Clean: {result.clean_count}")
 print(result.report)
-# 出力:
+# Output:
 # DataLoader: Loading CSV from sales.csv
 # DataCleaner: Removing nulls from 2 records
 # DataCleaner: Deduplicating by name
@@ -644,14 +648,14 @@ print(result.report)
 # }
 ```
 
-**ポイント**: 4 つのサブシステム（Loader, Cleaner, Analyzer, Reporter）の操作手順を `analyze_csv` に集約。簡易版 `quick_summary` も提供して、柔軟性と簡便性を両立している。
+**Key point**: The operation steps for 4 subsystems (Loader, Cleaner, Analyzer, Reporter) are consolidated in `analyze_csv`. A simplified `quick_summary` is also provided to balance flexibility and convenience.
 
 ---
 
-### コード例 4: Java -- メール送信 Facade
+### Code Example 4: Java -- Email Sending Facade
 
 ```java
-// === サブシステム群 ===
+// === Subsystems ===
 
 class SmtpClient {
     public void connect(String host, int port) {
@@ -689,7 +693,7 @@ class MimeBuilder {
 class TemplateEngine {
     public String render(String templateName, Map<String, Object> vars) {
         System.out.println("Template: Rendering " + templateName);
-        // 実際はテンプレートファイルを読み込み、変数を埋め込む
+        // In actual implementation, load template file and embed variables
         return "<html><body>Hello " + vars.getOrDefault("name", "User") + "</body></html>";
     }
 }
@@ -725,7 +729,7 @@ class EmailFacade {
         this.smtpPass = pass;
     }
 
-    /** テンプレートを使ったメール送信（最も一般的なユースケース） */
+    /** Send email using a template (most common use case) */
     public void sendTemplated(
         String from, String to,
         String templateName, Map<String, Object> vars
@@ -749,7 +753,7 @@ class EmailFacade {
         }
     }
 
-    /** プレーンテキストメールの簡易送信 */
+    /** Simple plain text email sending */
     public void sendPlain(String from, String to, String subject, String body) {
         if (!validator.validate(to)) {
             throw new IllegalArgumentException("Invalid email: " + to);
@@ -769,7 +773,7 @@ class EmailFacade {
     }
 }
 
-// === 使用例 ===
+// === Usage ===
 
 EmailFacade email = new EmailFacade("smtp.example.com", 587, "user", "pass");
 
@@ -779,7 +783,7 @@ email.sendTemplated(
     "welcome",
     Map.of("name", "Taro", "subject", "Welcome!")
 );
-// 出力:
+// Output:
 // Validator: user@example.com -> OK
 // Template: Rendering welcome
 // MIME: Building message (subject=Welcome!, attachments=0)
@@ -789,11 +793,11 @@ email.sendTemplated(
 // SMTP: Disconnected
 ```
 
-**ポイント**: SMTP 接続、MIME 構築、テンプレートレンダリング、アドレスバリデーションという 4 つの複雑なサブシステムを、`sendTemplated` と `sendPlain` の 2 メソッドに集約。
+**Key point**: The 4 complex subsystems — SMTP connection, MIME building, template rendering, and address validation — are consolidated into 2 methods: `sendTemplated` and `sendPlain`.
 
 ---
 
-### コード例 5: Go -- HTTP サーバー Facade
+### Code Example 5: Go -- HTTP Server Facade
 
 ```go
 package main
@@ -805,7 +809,7 @@ import (
     "time"
 )
 
-// === サブシステム群 ===
+// === Subsystems ===
 
 type Router struct {
     routes map[string]http.HandlerFunc
@@ -899,17 +903,17 @@ func NewServerFacade(addr string) *ServerFacade {
     }
 }
 
-// GET ルートを追加
+// Add a GET route
 func (s *ServerFacade) GET(path string, handler http.HandlerFunc) {
     s.router.AddRoute(path, handler)
 }
 
-// ミドルウェアを追加
+// Add middleware
 func (s *ServerFacade) Use(mw func(http.Handler) http.Handler) {
     s.middleware.Use(mw)
 }
 
-// サーバー起動（CORS・ミドルウェア・グレースフルシャットダウンを自動設定）
+// Start the server (automatically configures CORS, middleware, and graceful shutdown)
 func (s *ServerFacade) Start() error {
     var handler http.Handler = s.router
     handler = s.cors.Apply(handler)
@@ -919,12 +923,12 @@ func (s *ServerFacade) Start() error {
     return gs.Start()
 }
 
-// === 使用例 ===
+// === Usage ===
 
 func main() {
     app := NewServerFacade(":8080")
 
-    // ロギングミドルウェア
+    // Logging middleware
     app.Use(func(next http.Handler) http.Handler {
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
             log.Printf("%s %s", r.Method, r.URL.Path)
@@ -936,21 +940,21 @@ func main() {
         w.Write([]byte("OK"))
     })
 
-    // Router, Middleware, CORS, GracefulShutdown を意識せずに起動
+    // Start without being aware of Router, Middleware, CORS, or GracefulShutdown
     app.Start()
 }
 ```
 
-**ポイント**: Router, Middleware, CORS, GracefulShutdown という 4 つのサブシステムを `ServerFacade` が統合。`app.GET()` と `app.Start()` だけでサーバーが立ち上がる。Express.js の設計思想と同じ。
+**Key point**: `ServerFacade` integrates 4 subsystems — Router, Middleware, CORS, and GracefulShutdown. The server is up with just `app.GET()` and `app.Start()`. This is the same design philosophy as Express.js.
 
 ---
 
-### コード例 6: React -- カスタムフック as Facade（TypeScript）
+### Code Example 6: React -- Custom Hook as Facade (TypeScript)
 
 ```typescript
 import { useState, useEffect, useCallback, useMemo } from "react";
 
-// === サブシステム（個別の Hook） ===
+// === Subsystems (individual Hooks) ===
 
 function useCart() {
   const [items, setItems] = useState<CartItem[]>([]);
@@ -1047,20 +1051,20 @@ interface Address {
 }
 
 interface CheckoutState {
-  // カート
+  // Cart
   items: CartItem[];
   addItem: (item: CartItem) => void;
   removeItem: (id: string) => void;
-  // 金額
+  // Amounts
   subtotal: number;
   shippingCost: number;
   discount: number;
   total: number;
-  // アクション
+  // Actions
   applyCoupon: (code: string) => Promise<void>;
   setShippingAddress: (addr: Address) => Promise<void>;
   checkout: (paymentMethod: string) => Promise<void>;
-  // 状態
+  // State
   isProcessing: boolean;
   error: string | null;
   step: "cart" | "shipping" | "payment" | "complete";
@@ -1112,7 +1116,7 @@ function useCheckout(): CheckoutState {
   };
 }
 
-// === コンポーネントはシンプルに ===
+// === Components remain simple ===
 
 function CheckoutPage() {
   const {
@@ -1138,14 +1142,14 @@ function CheckoutPage() {
 }
 ```
 
-**ポイント**: `useCheckout` が Cart, Payment, Shipping, Coupon の 4 つの Hook を統合し、コンポーネントに対して統一された API を提供。コンポーネントは「支払い処理の内部構造」を知らなくてよい。
+**Key point**: `useCheckout` integrates 4 Hooks — Cart, Payment, Shipping, and Coupon — and provides a unified API to the component. The component does not need to know the "internal structure of the payment process."
 
 ---
 
-### コード例 7: Kotlin -- Android ネットワーク Facade
+### Code Example 7: Kotlin -- Android Network Facade
 
 ```kotlin
-// === サブシステム群 ===
+// === Subsystems ===
 
 class HttpClient {
     fun get(url: String, headers: Map<String, String> = emptyMap()): String {
@@ -1194,7 +1198,7 @@ class TokenManager {
 
 class CacheManager {
     private val cache = mutableMapOf<String, Pair<String, Long>>()
-    private val ttl = 60_000L // 1分
+    private val ttl = 60_000L // 1 minute
 
     fun get(key: String): String? {
         val entry = cache[key] ?: return null
@@ -1221,7 +1225,7 @@ class ApiClient(
     private val cache: CacheManager = CacheManager(),
     private val baseUrl: String = "https://api.example.com",
 ) {
-    /** 認証ヘッダー付き GET（キャッシュあり） */
+    /** GET with auth header (with cache) */
     fun <T> get(path: String, clazz: Class<T>, useCache: Boolean = true): T {
         val url = "$baseUrl$path"
 
@@ -1236,7 +1240,7 @@ class ApiClient(
         return json.parse(response, clazz)
     }
 
-    /** 認証ヘッダー付き POST */
+    /** POST with auth header */
     fun <T> post(path: String, body: Any, clazz: Class<T>): T {
         val url = "$baseUrl$path"
         val headers = mapOf("Authorization" to "Bearer ${auth.getToken()}")
@@ -1245,7 +1249,7 @@ class ApiClient(
         return json.parse(response, clazz)
     }
 
-    /** ログイン（トークン取得・保存） */
+    /** Login (fetch and store token) */
     fun login(username: String, password: String) {
         val body = json.toJson(mapOf("username" to username, "password" to password))
         val response = http.post("$baseUrl/auth/login", body)
@@ -1253,13 +1257,13 @@ class ApiClient(
         auth.setToken(result["token"] as? String ?: "dummy-token")
     }
 
-    /** ログアウト */
+    /** Logout */
     fun logout() {
         auth.clearToken()
     }
 }
 
-// === 使用例 ===
+// === Usage ===
 
 fun main() {
     val api = ApiClient()
@@ -1269,14 +1273,14 @@ fun main() {
 }
 ```
 
-**ポイント**: HTTP 通信、JSON パース、認証トークン管理、キャッシュという 4 つのサブシステムを `ApiClient` が統合。Android の Retrofit ライブラリはこの設計思想を発展させたもの。
+**Key point**: `ApiClient` integrates 4 subsystems — HTTP communication, JSON parsing, auth token management, and caching. The Retrofit library for Android is a further development of this design philosophy.
 
 ---
 
-### コード例 8: モジュール公開 API as Facade（TypeScript）
+### Code Example 8: Module Public API as Facade (TypeScript)
 
 ```typescript
-// === 内部モジュール群 ===
+// === Internal modules ===
 // internal/parser.ts
 class Parser {
   parse(source: string): ASTNode {
@@ -1317,7 +1321,7 @@ class Emitter {
   }
 }
 
-// === 型定義 ===
+// === Type definitions ===
 interface ASTNode {
   type: string;
   body: ASTNode[];
@@ -1348,8 +1352,8 @@ interface CompileResult {
 // === Facade (index.ts) ===
 
 /**
- * コンパイラの公開 API。
- * 内部の Parser, Validator, Optimizer, Transformer, Emitter を隠蔽する。
+ * The compiler's public API.
+ * Hides the internal Parser, Validator, Optimizer, Transformer, and Emitter.
  */
 export function compile(
   source: string,
@@ -1357,11 +1361,11 @@ export function compile(
 ): CompileResult {
   const { optimize = true, validate = true } = options;
 
-  // 1. パース
+  // 1. Parse
   const parser = new Parser();
   const ast = parser.parse(source);
 
-  // 2. バリデーション（オプション）
+  // 2. Validation (optional)
   if (validate) {
     const validator = new Validator();
     const result = validator.validate(ast);
@@ -1370,26 +1374,26 @@ export function compile(
     }
   }
 
-  // 3. 最適化（オプション）
+  // 3. Optimization (optional)
   let optimizedAst = ast;
   if (optimize) {
     const optimizer = new Optimizer();
     optimizedAst = optimizer.optimize(ast);
   }
 
-  // 4. 変換
+  // 4. Transform
   const transformer = new Transformer();
   const ir = transformer.transform(optimizedAst);
 
-  // 5. 出力
+  // 5. Emit output
   const emitter = new Emitter();
   const code = emitter.emit(ir);
 
   return { code, ast, errors: [] };
 }
 
-// === 使用例 ===
-// 利用側は内部を知る必要がない
+// === Usage ===
+// Consumers do not need to know the internals
 // import { compile } from "my-compiler";
 
 const result = compile("const x = 1 + 2;");
@@ -1398,11 +1402,11 @@ console.log(result.code);
 const resultNoOptimize = compile("const x = 1 + 2;", { optimize: false });
 ```
 
-**ポイント**: npm パッケージの `index.ts` は典型的な Facade。内部の 5 つのクラスを `compile` 関数 1 つに集約。TypeScript コンパイラ (`tsc`)、Babel、webpack も同じ設計。
+**Key point**: The `index.ts` of an npm package is a typical Facade. The internal 5 classes are consolidated into a single `compile` function. The TypeScript compiler (`tsc`), Babel, and webpack follow the same design.
 
 ---
 
-### コード例 9: Python -- Django/Flask 風 ORM Facade
+### Code Example 9: Python -- Django/Flask-style ORM Facade
 
 ```python
 from typing import Any, TypeVar, Generic
@@ -1410,10 +1414,10 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 
-# === サブシステム群 ===
+# === Subsystems ===
 
 class ConnectionPool:
-    """データベース接続プール"""
+    """Database connection pool"""
     _instance = None
 
     def __init__(self, dsn: str, pool_size: int = 5):
@@ -1430,10 +1434,10 @@ class ConnectionPool:
 
 
 class Connection:
-    """データベース接続"""
+    """Database connection"""
     def execute(self, sql: str, params: tuple = ()) -> list[dict]:
         print(f"Connection: {sql} params={params}")
-        return [{"id": 1}]  # ダミー結果
+        return [{"id": 1}]  # Dummy result
 
     def begin(self) -> None:
         print("Connection: BEGIN")
@@ -1446,7 +1450,7 @@ class Connection:
 
 
 class QueryBuilder:
-    """SQL クエリビルダー"""
+    """SQL query builder"""
     def __init__(self, table: str):
         self._table = table
         self._conditions: list[str] = []
@@ -1492,7 +1496,7 @@ class QueryBuilder:
 
 
 class Migrator:
-    """スキーママイグレーション"""
+    """Schema migration"""
     def create_table(self, name: str, columns: dict[str, str]) -> str:
         cols = ", ".join(f"{k} {v}" for k, v in columns.items())
         return f"CREATE TABLE IF NOT EXISTS {name} ({cols})"
@@ -1504,7 +1508,7 @@ T = TypeVar("T")
 
 
 class DatabaseFacade:
-    """データベース操作の統一インタフェース"""
+    """Unified interface for database operations"""
 
     def __init__(self, dsn: str):
         self._pool = ConnectionPool(dsn)
@@ -1517,7 +1521,7 @@ class DatabaseFacade:
         order_by: str | None = None,
         limit: int | None = None,
     ) -> list[dict]:
-        """条件検索（SELECT）"""
+        """Conditional search (SELECT)"""
         qb = QueryBuilder(table)
         if conditions:
             for col, val in conditions.items():
@@ -1537,7 +1541,7 @@ class DatabaseFacade:
             self._pool.release(conn)
 
     def insert(self, table: str, data: dict) -> dict:
-        """レコード挿入（INSERT）"""
+        """Insert record (INSERT)"""
         qb = QueryBuilder(table)
         sql, params = qb.build_insert(data)
         conn = self._pool.acquire()
@@ -1553,7 +1557,7 @@ class DatabaseFacade:
             self._pool.release(conn)
 
     def delete(self, table: str, conditions: dict[str, Any]) -> None:
-        """レコード削除（DELETE）"""
+        """Delete record (DELETE)"""
         qb = QueryBuilder(table)
         for col, val in conditions.items():
             qb.where(f"{col} = ?", val)
@@ -1570,7 +1574,7 @@ class DatabaseFacade:
             self._pool.release(conn)
 
     def migrate(self, table: str, columns: dict[str, str]) -> None:
-        """テーブル作成（マイグレーション）"""
+        """Create table (migration)"""
         sql = self._migrator.create_table(table, columns)
         conn = self._pool.acquire()
         try:
@@ -1579,11 +1583,11 @@ class DatabaseFacade:
             self._pool.release(conn)
 
 
-# === 使用例 ===
+# === Usage ===
 
 db = DatabaseFacade("postgresql://localhost:5432/mydb")
 
-# テーブル作成
+# Create table
 db.migrate("users", {
     "id": "SERIAL PRIMARY KEY",
     "name": "VARCHAR(100)",
@@ -1591,24 +1595,24 @@ db.migrate("users", {
     "created_at": "TIMESTAMP DEFAULT NOW()",
 })
 
-# レコード挿入
+# Insert record
 db.insert("users", {"name": "Alice", "email": "alice@example.com"})
 
-# 検索
+# Search
 users = db.find("users", conditions={"name": "Alice"}, order_by="-created_at", limit=10)
 
-# 削除
+# Delete
 db.delete("users", conditions={"id": 1})
 ```
 
-**ポイント**: ConnectionPool, QueryBuilder, Connection, Migrator の 4 つのサブシステムを `DatabaseFacade` が統合。Django ORM や SQLAlchemy の `Session` もこの設計。
+**Key point**: `DatabaseFacade` integrates 4 subsystems — ConnectionPool, QueryBuilder, Connection, and Migrator. Django ORM and SQLAlchemy's `Session` follow this design.
 
 ---
 
-### コード例 10: Facade + Strategy の組み合わせ（TypeScript）
+### Code Example 10: Facade + Strategy Combination (TypeScript)
 
 ```typescript
-// === Strategy インタフェース ===
+// === Strategy interface ===
 
 interface NotificationChannel {
   send(to: string, message: string): Promise<boolean>;
@@ -1642,7 +1646,7 @@ class SlackChannel implements NotificationChannel {
   }
 }
 
-// === サブシステム群 ===
+// === Subsystems ===
 
 class TemplateRenderer {
   render(template: string, vars: Record<string, string>): string {
@@ -1656,7 +1660,7 @@ class TemplateRenderer {
 
 class UserPreferences {
   getPreferredChannels(userId: string): string[] {
-    // 実際はDBから取得
+    // In practice, fetch from DB
     return ["email", "push"];
   }
 
@@ -1689,7 +1693,7 @@ interface NotifyOptions {
   template: string;
   vars: Record<string, string>;
   userId: string;
-  channels?: string[];  // 指定しなければユーザー設定を使用
+  channels?: string[];  // Uses user preferences if not specified
 }
 
 class NotificationFacade {
@@ -1704,21 +1708,21 @@ class NotificationFacade {
     this.channelMap = new Map(Object.entries(channels));
   }
 
-  /** 通知送信: テンプレート展開 → チャネル選択 → 送信 → ログ */
+  /** Send notification: template expansion → channel selection → send → log */
   async notify(options: NotifyOptions): Promise<void> {
     const { template, vars, userId } = options;
 
-    // 1. テンプレート展開
+    // 1. Expand template
     const message = this.renderer.render(template, vars);
 
-    // 2. チャネル決定（明示指定 or ユーザー設定）
+    // 2. Determine channels (explicit or user preferences)
     const channelNames = options.channels
       ?? this.preferences.getPreferredChannels(userId);
 
-    // 3. 連絡先取得
+    // 3. Fetch contact info
     const contacts = this.preferences.getContactInfo(userId);
 
-    // 4. 全チャネルに送信（並列）
+    // 4. Send to all channels (in parallel)
     const results = await Promise.allSettled(
       channelNames.map(async (name) => {
         const channel = this.channelMap.get(name);
@@ -1739,7 +1743,7 @@ class NotificationFacade {
     }
   }
 
-  /** 緊急通知: 全チャネルに送信 */
+  /** Emergency notification: send to all channels */
   async emergency(userId: string, message: string): Promise<void> {
     const allChannels = Array.from(this.channelMap.keys());
     await this.notify({
@@ -1751,7 +1755,7 @@ class NotificationFacade {
   }
 }
 
-// === 使用例 ===
+// === Usage ===
 
 const notifier = new NotificationFacade(
   new TemplateRenderer(),
@@ -1765,99 +1769,99 @@ const notifier = new NotificationFacade(
   },
 );
 
-// ユーザー設定に基づいて通知（email + push）
+// Notify based on user preferences (email + push)
 await notifier.notify({
   template: "Hello {{name}}, your order #{{orderId}} has shipped!",
   vars: { name: "Taro", orderId: "12345" },
   userId: "user-1",
 });
 
-// 緊急通知: 全チャネル
+// Emergency notification: all channels
 await notifier.emergency("user-1", "System maintenance in 30 minutes");
 ```
 
-**ポイント**: Facade（NotificationFacade）が Strategy（NotificationChannel）と組み合わされている。Facade がサブシステム群のオーケストレーションを担当し、Strategy が個々の送信チャネルの切り替えを担当する。
+**Key point**: The Facade (NotificationFacade) is combined with Strategy (NotificationChannel). The Facade handles orchestration of the subsystems, while Strategy handles switching between individual notification channels.
 
 ---
 
-## 4. 比較表
+## 4. Comparison Tables
 
-### 比較表 1: Facade vs Adapter vs Mediator vs Controller
+### Comparison Table 1: Facade vs Adapter vs Mediator vs Controller
 
-| 観点 | Facade | Adapter | Mediator | Controller |
+| Aspect | Facade | Adapter | Mediator | Controller |
 |------|--------|---------|----------|------------|
-| **目的** | 複雑さの隠蔽 | インタフェース変換 | オブジェクト間の調停 | リクエストのルーティング |
-| **対象数** | 多数のサブシステム | 1 つ | 多数のコンポーネント | 多数のサービス |
-| **方向** | 一方向（Client -> Sub） | 一方向 | 双方向 | 一方向 |
-| **新 IF 作成** | 簡素化された IF を作る | 既存 IF を変換 | 通信 IF を作る | エンドポイント IF を作る |
-| **サブシステムの認識** | 知らない | 知らない | 互いを知る | 知らない |
-| **状態管理** | なし（ステートレス） | なし | あり（コンポーネント状態） | あり（リクエスト状態） |
-| **例** | `compile(source)` | XMLParser -> JSON | ChatRoom | Express Router |
+| **Purpose** | Hide complexity | Interface conversion | Mediate between objects | Route requests |
+| **Target count** | Many subsystems | 1 | Many components | Many services |
+| **Direction** | One-way (Client -> Sub) | One-way | Bidirectional | One-way |
+| **Creates new IF** | Creates simplified IF | Converts existing IF | Creates communication IF | Creates endpoint IF |
+| **Subsystem awareness** | Unaware | Unaware | Know each other | Unaware |
+| **State management** | None (stateless) | None | Yes (component state) | Yes (request state) |
+| **Example** | `compile(source)` | XMLParser -> JSON | ChatRoom | Express Router |
 
-### 比較表 2: Facade のレベル別設計
+### Comparison Table 2: Facade Design by Level
 
-| レベル | 例 | 粒度 | スコープ |
+| Level | Example | Granularity | Scope |
 |--------|-----|------|---------|
-| **関数** | `compile(source)` | 最細粒度 | 1 ファイル内 |
-| **モジュール** | `index.ts` の re-export | 細粒度 | 1 パッケージ |
-| **クラス** | `UserFacade` | 中粒度 | 1 ドメイン |
-| **サービス** | API Gateway | 粗粒度 | 複数マイクロサービス |
-| **インフラ** | CDK/Terraform wrapper | 最粗粒度 | クラウドリソース群 |
+| **Function** | `compile(source)` | Finest | Within 1 file |
+| **Module** | `index.ts` re-export | Fine | 1 package |
+| **Class** | `UserFacade` | Medium | 1 domain |
+| **Service** | API Gateway | Coarse | Multiple microservices |
+| **Infrastructure** | CDK/Terraform wrapper | Coarsest | Cloud resources |
 
-### 比較表 3: Facade パターンの実装方式
+### Comparison Table 3: Facade Pattern Implementation Methods
 
-| 方式 | 言語/フレームワーク | 特徴 | 適用場面 |
+| Method | Language/Framework | Characteristics | When to Use |
 |------|---------------------|------|---------|
-| **クラス Facade** | Java, TypeScript, Kotlin | DI 可能、テストしやすい | サービス層 |
-| **関数 Facade** | TypeScript, Python, Go | シンプル、状態なし | ユーティリティ |
-| **モジュール Facade** | `index.ts`, `__init__.py` | re-export で公開 API 制御 | パッケージ公開 |
-| **カスタムフック** | React | Hook の合成 | UI 状態管理 |
-| **ゲートウェイ** | API Gateway, BFF | ネットワーク境界 | マイクロサービス |
-| **CLI ラッパー** | Makefile, npm scripts | コマンド集約 | 開発ワークフロー |
+| **Class Facade** | Java, TypeScript, Kotlin | DI-capable, easy to test | Service layer |
+| **Function Facade** | TypeScript, Python, Go | Simple, stateless | Utilities |
+| **Module Facade** | `index.ts`, `__init__.py` | Public API control via re-export | Package publishing |
+| **Custom Hook** | React | Hook composition | UI state management |
+| **Gateway** | API Gateway, BFF | Network boundary | Microservices |
+| **CLI Wrapper** | Makefile, npm scripts | Command aggregation | Development workflow |
 
 ---
 
-## 5. アンチパターン
+## 5. Anti-Patterns
 
-### アンチパターン 1: God Facade（肥大化 Facade）
+### Anti-Pattern 1: God Facade (Bloated Facade)
 
 ```typescript
-// NG: あらゆるドメインの操作を 1 つの Facade に詰め込む
+// BAD: Packing operations from every domain into a single Facade
 class AppFacade {
-  // ユーザー管理
+  // User management
   createUser(name: string): void { /* ... */ }
   deleteUser(id: string): void { /* ... */ }
   updateUserProfile(id: string, data: unknown): void { /* ... */ }
 
-  // 注文管理
+  // Order management
   createOrder(userId: string, items: unknown[]): void { /* ... */ }
   cancelOrder(orderId: string): void { /* ... */ }
   refundOrder(orderId: string): void { /* ... */ }
 
-  // 決済
+  // Payment
   processPayment(orderId: string, method: string): void { /* ... */ }
   verifyPayment(txId: string): void { /* ... */ }
 
-  // レポート
+  // Reports
   generateDailyReport(): void { /* ... */ }
   generateMonthlyReport(): void { /* ... */ }
 
-  // メール
+  // Email
   sendWelcomeEmail(userId: string): void { /* ... */ }
   sendOrderConfirmation(orderId: string): void { /* ... */ }
 
-  // ... 50 メソッド以上
+  // ... 50+ methods
 }
 
-// 問題:
-// 1. SRP 違反: 1 つのクラスに 5+ ドメインの責務
-// 2. 変更の影響範囲が広すぎる
-// 3. テストが困難（モック対象が多すぎる）
-// 4. Facade 自体が「複雑なサブシステム」になる
+// Problems:
+// 1. SRP violation: 5+ domain responsibilities in 1 class
+// 2. Scope of change impact is too wide
+// 3. Difficult to test (too many mock targets)
+// 4. The Facade itself becomes a "complex subsystem"
 ```
 
 ```typescript
-// OK: ドメインごとに Facade を分割
+// GOOD: Split Facade by domain
 
 class UserFacade {
   constructor(
@@ -1891,45 +1895,45 @@ class ReportFacade {
   monthly(): Report { /* ... */ }
 }
 
-// 各 Facade は 3-5 メソッド、明確な責務境界
+// Each Facade has 3-5 methods and clear responsibility boundaries
 ```
 
-**判断基準**: 1 つの Facade が **7 メソッド以上** になったら分割を検討する。
+**Decision criteria**: Consider splitting when a single Facade has **7 or more methods**.
 
 ---
 
-### アンチパターン 2: Leaky Facade（漏れのある Facade）
+### Anti-Pattern 2: Leaky Facade
 
 ```typescript
-// NG: Facade がサブシステムの内部詳細を露出している
+// BAD: Facade exposes internal details of subsystems
 class LeakyFacade {
   private db: Database;
   private cache: Redis;
 
-  // サブシステムの型がそのまま露出
+  // Subsystem type is directly exposed
   getDbConnection(): DatabaseConnection {
     return this.db.getConnection();
   }
 
-  // 内部のキャッシュキー規則がリークしている
+  // Internal cache key rules are leaking
   getCachedUser(userId: string): string | null {
-    return this.cache.get(`user:v2:${userId}`);  // キー形式がリーク
+    return this.cache.get(`user:v2:${userId}`);  // Key format leaks
   }
 
-  // SQL がそのまま露出
+  // SQL is directly exposed
   queryUsers(sql: string): User[] {
     return this.db.query(sql);
   }
 }
 
-// 問題:
-// 1. クライアントがサブシステムの内部を知る必要がある
-// 2. キャッシュキー形式の変更が全クライアントに影響
-// 3. SQL インジェクションのリスク
+// Problems:
+// 1. Clients need to know internals of subsystems
+// 2. Changes to cache key format affect all clients
+// 3. Risk of SQL injection
 ```
 
 ```typescript
-// OK: 内部詳細を完全に隠蔽
+// GOOD: Completely hide internal details
 
 class CleanFacade {
   constructor(
@@ -1937,13 +1941,13 @@ class CleanFacade {
     private cache: Redis,
   ) {}
 
-  // サブシステムの型を隠蔽し、ドメイン型を返す
+  // Hide subsystem types and return domain types
   async findUser(userId: string): Promise<User | null> {
-    // キャッシュ戦略は内部で管理
+    // Cache strategy is managed internally
     const cached = this.cache.get(`user:v2:${userId}`);
     if (cached) return JSON.parse(cached);
 
-    // SQL は内部で管理
+    // SQL is managed internally
     const user = await this.db.query(
       "SELECT * FROM users WHERE id = ?", [userId]
     );
@@ -1955,42 +1959,42 @@ class CleanFacade {
 }
 ```
 
-**判断基準**: Facade のメソッドシグネチャにサブシステム固有の型や規則が現れたら、抽象化が不十分。
+**Decision criteria**: If subsystem-specific types or rules appear in the Facade's method signatures, the abstraction is insufficient.
 
 ---
 
-### アンチパターン 3: Rigid Facade（硬直した Facade）
+### Anti-Pattern 3: Rigid Facade
 
 ```typescript
-// NG: サブシステムへの直接アクセスを完全に遮断
+// BAD: Completely blocking direct access to subsystems
 class RigidFacade {
-  // サブシステムをすべて private で隠蔽
+  // All subsystems hidden as private
   private emailService: EmailService;
   private smsService: SmsService;
   private pushService: PushService;
 
-  // 定型操作のみ提供
+  // Only provides standard operations
   notifyUser(userId: string, msg: string): void {
-    // 常に email + push で送信（変更不可）
+    // Always sends email + push (not changeable)
     this.emailService.send(userId, msg);
     this.pushService.send(userId, msg);
   }
 
-  // SMS だけ送りたい場合の手段がない
-  // カスタムチャネル組み合わせの手段がない
+  // No way to send only SMS
+  // No way to combine custom channels
 }
 
-// 問題:
-// 1. 高度なユースケースに対応できない
-// 2. 新しい要件のたびに Facade にメソッド追加が必要
-// 3. 結局 Facade を迂回するハックが生まれる
+// Problems:
+// 1. Cannot handle advanced use cases
+// 2. Every new requirement requires adding a method to the Facade
+// 3. Eventually leads to hacks that bypass the Facade
 ```
 
 ```typescript
-// OK: Facade は便利なショートカット、直接アクセスも許容
+// GOOD: Facade as a convenient shortcut, direct access also allowed
 
 class FlexibleFacade {
-  // サブシステムを公開（高度なユースケース用）
+  // Expose subsystems (for advanced use cases)
   readonly email: EmailService;
   readonly sms: SmsService;
   readonly push: PushService;
@@ -2005,28 +2009,28 @@ class FlexibleFacade {
     this.push = push;
   }
 
-  // 定型操作のショートカット
+  // Shortcut for standard operations
   notifyUser(userId: string, msg: string): void {
     this.email.send(userId, msg);
     this.push.send(userId, msg);
   }
 
-  // 高度なユースケースはサブシステムに直接アクセス
+  // Advanced use cases access subsystems directly
   // facade.sms.send(userId, urgentMsg);
 }
 ```
 
-**判断基準**: Facade は「壁」ではなく「門」。80% のユースケースをカバーし、残り 20% はサブシステム直接アクセスを許容する。
+**Decision criteria**: A Facade is a "gate," not a "wall." It should cover 80% of use cases and allow direct subsystem access for the remaining 20%.
 
 ---
 
-## 6. エッジケースと注意点
+## 6. Edge Cases and Considerations
 
-### 6.1 Facade のライフサイクル管理
+### 6.1 Facade Lifecycle Management
 
 ```typescript
-// Facade がサブシステムのリソースを管理する場合、
-// 適切なクリーンアップが必要
+// When a Facade manages resources of subsystems,
+// proper cleanup is necessary
 
 class ManagedFacade implements Disposable {
   private pool: ConnectionPool;
@@ -2037,7 +2041,7 @@ class ManagedFacade implements Disposable {
     this.cache = new CacheService();
   }
 
-  // ES2024+ Disposable パターン
+  // ES2024+ Disposable pattern
   [Symbol.dispose](): void {
     this.pool.close();
     this.cache.flush();
@@ -2045,26 +2049,26 @@ class ManagedFacade implements Disposable {
   }
 }
 
-// using で自動クリーンアップ
+// Automatic cleanup with using
 {
   using facade = new ManagedFacade();
-  // ... 使用
-} // 自動的に dispose される
+  // ... use
+} // Automatically disposed
 ```
 
-### 6.2 非同期 Facade のエラーハンドリング
+### 6.2 Error Handling in Async Facades
 
 ```typescript
 class AsyncFacade {
   async complexOperation(): Promise<Result> {
-    // 複数の非同期操作を順番に実行
-    // 途中で失敗した場合の補償処理（compensation）が重要
+    // Execute multiple async operations sequentially
+    // Compensation handling on failure is important
     const step1 = await this.serviceA.doSomething();
 
     try {
       const step2 = await this.serviceB.doSomething(step1);
     } catch (error) {
-      // step1 を元に戻す（補償トランザクション）
+      // Undo step1 (compensating transaction)
       await this.serviceA.undo(step1);
       throw error;
     }
@@ -2072,27 +2076,27 @@ class AsyncFacade {
 }
 ```
 
-### 6.3 Facade のバージョニング
+### 6.3 Facade Versioning
 
 ```typescript
-// API が進化する場合、古い Facade を残して新しい Facade を追加
+// When the API evolves, keep the old Facade and add a new one
 
 /** @deprecated Use CheckoutFacadeV2 */
 class CheckoutFacade {
-  checkout(cartId: string): void { /* 旧実装 */ }
+  checkout(cartId: string): void { /* old implementation */ }
 }
 
 class CheckoutFacadeV2 {
   checkout(cartId: string, options: CheckoutOptions): Promise<Receipt> {
-    /* 新実装 */
+    /* new implementation */
   }
 }
 ```
 
-### 6.4 テスト戦略
+### 6.4 Testing Strategy
 
 ```typescript
-// Facade のテスト: サブシステムをモックして統合テスト
+// Testing a Facade: integration test with mocked subsystems
 
 describe("DeployFacade", () => {
   it("should execute full deployment pipeline", async () => {
@@ -2113,7 +2117,7 @@ describe("DeployFacade", () => {
     const facade = new DeployFacade(git, build, deploy, notify);
     const result = await facade.release("1.0.0");
 
-    // 各サブシステムが正しい順序で呼ばれたか検証
+    // Verify each subsystem was called in the correct order
     expect(git.pull).toHaveBeenCalledWith("main");
     expect(build.build).toHaveBeenCalledAfter(build.test);
     expect(deploy.healthCheck).toHaveBeenCalled();
@@ -2125,68 +2129,71 @@ describe("DeployFacade", () => {
     const deploy = {
       upload: jest.fn().mockReturnValue("url"),
       activate: jest.fn(),
-      healthCheck: jest.fn().mockReturnValue(false),  // 失敗
+      healthCheck: jest.fn().mockReturnValue(false),  // Failure
       rollback: jest.fn(),
     };
-    // ... ロールバックが呼ばれることを検証
+    // ... verify that rollback is called
   });
 });
 ```
 
 ---
 
-## 7. トレードオフ分析
+## 7. Trade-off Analysis
 
-### 導入すべき場面
+### When to Introduce
 
-| 場面 | 理由 |
+| Situation | Reason |
 |------|------|
-| 3+ サブシステムを組み合わせる定型操作 | 手順の重複を排除 |
-| ライブラリ/フレームワークの公開 API | 内部を隠蔽し安定 API を提供 |
-| レガシーシステムのラッピング | 新 API で古い実装を隠蔽 |
-| マイクロサービスの BFF | 複数サービスを集約 |
-| テスト容易性の向上 | モック対象を Facade に集約 |
+| Routine operations combining 3+ subsystems | Eliminate duplicated steps |
+| Public API of a library/framework | Hide internals and provide a stable API |
+| Wrapping a legacy system | Hide old implementation with a new API |
+| BFF in microservices | Aggregate multiple services |
+| Improving testability | Consolidate mock targets to the Facade |
 
-### 導入すべきでない場面
+### When Not to Introduce
 
-| 場面 | 理由 |
+| Situation | Reason |
 |------|------|
-| サブシステムが 1 つだけ | Facade の付加価値がない |
-| クライアントがサブシステムの柔軟な組み合わせを必要とする | Facade が制約になる |
-| Facade のメソッド数が 10+ になりそう | God Facade のリスク |
-| パフォーマンスクリティカルなパス | 追加の間接層がオーバーヘッドになる |
+| Only one subsystem | No added value from a Facade |
+| Client needs flexible combinations of subsystems | Facade becomes a constraint |
+| Facade is likely to have 10+ methods | Risk of God Facade |
+| Performance-critical path | Additional indirection layer becomes overhead |
 
-### Facade のコスト
+### Cost of a Facade
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│                 Facade のコスト分析                       │
+│                 Facade Cost Analysis                      │
 │                                                         │
-│  メリット                    デメリット                  │
+│  Benefits                    Drawbacks                  │
 │  ┌──────────────────────┐    ┌──────────────────────┐   │
-│  │ + クライアントの簡素化│    │ - 間接層の追加       │   │
-│  │ + DRY（手順の一元化） │    │ - God Facade のリスク│   │
-│  │ + 疎結合             │    │ - 柔軟性の低下       │   │
-│  │ + テスト容易性       │    │   （定型操作のみ）    │   │
-│  │ + 変更の局所化       │    │ - 全機能の再公開が   │   │
-│  │ + 学習コスト低下     │    │   必要になる場合     │   │
+│  │ + Simplified client  │    │ - Additional layer   │   │
+│  │ + DRY (centralized   │    │ - Risk of God Facade │   │
+│  │   steps)             │    │ - Reduced flexibility│   │
+│  │ + Loose coupling     │    │   (standard ops only)│   │
+│  │ + Testability        │    │ - May need to        │   │
+│  │ + Localized changes  │    │   re-expose all      │   │
+│  │ + Lower learning     │    │   features           │   │
+│  │   cost               │    │                      │   │
 │  └──────────────────────┘    └──────────────────────┘   │
 │                                                         │
-│  判断: サブシステムが 3+ あり、80%+ のユースケースが     │
-│  定型的であれば、Facade の導入は合理的。                  │
+│  Judgment: If there are 3+ subsystems and 80%+ of       │
+│  use cases are routine, introducing a Facade is          │
+│  reasonable.                                             │
 └──────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 8. 演習問題
+## 8. Exercises
 
-### 演習 1: 基本 -- ファイル変換 Facade（難易度: ★☆☆）
+### Exercise 1: Basic -- File Conversion Facade (Difficulty: ★☆☆)
 
-以下のサブシステムを使って、`FileConverterFacade` を実装してください。
+Implement `FileConverterFacade` using the following subsystems.
 
 ```typescript
-// 与えられたサブシステム
+// Given subsystems
 class FileReader {
   read(path: string): string {
     console.log(`Reading ${path}`);
@@ -2214,12 +2221,12 @@ class FileWriter {
   }
 }
 
-// TODO: FileConverterFacade を実装
-// - convertCsvToJson(inputPath, outputPath) メソッドを提供
-// - 4 つのサブシステムを正しい順序で使う
+// TODO: Implement FileConverterFacade
+// - Provide a convertCsvToJson(inputPath, outputPath) method
+// - Use the 4 subsystems in the correct order
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 Reading data.csv
@@ -2229,7 +2236,7 @@ Writing to data.json
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Answer (click to expand)</summary>
 
 ```typescript
 class FileConverterFacade {
@@ -2241,16 +2248,16 @@ class FileConverterFacade {
   ) {}
 
   convertCsvToJson(inputPath: string, outputPath: string): void {
-    // 1. ファイル読み込み
+    // 1. Read file
     const content = this.reader.read(inputPath);
 
-    // 2. CSV パース
+    // 2. Parse CSV
     const data = this.parser.parse(content);
 
-    // 3. JSON フォーマット
+    // 3. Format to JSON
     const json = this.formatter.format(data);
 
-    // 4. ファイル書き込み
+    // 4. Write file
     this.writer.write(outputPath, json);
   }
 }
@@ -2263,7 +2270,7 @@ const converter = new FileConverterFacade(
 );
 
 converter.convertCsvToJson("data.csv", "data.json");
-// 出力:
+// Output:
 // Reading data.csv
 // Parsing CSV
 // Formatting to JSON
@@ -2274,22 +2281,22 @@ converter.convertCsvToJson("data.csv", "data.json");
 
 ---
 
-### 演習 2: 応用 -- 決済処理 Facade（難易度: ★★☆）
+### Exercise 2: Applied -- Payment Processing Facade (Difficulty: ★★☆)
 
-以下の要件を満たす `PaymentFacade` を設計・実装してください。
+Design and implement a `PaymentFacade` that meets the following requirements.
 
-**要件**:
-1. `processPayment(orderId, amount, method)` メソッドを提供
-2. 以下の手順を実行: 在庫確認 -> 決済処理 -> 在庫減算 -> 領収書生成 -> メール送信
-3. 決済失敗時は在庫を元に戻す（補償トランザクション）
-4. 各サブシステムはインタフェースで定義し、DI で注入
+**Requirements**:
+1. Provide a `processPayment(orderId, amount, method)` method
+2. Execute the following steps: stock check → payment processing → stock deduction → receipt generation → email notification
+3. On payment failure, restore the stock (compensating transaction)
+4. Define each subsystem with an interface and inject via DI
 
 ```typescript
-// サブシステムのインタフェース
+// Subsystem interfaces
 interface InventoryService {
   check(orderId: string): boolean;
   reserve(orderId: string): void;
-  release(orderId: string): void;  // 補償用
+  release(orderId: string): void;  // For compensation
 }
 
 interface PaymentGateway {
@@ -2305,7 +2312,7 @@ interface EmailService {
 }
 ```
 
-**期待される出力（正常系）**:
+**Expected output (happy path)**:
 
 ```
 Inventory: Checking order-123
@@ -2316,7 +2323,7 @@ Email: Sent to customer
 Payment complete: TX-abc
 ```
 
-**期待される出力（決済失敗）**:
+**Expected output (payment failure)**:
 
 ```
 Inventory: Checking order-123
@@ -2328,7 +2335,7 @@ Error: Payment failed
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Answer (click to expand)</summary>
 
 ```typescript
 class PaymentFacade {
@@ -2345,28 +2352,28 @@ class PaymentFacade {
     method: string,
     customerEmail: string = "customer@example.com",
   ): Promise<string> {
-    // 1. 在庫確認
+    // 1. Stock check
     if (!this.inventory.check(orderId)) {
       throw new Error("Out of stock");
     }
 
-    // 2. 在庫予約
+    // 2. Reserve stock
     this.inventory.reserve(orderId);
 
-    // 3. 決済（失敗時は在庫を元に戻す）
+    // 3. Payment (restore stock on failure)
     let txId: string;
     try {
       txId = await this.payment.charge(amount, method);
     } catch (error) {
-      // 補償トランザクション: 在庫を元に戻す
+      // Compensating transaction: restore stock
       this.inventory.release(orderId);
       throw error;
     }
 
-    // 4. 領収書生成
+    // 4. Generate receipt
     const receiptText = this.receipt.generate(orderId, txId, amount);
 
-    // 5. メール送信
+    // 5. Send email
     this.email.send(
       customerEmail,
       `Order ${orderId} confirmed`,
@@ -2377,7 +2384,7 @@ class PaymentFacade {
   }
 }
 
-// === テスト用の実装 ===
+// === Test implementations ===
 
 class MockInventory implements InventoryService {
   check(orderId: string): boolean {
@@ -2417,7 +2424,7 @@ class MockEmailService implements EmailService {
   }
 }
 
-// 正常系
+// Happy path
 const facade = new PaymentFacade(
   new MockInventory(),
   new MockPaymentGateway(false),
@@ -2427,10 +2434,10 @@ const facade = new PaymentFacade(
 const txId = await facade.processPayment("order-123", 5000, "credit_card");
 console.log(`Payment complete: ${txId}`);
 
-// 異常系
+// Error path
 const facadeFail = new PaymentFacade(
   new MockInventory(),
-  new MockPaymentGateway(true),  // 決済失敗
+  new MockPaymentGateway(true),  // Payment failure
   new MockReceiptService(),
   new MockEmailService(),
 );
@@ -2445,32 +2452,32 @@ try {
 
 ---
 
-### 演習 3: 発展 -- Facade のリファクタリング（難易度: ★★★）
+### Exercise 3: Advanced -- Facade Refactoring (Difficulty: ★★★)
 
-以下の God Facade を、適切に分割してリファクタリングしてください。
+Refactor the following God Facade by splitting it appropriately.
 
-**要件**:
-1. God Facade を 3 つ以上の Facade に分割
-2. 各 Facade は SRP を守る（1 ドメインのみ担当）
-3. Facade 間で共通のサブシステムがある場合は DI で共有
-4. 元のクライアントコードが最小限の変更で動作すること
+**Requirements**:
+1. Split the God Facade into 3 or more Facades
+2. Each Facade must follow SRP (responsible for only 1 domain)
+3. If subsystems are shared between Facades, share them via DI
+4. The original client code should work with minimal changes
 
 ```typescript
-// 現状の God Facade（リファクタリング対象）
+// Current God Facade (target for refactoring)
 class ECommerceFacade {
-  // ユーザー系
+  // User-related
   registerUser(name: string, email: string): User { /* ... */ }
   loginUser(email: string, password: string): string { /* ... */ }
   updateProfile(userId: string, data: Partial<User>): void { /* ... */ }
   deleteUser(userId: string): void { /* ... */ }
 
-  // 商品系
+  // Product-related
   listProducts(category?: string): Product[] { /* ... */ }
   searchProducts(query: string): Product[] { /* ... */ }
   getProductDetail(productId: string): Product { /* ... */ }
   addProductReview(productId: string, review: Review): void { /* ... */ }
 
-  // 注文系
+  // Order-related
   createOrder(userId: string, items: CartItem[]): Order { /* ... */ }
   cancelOrder(orderId: string): void { /* ... */ }
   trackOrder(orderId: string): OrderStatus { /* ... */ }
@@ -2478,14 +2485,14 @@ class ECommerceFacade {
   processPayment(orderId: string, method: string): void { /* ... */ }
   generateInvoice(orderId: string): string { /* ... */ }
 
-  // 通知系
+  // Notification-related
   sendEmail(to: string, template: string, vars: object): void { /* ... */ }
   sendSms(to: string, message: string): void { /* ... */ }
   sendPushNotification(deviceId: string, message: string): void { /* ... */ }
 }
 ```
 
-**期待する分割結果の構造**:
+**Expected split structure**:
 
 ```
 Before: 1 God Facade (16 methods)
@@ -2497,10 +2504,10 @@ After:  4 Domain Facades (3-5 methods each)
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Answer (click to expand)</summary>
 
 ```typescript
-// === 共通サブシステム ===
+// === Shared subsystems ===
 
 interface EventBus {
   emit(event: string, data: unknown): void;
@@ -2510,7 +2517,7 @@ interface AuditLogger {
   log(action: string, userId: string, detail: string): void;
 }
 
-// === 分割された Facade 群 ===
+// === Split Facades ===
 
 class UserFacade {
   constructor(
@@ -2573,8 +2580,8 @@ class OrderFacade {
     private payment: PaymentGateway,
     private inventory: InventoryService,
     private invoicing: InvoiceService,
-    private events: EventBus,        // UserFacade と共有
-    private audit: AuditLogger,      // UserFacade と共有
+    private events: EventBus,        // Shared with UserFacade
+    private audit: AuditLogger,      // Shared with UserFacade
   ) {}
 
   create(userId: string, items: CartItem[]): Order {
@@ -2635,10 +2642,10 @@ class NotificationFacade {
   }
 }
 
-// === DI コンテナでの構成 ===
+// === Configuration in DI container ===
 
 function createFacades(container: DIContainer) {
-  // 共通サブシステム
+  // Shared subsystems
   const events = container.get(EventBus);
   const audit = container.get(AuditLogger);
 
@@ -2646,8 +2653,8 @@ function createFacades(container: DIContainer) {
     users: new UserFacade(
       container.get(UserRepository),
       container.get(AuthService),
-      events,  // 共有
-      audit,   // 共有
+      events,  // shared
+      audit,   // shared
     ),
     products: new ProductFacade(
       container.get(CatalogService),
@@ -2659,8 +2666,8 @@ function createFacades(container: DIContainer) {
       container.get(PaymentGateway),
       container.get(InventoryService),
       container.get(InvoiceService),
-      events,  // 共有
-      audit,   // 共有
+      events,  // shared
+      audit,   // shared
     ),
     notifications: new NotificationFacade(
       container.get(EmailService),
@@ -2671,9 +2678,9 @@ function createFacades(container: DIContainer) {
   };
 }
 
-// === 移行用のアダプター（後方互換性） ===
+// === Adapter for backward compatibility ===
 
-/** @deprecated 個別の Facade を使用してください */
+/** @deprecated Please use the individual Facades */
 class LegacyECommerceFacade {
   constructor(
     private users: UserFacade,
@@ -2682,14 +2689,14 @@ class LegacyECommerceFacade {
     private notifications: NotificationFacade,
   ) {}
 
-  // 旧 API を新 Facade に委譲
+  // Delegate old API to new Facades
   registerUser(name: string, email: string): User {
     return this.users.register(name, email);
   }
   createOrder(userId: string, items: CartItem[]): Order {
     return this.orders.create(userId, items);
   }
-  // ... 他のメソッドも同様に委譲
+  // ... delegate other methods similarly
 }
 ```
 
@@ -2699,65 +2706,65 @@ class LegacyECommerceFacade {
 
 ## 9. FAQ
 
-### Q1: Facade は API Gateway と同じですか？
+### Q1: Is a Facade the same as an API Gateway?
 
-概念は同じです。API Gateway はネットワーク境界で動作する Facade パターンの大規模適用と言えます。両者の違いは以下の通りです。
+Conceptually, yes. An API Gateway can be described as a large-scale application of the Facade pattern operating at the network boundary. The differences are as follows:
 
-| 観点 | Facade（コード内） | API Gateway |
+| Aspect | Facade (in code) | API Gateway |
 |------|---------------------|-------------|
-| スコープ | アプリケーション内 | ネットワーク境界 |
-| プロトコル | メソッド呼び出し | HTTP/gRPC |
-| 追加責務 | なし | 認証、レート制限、ロードバランシング |
-| 例 | `UserFacade` クラス | Kong, AWS API Gateway |
+| Scope | Within the application | Network boundary |
+| Protocol | Method calls | HTTP/gRPC |
+| Additional responsibilities | None | Authentication, rate limiting, load balancing |
+| Example | `UserFacade` class | Kong, AWS API Gateway |
 
-### Q2: Facade を使うとテストが難しくなりませんか？
+### Q2: Does using a Facade make testing harder?
 
-いいえ、むしろ容易になります。DI でサブシステムを注入する設計にすれば、テスト時にモックを注入できます。Facade がなければ、クライアントが直接操作する全サブシステムをモックする必要があり、テストがより複雑になります。
+No, it actually makes it easier. If subsystems are injected via DI, mocks can be injected during testing. Without a Facade, clients must mock all subsystems they directly operate, making tests more complex.
 
-### Q3: React のカスタムフックは Facade ですか？
+### Q3: Is a React custom hook a Facade?
 
-はい。複数の Hook（useState, useEffect, useReducer 等）や API 呼び出しを内部に隠蔽し、コンポーネントにシンプルな API を提供する点で、Facade パターンの一形態です。React 公式ドキュメントでも「カスタムフックで複雑さを隠蔽する」設計が推奨されています。
+Yes. In that it hides multiple Hooks (useState, useEffect, useReducer, etc.) and API calls internally and provides a simple API to the component, it is a form of the Facade pattern. The React official documentation also recommends the design of "hiding complexity with custom hooks."
 
-### Q4: Facade とサービス層（Service Layer）の違いは何ですか？
+### Q4: What is the difference between a Facade and a Service Layer?
 
-Facade は構造パターンで「既存のサブシステム群を簡素化する入口」を提供します。Service Layer はアーキテクチャパターンで「ビジネスロジックの実行層」を定義します。実際にはサービス層が Facade の役割を兼ねることが多いです。
+A Facade is a structural pattern that provides an "entry point that simplifies existing subsystems." A Service Layer is an architectural pattern that defines "the execution layer for business logic." In practice, the service layer often also serves as a Facade.
 
-| 観点 | Facade | Service Layer |
+| Aspect | Facade | Service Layer |
 |------|--------|---------------|
-| 目的 | 複雑さの隠蔽 | ビジネスロジックの集約 |
-| ロジック | 最小限（委譲のみ） | ビジネスルールを含む |
-| トランザクション | 通常なし | トランザクション境界 |
-| 再利用 | プレゼンテーション層から | 複数のプレゼンテーションから |
+| Purpose | Hide complexity | Aggregate business logic |
+| Logic | Minimal (delegation only) | Contains business rules |
+| Transactions | Typically none | Transaction boundaries |
+| Reuse | From the presentation layer | From multiple presentations |
 
-### Q5: Facade の中にビジネスロジックを入れてもよいですか？
+### Q5: Is it acceptable to put business logic inside a Facade?
 
-原則として入れるべきではありません。Facade は「薄いオーケストレーション層」であるべきです。ビジネスロジックはサブシステム（ドメインサービス）に配置し、Facade はそれらの呼び出し順序の管理に専念してください。
+In principle, no. A Facade should be a "thin orchestration layer." Business logic should be placed in the subsystems (domain services), and the Facade should focus on managing the order in which they are called.
 
 ```typescript
-// NG: Facade にビジネスロジック
+// BAD: Business logic in Facade
 class BadFacade {
   placeOrder(items: Item[]) {
     const total = items.reduce((sum, i) => sum + i.price * i.qty, 0);
     if (total > 10000) {
-      const discount = total * 0.1;  // ← ビジネスロジック
+      const discount = total * 0.1;  // ← business logic
       // ...
     }
   }
 }
 
-// OK: ビジネスロジックはサブシステムに
+// GOOD: Business logic in subsystems
 class GoodFacade {
   placeOrder(items: Item[]) {
-    const total = this.pricing.calculate(items);  // ← サブシステムに委譲
+    const total = this.pricing.calculate(items);  // ← delegate to subsystem
     const order = this.orders.create(items, total);
     this.notify.send(order);
   }
 }
 ```
 
-### Q6: Facade パターンはマイクロサービスでどう使われますか？
+### Q6: How is the Facade pattern used in microservices?
 
-マイクロサービスアーキテクチャでは、**BFF（Backend for Frontend）** が Facade パターンの典型例です。モバイルアプリ用 BFF は複数のマイクロサービス（User, Product, Order, Payment）を集約して、1 つの API エンドポイントでクライアントに必要なデータをまとめて返します。
+In microservice architecture, the **BFF (Backend for Frontend)** is a typical example of the Facade pattern. A mobile BFF aggregates multiple microservices (User, Product, Order, Payment) and returns all the data the client needs from a single API endpoint.
 
 ```
 Mobile App
@@ -2778,47 +2785,47 @@ Mobile App
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just through theory but by actually writing code and verifying behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend solidly understanding the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is it used in practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| **目的** | 複雑なサブシステム群に統一された簡潔なインタフェースを提供 |
-| **本質** | 情報隠蔽 + 手順のカプセル化 + ショートカット |
-| **利点** | クライアントの簡素化、疎結合、DRY、テスト容易性 |
-| **適用レベル** | 関数 / モジュール / クラス / サービス / インフラ |
-| **アンチパターン** | God Facade / Leaky Facade / Rigid Facade |
-| **注意** | Facade は「壁」ではなく「門」。直接アクセスも許容する |
-| **テスト** | DI でサブシステムを注入し、モックでテスト |
-| **組み合わせ** | Strategy, Observer, Template Method と併用可能 |
+| **Purpose** | Provide a unified, simplified interface to a set of complex subsystems |
+| **Essence** | Information hiding + encapsulation of procedures + shortcut |
+| **Benefits** | Simplified client, loose coupling, DRY, testability |
+| **Application levels** | Function / module / class / service / infrastructure |
+| **Anti-patterns** | God Facade / Leaky Facade / Rigid Facade |
+| **Note** | A Facade is a "gate," not a "wall." Direct access should also be permitted |
+| **Testing** | Inject subsystems via DI and test with mocks |
+| **Combinations** | Can be used together with Strategy, Observer, Template Method |
 
 ---
 
-## 次に読むべきガイド
+## Recommended Next Guides
 
-- [Proxy パターン](./03-proxy.md) -- アクセス制御の代理オブジェクト
-- [Adapter パターン](./00-adapter.md) -- インタフェース変換
-- [Decorator パターン](./01-decorator.md) -- 動的な機能追加
-- [Composite パターン](./04-composite.md) -- ツリー構造の統一操作
-- [Mediator パターン](../02-behavioral/00-observer.md) -- オブジェクト間の調停
-- [クリーンアーキテクチャ](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) -- 層構造設計
+- [Proxy Pattern](./03-proxy.md) -- Proxy object for access control
+- [Adapter Pattern](./00-adapter.md) -- Interface conversion
+- [Decorator Pattern](./01-decorator.md) -- Dynamic feature addition
+- [Composite Pattern](./04-composite.md) -- Unified operations on tree structures
+- [Mediator Pattern](../02-behavioral/00-observer.md) -- Mediation between objects
+- [Clean Architecture](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) -- Layered structure design
 
 ---
 
-## 参考文献
+## References
 
 1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley.
 2. Freeman, E. et al. (2004). *Head First Design Patterns*. O'Reilly Media.

--- a/03-software-design/design-patterns-guide/docs/01-structural/03-proxy.md
+++ b/03-software-design/design-patterns-guide/docs/01-structural/03-proxy.md
@@ -1,121 +1,121 @@
-# Proxy パターン
+# Proxy Pattern
 
-> 別のオブジェクトへの **アクセスを制御する代理オブジェクト** を提供し、遅延初期化・アクセス制御・キャッシュなどの横断的関心事を実装する構造パターン。
+> A structural pattern that provides a **surrogate object to control access** to another object, implementing cross-cutting concerns such as lazy initialization, access control, and caching.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| インタフェースと多態性 | 基本 | TypeScript / Java / Python の OOP |
-| 依存性注入 (DI) | 基本 | [クリーンアーキテクチャ](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) |
-| 非同期プログラミング | 基本 | Promise / async-await |
-| Decorator パターン | 推奨 | [Decorator パターン](./01-decorator.md) |
-| ES6 Proxy / Reflect | 推奨 | MDN Web Docs |
+| Interfaces and polymorphism | Basic | TypeScript / Java / Python OOP |
+| Dependency Injection (DI) | Basic | [Clean Architecture](../../../system-design-guide/docs/02-architecture/01-clean-architecture.md) |
+| Asynchronous programming | Basic | Promise / async-await |
+| Decorator pattern | Recommended | [Decorator Pattern](./01-decorator.md) |
+| ES6 Proxy / Reflect | Recommended | MDN Web Docs |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn in This Chapter
 
-1. Proxy パターンが解決する「アクセス制御」問題と、その 5 つの分類（Virtual / Protection / Cache / Remote / Logging）
-2. GoF Proxy パターンと JavaScript ES6 Proxy の関係および本質的な違い
-3. Proxy と Decorator の明確な使い分け基準
-4. 5 言語（TypeScript, Python, Java, Go, Kotlin）での実装パターン
-5. Proxy チェーン、動的 Proxy 生成、Smart Reference の高度なテクニック
+1. The "access control" problem that the Proxy pattern solves, and its 5 classifications (Virtual / Protection / Cache / Remote / Logging)
+2. The relationship and essential differences between the GoF Proxy pattern and JavaScript ES6 Proxy
+3. Clear criteria for choosing between Proxy and Decorator
+4. Implementation patterns in 5 languages (TypeScript, Python, Java, Go, Kotlin)
+5. Advanced techniques: Proxy chains, dynamic Proxy generation, and Smart References
 
 ---
 
-## 1. なぜ Proxy が必要なのか（WHY）
+## 1. Why Is Proxy Necessary? (WHY)
 
-### 1.1 Proxy なしの世界
+### 1.1 A World Without Proxy
 
-あるオブジェクトを使うとき、以下のような横断的関心事が生じる。
+When using an object, the following cross-cutting concerns arise.
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  Proxy なし: 横断的関心事がクライアントに散らばる         │
+│  Without Proxy: cross-cutting concerns scattered in client │
 │                                                          │
 │  Client A:                                               │
-│    if (!user.isAdmin) throw "Access denied";  ← 認証     │
-│    const cached = cache.get(key);              ← キャッシュ│
+│    if (!user.isAdmin) throw "Access denied";  ← auth     │
+│    const cached = cache.get(key);              ← cache   │
 │    if (!cached) {                                        │
-│      const data = service.getData();           ← 本来の処理│
-│      cache.set(key, data);                     ← キャッシュ│
+│      const data = service.getData();           ← business logic │
+│      cache.set(key, data);                     ← cache   │
 │    }                                                     │
-│    logger.log("getData called");               ← ログ    │
+│    logger.log("getData called");               ← log     │
 │                                                          │
 │  Client B:                                               │
-│    if (!user.isAdmin) throw "Access denied";  ← 同じ認証 │
-│    const cached = cache.get(key);              ← 同じ     │
-│    if (!cached) {                              キャッシュ  │
+│    if (!user.isAdmin) throw "Access denied";  ← same auth │
+│    const cached = cache.get(key);              ← same    │
+│    if (!cached) {                              cache      │
 │      const data = service.getData();                     │
 │      cache.set(key, data);                               │
 │    }                                                     │
-│    logger.log("getData called");               ← 同じログ │
+│    logger.log("getData called");               ← same log │
 │                                                          │
-│  問題:                                                   │
-│  - 認証・キャッシュ・ログが全クライアントに重複           │
-│  - ビジネスロジックと横断的関心事が混在                   │
-│  - テストで横断的関心事を分離できない                     │
-│  - 新しい横断的関心事の追加に全クライアントの修正が必要   │
+│  Problems:                                               │
+│  - Auth, cache, and log are duplicated across all clients │
+│  - Business logic and cross-cutting concerns are mixed   │
+│  - Cross-cutting concerns cannot be isolated in tests    │
+│  - Adding a new concern requires modifying all clients   │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 現実世界のアナロジー
+### 1.2 Real-World Analogy
 
-**銀行のATM** を考えてみよう。ATM は銀行口座（RealSubject）への代理（Proxy）である。
+Think of a **bank ATM**. The ATM is a proxy for the bank account (RealSubject).
 
-- 本人確認（暗証番号） = **Protection Proxy**
-- 残高キャッシュ（毎回DBに問い合わせない） = **Cache Proxy**
-- 取引記録（通帳記帳） = **Logging Proxy**
-- リモートの銀行システムへの接続 = **Remote Proxy**
+- Identity verification (PIN) = **Protection Proxy**
+- Balance caching (no DB query every time) = **Cache Proxy**
+- Transaction recording (passbook entry) = **Logging Proxy**
+- Connection to the remote banking system = **Remote Proxy**
 
-ATM を通じて口座にアクセスするが、ATM と口座は同じ「取引」インタフェースを持つ。クライアント（利用者）は ATM を通じても、窓口で直接でも、同じ操作ができる。
+Customers access their accounts through the ATM, and both the ATM and the account share the same "transaction" interface. The client (customer) can perform the same operations whether through the ATM or directly at the counter.
 
-### 1.3 Proxy ありの世界
+### 1.3 A World With Proxy
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  Proxy あり: 横断的関心事が Proxy に集約                  │
+│  With Proxy: cross-cutting concerns consolidated in Proxy │
 │                                                          │
 │  Client A ──▶ Proxy.getData()                            │
 │  Client B ──▶ Proxy.getData()                            │
 │                    │                                     │
-│                    ├── 認証チェック（Protection）         │
-│                    ├── キャッシュ確認（Cache）            │
-│                    ├── service.getData()（委譲）          │
-│                    ├── キャッシュ保存（Cache）            │
-│                    └── ログ記録（Logging）                │
+│                    ├── Auth check (Protection)           │
+│                    ├── Cache lookup (Cache)              │
+│                    ├── service.getData() (delegation)    │
+│                    ├── Cache store (Cache)               │
+│                    └── Log record (Logging)              │
 │                                                          │
-│  利点:                                                   │
-│  - 横断的関心事の一元管理                                 │
-│  - クライアントは本来の処理にだけ集中                     │
-│  - Proxy は RealSubject と同じインタフェース              │
-│  - クライアントは Proxy の存在を意識しない（透過的）      │
+│  Benefits:                                               │
+│  - Centralized management of cross-cutting concerns      │
+│  - Clients focus only on the core logic                  │
+│  - Proxy shares the same interface as RealSubject        │
+│  - Proxy is transparent to the client                    │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 1.4 Proxy パターンの本質
+### 1.4 The Essence of the Proxy Pattern
 
-Proxy の本質は「**同じインタフェースを持つ代理オブジェクトを通じてアクセスを制御する**」ことである。
+The essence of Proxy is **"controlling access through a surrogate object with the same interface"**.
 
-1. **同一インタフェース**: Proxy と RealSubject は同じインタフェースを実装
-2. **透過性**: クライアントは Proxy と RealSubject を区別できない
-3. **アクセス制御**: 遅延初期化、認証、キャッシュ、ログなどの横断的関心事を挿入
-4. **ライフサイクル管理**: Proxy が RealSubject の生成・破棄を管理できる
+1. **Same interface**: Proxy and RealSubject implement the same interface
+2. **Transparency**: Clients cannot distinguish between Proxy and RealSubject
+3. **Access control**: Insert cross-cutting concerns such as lazy initialization, auth, caching, and logging
+4. **Lifecycle management**: Proxy can manage the creation and destruction of RealSubject
 
-> **Proxy vs Decorator の本質的な違い**: Proxy は「アクセスの制御」、Decorator は「機能の追加」が目的。Proxy は RealSubject のライフサイクルを管理するが、Decorator は外部から渡されたオブジェクトを装飾する。
+> **The essential difference between Proxy and Decorator**: Proxy's purpose is "access control"; Decorator's purpose is "adding functionality". Proxy manages the lifecycle of RealSubject, while Decorator decorates an externally provided object.
 
 ---
 
-## 2. Proxy の構造
+## 2. Proxy Structure
 
-### 2.1 クラス図
+### 2.1 Class Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                      UML クラス図                        │
+│                      UML Class Diagram                   │
 │                                                         │
 │            ┌──────────────────┐                          │
 │            │    <<interface>> │                          │
@@ -132,9 +132,9 @@ Proxy の本質は「**同じインタフェースを持つ代理オブジェク
 │  │ - real: Subject  │──│ + request()     │             │
 │  │ + request()      │  │                 │             │
 │  │  {               │  └─────────────────┘             │
-│  │   // 前処理      │                                  │
+│  │   // pre-process │                                  │
 │  │   real.request() │                                  │
-│  │   // 後処理      │                                  │
+│  │   // post-process│                                  │
 │  │  }               │                                  │
 │  └──────────────────┘                                  │
 │                                                         │
@@ -142,63 +142,63 @@ Proxy の本質は「**同じインタフェースを持つ代理オブジェク
 │  │  Client  │──────▶ Subject (Proxy or RealSubject)    │
 │  └──────────┘                                          │
 │                                                         │
-│  ポイント:                                              │
-│  - Client は Subject インタフェースにのみ依存           │
-│  - Proxy は RealSubject への参照を内部に持つ            │
-│  - Proxy が RealSubject のライフサイクルを管理可能      │
+│  Key points:                                            │
+│  - Client depends only on the Subject interface         │
+│  - Proxy holds a reference to RealSubject internally    │
+│  - Proxy can manage the lifecycle of RealSubject        │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### 2.2 Proxy の種類と分類
+### 2.2 Types and Classifications of Proxy
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│                   Proxy の分類体系                        │
+│                   Proxy Classification System             │
 │                                                          │
 │  ┌──────────────┬───────────────────────────────────┐   │
-│  │ Virtual      │ 重いオブジェクトの遅延初期化       │   │
-│  │ Proxy        │ 例: 画像、DB接続、大量データ       │   │
-│  │              │ 目的: パフォーマンス最適化          │   │
+│  │ Virtual      │ Lazy initialization of heavy objects│  │
+│  │ Proxy        │ e.g. images, DB connections, large data││
+│  │              │ Purpose: performance optimization    │  │
 │  ├──────────────┼───────────────────────────────────┤   │
-│  │ Protection   │ アクセス権限のチェック              │   │
-│  │ Proxy        │ 例: RBAC、認証・認可ガード         │   │
-│  │              │ 目的: セキュリティ                  │   │
+│  │ Protection   │ Access permission checks           │   │
+│  │ Proxy        │ e.g. RBAC, authentication/authz   │   │
+│  │              │ Purpose: security                  │   │
 │  ├──────────────┼───────────────────────────────────┤   │
-│  │ Cache        │ 結果のキャッシュ（メモ化）         │   │
-│  │ Proxy        │ 例: API応答、DB結果、計算結果      │   │
-│  │              │ 目的: パフォーマンス最適化          │   │
+│  │ Cache        │ Result caching (memoization)       │   │
+│  │ Proxy        │ e.g. API responses, DB results     │   │
+│  │              │ Purpose: performance optimization  │   │
 │  ├──────────────┼───────────────────────────────────┤   │
-│  │ Remote       │ リモートオブジェクトのローカル代理 │   │
-│  │ Proxy        │ 例: RPC, gRPC, GraphQL スタブ      │   │
-│  │              │ 目的: 分散システムの透過性          │   │
+│  │ Remote       │ Local proxy for a remote object    │   │
+│  │ Proxy        │ e.g. RPC, gRPC, GraphQL stubs      │   │
+│  │              │ Purpose: transparency in distributed systems│
 │  ├──────────────┼───────────────────────────────────┤   │
-│  │ Logging      │ 操作の記録・監査・メトリクス       │   │
-│  │ Proxy        │ 例: メソッド呼び出しトレース       │   │
-│  │              │ 目的: 可観測性                      │   │
+│  │ Logging      │ Operation recording/audit/metrics  │   │
+│  │ Proxy        │ e.g. method call tracing           │   │
+│  │              │ Purpose: observability             │   │
 │  ├──────────────┼───────────────────────────────────┤   │
-│  │ Smart        │ 追加のハウスキーピング処理         │   │
-│  │ Reference    │ 例: 参照カウント、変更通知         │   │
-│  │              │ 目的: リソース管理                  │   │
+│  │ Smart        │ Additional housekeeping processing │   │
+│  │ Reference    │ e.g. reference counting, change notification│
+│  │              │ Purpose: resource management       │   │
 │  └──────────────┴───────────────────────────────────┘   │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 2.3 シーケンス図（Virtual Proxy）
+### 2.3 Sequence Diagram (Virtual Proxy)
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                シーケンス図: Virtual Proxy                │
+│                Sequence Diagram: Virtual Proxy            │
 │                                                         │
 │  Client        Proxy          RealSubject               │
 │    │             │                                      │
 │    │ new Proxy() │                                      │
-│    │────────────▶│  (RealSubject はまだ生成されない)     │
+│    │────────────▶│  (RealSubject is not yet created)    │
 │    │             │                                      │
 │    │ request()   │                                      │
 │    │────────────▶│                                      │
 │    │             │ [real == null?]                       │
 │    │             │── Yes ──▶ new RealSubject()           │
-│    │             │           (ここで初めて生成)          │
+│    │             │           (created here for the first time) │
 │    │             │                  │                    │
 │    │             │ real.request()   │                    │
 │    │             │─────────────────▶│                    │
@@ -207,7 +207,7 @@ Proxy の本質は「**同じインタフェースを持つ代理オブジェク
 │    │  result     │                  │                    │
 │    │◀────────────│                  │                    │
 │    │             │                                      │
-│    │ request()   │  (2回目: すでに生成済み)             │
+│    │ request()   │  (2nd call: already created)         │
 │    │────────────▶│                                      │
 │    │             │ [real != null]                        │
 │    │             │ real.request()   │                    │
@@ -221,12 +221,12 @@ Proxy の本質は「**同じインタフェースを持つ代理オブジェク
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: Virtual Proxy -- 遅延初期化（TypeScript）
+### Code Example 1: Virtual Proxy -- Lazy Initialization (TypeScript)
 
 ```typescript
-// === Subject インタフェース ===
+// === Subject Interface ===
 
 interface Image {
   display(): void;
@@ -240,10 +240,10 @@ class HighResImage implements Image {
   private data: Uint8Array;
 
   constructor(private filename: string) {
-    // 重い処理: ファイルを読み込む（コンストラクタで実行）
+    // Heavy operation: read file (executed in constructor)
     console.log(`[HighResImage] Loading ${filename} from disk...`);
     console.log(`[HighResImage] Decoding image data...`);
-    this.data = new Uint8Array(10_000_000); // 10MB のバッファ
+    this.data = new Uint8Array(10_000_000); // 10MB buffer
     console.log(`[HighResImage] ${filename} loaded (${this.data.length} bytes)`);
   }
 
@@ -266,7 +266,7 @@ class ImageProxy implements Image {
   private real: HighResImage | null = null;
 
   constructor(private filename: string) {
-    // Proxy の生成は軽量（ファイル読み込みは行わない）
+    // Proxy creation is lightweight (no file loading)
     console.log(`[ImageProxy] Created proxy for ${filename}`);
   }
 
@@ -287,12 +287,12 @@ class ImageProxy implements Image {
   }
 
   getFilename(): string {
-    // ファイル名はProxyが知っているので、RealSubjectを生成する必要がない
+    // The proxy already knows the filename, so no need to create RealSubject
     return this.filename;
   }
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 console.log("=== Creating image gallery ===");
 const gallery: Image[] = [
@@ -303,29 +303,29 @@ const gallery: Image[] = [
   new ImageProxy("photo5.jpg"),
 ];
 console.log(`Gallery has ${gallery.length} images`);
-// 出力: 5 つの Proxy が作られるだけ。画像データは未ロード。
+// Output: only 5 Proxies are created. Image data is not loaded yet.
 
 console.log("\n=== User scrolls to image 2 ===");
 gallery[1].display();
-// 出力: photo2.jpg のみロードされる
+// Output: only photo2.jpg is loaded
 
 console.log("\n=== User scrolls to image 2 again ===");
 gallery[1].display();
-// 出力: すでにロード済みなので即座に表示
+// Output: already loaded, so displays immediately
 
 console.log("\n=== Getting filename (no loading needed) ===");
 console.log(gallery[3].getFilename());
-// 出力: photo4.jpg（ロードなしで返せる）
+// Output: photo4.jpg (can be returned without loading)
 ```
 
-**ポイント**: 5 枚の画像のうち、実際にロードされるのはユーザーが表示した画像だけ。`getFilename()` はロードなしで返せるメソッドの例。
+**Key point**: Of the 5 images, only the ones the user views are actually loaded. `getFilename()` is an example of a method that can return without triggering a load.
 
 ---
 
-### コード例 2: Protection Proxy -- RBAC アクセス制御（TypeScript）
+### Code Example 2: Protection Proxy -- RBAC Access Control (TypeScript)
 
 ```typescript
-// === Subject インタフェース ===
+// === Subject Interface ===
 
 interface AdminService {
   listUsers(): User[];
@@ -375,7 +375,7 @@ class RealAdminService implements AdminService {
 
 type Role = User["role"];
 
-// メソッドごとの必要ロールを定義
+// Declare the required roles per method
 const REQUIRED_ROLES: Record<keyof AdminService, Role[]> = {
   listUsers: ["viewer", "editor", "admin", "superadmin"],
   deleteUser: ["admin", "superadmin"],
@@ -409,7 +409,7 @@ class AdminProxy implements AdminService {
 
   deleteUser(userId: string): void {
     this.checkAccess("deleteUser");
-    // 追加チェック: 自分自身は削除できない
+    // Additional check: cannot delete yourself
     if (userId === this.currentUser.id) {
       throw new Error("Cannot delete yourself");
     }
@@ -427,32 +427,32 @@ class AdminProxy implements AdminService {
   }
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 const realService = new RealAdminService();
 
-// Admin ユーザー
+// Admin user
 const admin: User = { id: "1", name: "Alice", role: "admin" };
 const adminProxy = new AdminProxy(realService, admin);
 adminProxy.listUsers();       // OK
 adminProxy.deleteUser("2");   // OK
 // adminProxy.resetDatabase(); // Error: requires superadmin
 
-// Viewer ユーザー
+// Viewer user
 const viewer: User = { id: "2", name: "Bob", role: "viewer" };
 const viewerProxy = new AdminProxy(realService, viewer);
 viewerProxy.listUsers();      // OK
 // viewerProxy.deleteUser("1"); // Error: requires admin or superadmin
 ```
 
-**ポイント**: `REQUIRED_ROLES` テーブルでメソッドごとの必要ロールを宣言的に定義。新しいメソッド追加時もテーブルに 1 行追加するだけ。
+**Key point**: The `REQUIRED_ROLES` table declaratively defines the required role per method. When adding a new method, just add one row to the table.
 
 ---
 
-### コード例 3: Cache Proxy -- TTL + LRU キャッシュ（TypeScript）
+### Code Example 3: Cache Proxy -- TTL + LRU Cache (TypeScript)
 
 ```typescript
-// === Subject インタフェース ===
+// === Subject Interface ===
 
 interface ApiClient {
   fetchUser(id: string): Promise<User>;
@@ -476,7 +476,7 @@ interface Post {
 class RealApiClient implements ApiClient {
   async fetchUser(id: string): Promise<User> {
     console.log(`[API] GET /users/${id} (network request)`);
-    // 実際はHTTPリクエスト
+    // In practice, this would be an HTTP request
     await new Promise(r => setTimeout(r, 100));
     return { id, name: `User-${id}`, email: `user${id}@example.com` };
   }
@@ -490,7 +490,7 @@ class RealApiClient implements ApiClient {
   }
 }
 
-// === LRU キャッシュ実装 ===
+// === LRU Cache Implementation ===
 
 class LRUCache<T> {
   private cache = new Map<string, { data: T; expiry: number }>();
@@ -510,7 +510,7 @@ class LRUCache<T> {
       return undefined;
     }
 
-    // LRU: アクセスされたエントリを末尾に移動
+    // LRU: move accessed entry to the end
     this.cache.delete(key);
     this.cache.set(key, entry);
     console.log(`[Cache] HIT: ${key}`);
@@ -518,7 +518,7 @@ class LRUCache<T> {
   }
 
   set(key: string, data: T): void {
-    // 容量超過時は最も古いエントリを削除
+    // When capacity is exceeded, delete the oldest entry
     if (this.cache.size >= this.maxSize) {
       const oldestKey = this.cache.keys().next().value;
       if (oldestKey) {
@@ -579,35 +579,35 @@ class CachingApiProxy implements ApiClient {
     return posts;
   }
 
-  /** キャッシュを手動で無効化 */
+  /** Manually invalidate the cache */
   invalidateUser(id: string): void {
     this.cache.invalidate(`user:${id}`);
   }
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 const api: ApiClient = new CachingApiProxy(new RealApiClient(), 50, 30_000);
 
-// 1回目: キャッシュなし → ネットワークリクエスト
+// 1st call: no cache → network request
 const user1 = await api.fetchUser("42");
-// 出力: [Cache] key not found
-// 出力: [API] GET /users/42 (network request)
-// 出力: [Cache] STORED: user:42
+// Output: [Cache] key not found
+// Output: [API] GET /users/42 (network request)
+// Output: [Cache] STORED: user:42
 
-// 2回目: キャッシュヒット → ネットワークリクエストなし
+// 2nd call: cache hit → no network request
 const user2 = await api.fetchUser("42");
-// 出力: [Cache] HIT: user:42
+// Output: [Cache] HIT: user:42
 ```
 
-**ポイント**: LRU（Least Recently Used）とTTL（Time To Live）を組み合わせたキャッシュ Proxy。`invalidateUser` で明示的なキャッシュ無効化も可能。
+**Key point**: A cache Proxy combining LRU (Least Recently Used) and TTL (Time To Live). `invalidateUser` allows explicit cache invalidation.
 
 ---
 
-### コード例 4: ES6 Proxy -- メタプログラミング（TypeScript）
+### Code Example 4: ES6 Proxy -- Metaprogramming (TypeScript)
 
 ```typescript
-// === ES6 Proxy を使ったバリデーション ===
+// === Validation using ES6 Proxy ===
 
 interface UserData {
   name: string;
@@ -666,7 +666,7 @@ function createValidatedUser(initial: UserData): UserData {
   });
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 const user = createValidatedUser({ name: "Taro", age: 30, email: "taro@example.com" });
 
@@ -681,10 +681,10 @@ console.log(user.name);  // "Hanako"
 
 ---
 
-### コード例 5: ES6 Proxy -- リアクティブ変更検知（TypeScript）
+### Code Example 5: ES6 Proxy -- Reactive Change Detection (TypeScript)
 
 ```typescript
-// === Vue.js 風のリアクティブシステム ===
+// === Vue.js-style reactive system ===
 
 type Listener = () => void;
 
@@ -702,7 +702,7 @@ function reactive<T extends object>(target: T, onChange: Listener): T {
 
     get(obj: T, prop: string | symbol): unknown {
       const value = (obj as Record<string | symbol, unknown>)[prop];
-      // ネストされたオブジェクトも再帰的にリアクティブ化
+      // Recursively make nested objects reactive as well
       if (value && typeof value === "object" && !Array.isArray(value)) {
         return reactive(value as object, onChange);
       }
@@ -713,7 +713,7 @@ function reactive<T extends object>(target: T, onChange: Listener): T {
   return new Proxy(target, handler);
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 interface AppState {
   count: number;
@@ -741,28 +741,28 @@ const state = reactive<AppState>(
 );
 
 state.count = 1;
-// 出力: [Reactive] count: 0 -> 1
-// 出力: [App] Re-render #1
+// Output: [Reactive] count: 0 -> 1
+// Output: [App] Re-render #1
 
 state.user.name = "Hanako";
-// 出力: [Reactive] name: Taro -> Hanako
-// 出力: [App] Re-render #2
+// Output: [Reactive] name: Taro -> Hanako
+// Output: [App] Re-render #2
 
 state.user.settings.theme = "dark";
-// 出力: [Reactive] theme: light -> dark
-// 出力: [App] Re-render #3
+// Output: [Reactive] theme: light -> dark
+// Output: [App] Re-render #3
 
-state.count = 1; // 同じ値 → 変更なし → 再レンダリングなし
+state.count = 1; // same value → no change → no re-render
 ```
 
-**ポイント**: Vue.js 3 のリアクティブシステムはこの ES6 Proxy ベースの設計。プロパティアクセスをトラップしてネストされたオブジェクトも再帰的にリアクティブ化する。
+**Key point**: Vue.js 3's reactive system is based on this ES6 Proxy design. It traps property access and recursively makes nested objects reactive.
 
 ---
 
-### コード例 6: Logging Proxy -- メソッド呼び出しの自動トレース（TypeScript）
+### Code Example 6: Logging Proxy -- Automatic Method Call Tracing (TypeScript)
 
 ```typescript
-// === 汎用 Logging Proxy ファクトリ ===
+// === Generic Logging Proxy factory ===
 
 interface LogEntry {
   method: string;
@@ -813,7 +813,7 @@ function createLoggingProxy<T extends object>(
         try {
           const result = (value as Function).apply(obj, args);
 
-          // Promise を検知して非同期もトレース
+          // Detect Promise and trace async methods too
           if (result instanceof Promise) {
             return result
               .then((resolved: unknown) => {
@@ -845,7 +845,7 @@ function createLoggingProxy<T extends object>(
   });
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 class UserRepository {
   findById(id: string): User | null {
@@ -867,23 +867,23 @@ const repo = createLoggingProxy(new UserRepository(), {
 });
 
 repo.findById("42");
-// 出力: [UserRepo] findById("42") -> {"id":"42","name":"User-42",...} [0ms]
+// Output: [UserRepo] findById("42") -> {"id":"42","name":"User-42",...} [0ms]
 
 await repo.save({ id: "1", name: "New", email: "new@example.com" });
-// 出力: [UserRepo] save({"id":"1",...}) [51ms]
+// Output: [UserRepo] save({"id":"1",...}) [51ms]
 
 try {
   repo.delete("1");
 } catch (e) {
-  // 出力: [UserRepo] delete("1") ERROR: Not implemented [0ms]
+  // Output: [UserRepo] delete("1") ERROR: Not implemented [0ms]
 }
 ```
 
-**ポイント**: ES6 Proxy を使って、任意のオブジェクトに対して自動的にログ Proxy を生成。同期・非同期メソッドの両方に対応し、実行時間も計測する。
+**Key point**: Uses ES6 Proxy to automatically generate a logging Proxy for any object. Supports both synchronous and asynchronous methods, and measures execution time.
 
 ---
 
-### コード例 7: Python -- 動的 Proxy（`__getattr__`）
+### Code Example 7: Python -- Dynamic Proxy (`__getattr__`)
 
 ```python
 from abc import ABC, abstractmethod
@@ -904,7 +904,7 @@ class Database(ABC):
 
 class PostgresDatabase(Database):
     def query(self, sql: str) -> list[dict]:
-        time.sleep(0.05)  # ネットワーク遅延のシミュレーション
+        time.sleep(0.05)  # Simulate network latency
         print(f"[Postgres] Executing query: {sql}")
         return [{"id": 1, "name": "Taro"}]
 
@@ -917,7 +917,7 @@ class PostgresDatabase(Database):
 # === Logging Proxy ===
 
 class LoggingProxy:
-    """__getattr__ を使った汎用 Logging Proxy"""
+    """Generic Logging Proxy using __getattr__"""
 
     def __init__(self, target: Any, name: str = ""):
         self._target = target
@@ -954,7 +954,7 @@ class LoggingProxy:
 # === Cache Proxy ===
 
 class CachingProxy:
-    """TTL 付きキャッシュ Proxy"""
+    """Cache Proxy with TTL"""
 
     def __init__(self, target: Any, ttl: float = 60.0):
         self._target = target
@@ -971,7 +971,7 @@ class CachingProxy:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             key = f"{attr}:{args!r}:{kwargs!r}"
 
-            # キャッシュチェック
+            # Cache check
             if key in self._cache:
                 result, expiry = self._cache[key]
                 if time.time() < expiry:
@@ -989,33 +989,33 @@ class CachingProxy:
         return wrapper
 
 
-# === Proxy チェーン ===
+# === Proxy Chain ===
 
 db: Database = PostgresDatabase()
-db = CachingProxy(db, ttl=30.0)   # キャッシュ層
-db = LoggingProxy(db, "DB")        # ログ層
+db = CachingProxy(db, ttl=30.0)   # cache layer
+db = LoggingProxy(db, "DB")        # logging layer
 
-# 1回目: キャッシュミス → DB アクセス
+# 1st call: cache miss → DB access
 result = db.query("SELECT * FROM users")
-# 出力:
+# Output:
 # [DB] query('SELECT * FROM users')
 # [Cache] MISS: query:('SELECT * FROM users',):{}
 # [Postgres] Executing query: SELECT * FROM users
 # [DB] query -> [{'id': 1, 'name': 'Taro'}] [52.3ms]
 
-# 2回目: キャッシュヒット
+# 2nd call: cache hit
 result = db.query("SELECT * FROM users")
-# 出力:
+# Output:
 # [DB] query('SELECT * FROM users')
 # [Cache] HIT: query:('SELECT * FROM users',):{}
 # [DB] query -> [{'id': 1, 'name': 'Taro'}] [0.1ms]
 ```
 
-**ポイント**: Python の `__getattr__` を使うと、GoF Proxy パターンをインタフェースなしで実装できる。CachingProxy と LoggingProxy のチェーンで、Decorator パターン的な合成も可能。
+**Key point**: Using Python's `__getattr__`, the GoF Proxy pattern can be implemented without interfaces. Chaining CachingProxy and LoggingProxy also enables Decorator-style composition.
 
 ---
 
-### コード例 8: Java -- 動的 Proxy（java.lang.reflect.Proxy）
+### Code Example 8: Java -- Dynamic Proxy (java.lang.reflect.Proxy)
 
 ```java
 import java.lang.reflect.InvocationHandler;
@@ -1023,7 +1023,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
 
-// === Subject インタフェース ===
+// === Subject Interface ===
 
 interface UserService {
     User findById(String id);
@@ -1057,7 +1057,7 @@ class UserServiceImpl implements UserService {
     }
 }
 
-// === 動的 Proxy (InvocationHandler) ===
+// === Dynamic Proxy (InvocationHandler) ===
 
 class LoggingHandler implements InvocationHandler {
     private final Object target;
@@ -1097,7 +1097,7 @@ class CachingHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        // void メソッドはキャッシュしない
+        // Do not cache void methods
         if (method.getReturnType() == void.class) {
             return method.invoke(target, args);
         }
@@ -1115,7 +1115,7 @@ class CachingHandler implements InvocationHandler {
     }
 }
 
-// === 動的 Proxy ファクトリ ===
+// === Dynamic Proxy Factory ===
 
 class ProxyFactory {
     @SuppressWarnings("unchecked")
@@ -1137,13 +1137,13 @@ class ProxyFactory {
     }
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 public class Main {
     public static void main(String[] args) {
         UserService real = new UserServiceImpl();
 
-        // キャッシュ + ログの Proxy チェーン
+        // Proxy chain: cache + logging
         UserService cached = ProxyFactory.createCachingProxy(real, UserService.class);
         UserService logged = ProxyFactory.createLoggingProxy(cached, UserService.class);
 
@@ -1161,11 +1161,11 @@ public class Main {
 }
 ```
 
-**ポイント**: Java の `java.lang.reflect.Proxy` を使うと、インタフェースに対して動的に Proxy を生成できる。Spring AOP やHibernate の遅延ロードも同じ仕組み。
+**Key point**: Java's `java.lang.reflect.Proxy` allows dynamic Proxy generation against interfaces. Spring AOP and Hibernate's lazy loading use the same mechanism.
 
 ---
 
-### コード例 9: Go -- インタフェースベース Proxy
+### Code Example 9: Go -- Interface-Based Proxy
 
 ```go
 package main
@@ -1177,7 +1177,7 @@ import (
     "time"
 )
 
-// === Subject インタフェース ===
+// === Subject Interface ===
 
 type Storage interface {
     Get(ctx context.Context, key string) (string, error)
@@ -1199,7 +1199,7 @@ func NewRedisStorage() *RedisStorage {
 func (r *RedisStorage) Get(ctx context.Context, key string) (string, error) {
     r.mu.RLock()
     defer r.mu.RUnlock()
-    time.Sleep(10 * time.Millisecond) // ネットワーク遅延
+    time.Sleep(10 * time.Millisecond) // network latency
     val, ok := r.data[key]
     if !ok {
         return "", fmt.Errorf("key not found: %s", key)
@@ -1372,12 +1372,12 @@ func (cb *CircuitBreakerStorage) Delete(ctx context.Context, key string) error {
     return err
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 func main() {
     ctx := context.Background()
 
-    // Proxy チェーン: Redis -> CircuitBreaker -> Logging
+    // Proxy chain: Redis -> CircuitBreaker -> Logging
     var storage Storage = NewRedisStorage()
     storage = NewCircuitBreakerStorage(storage, 3, 30*time.Second)
     storage = NewLoggingStorage(storage)
@@ -1387,17 +1387,17 @@ func main() {
 }
 ```
 
-**ポイント**: Go のインタフェースは暗黙的実装のため、Proxy パターンが自然に実装できる。CircuitBreaker を Proxy として実装し、Logging Proxy とチェーンしている。
+**Key point**: Go's implicit interface implementation makes the Proxy pattern feel natural. The CircuitBreaker is implemented as a Proxy and chained with the Logging Proxy.
 
 ---
 
-### コード例 10: Kotlin -- Property Delegation as Proxy
+### Code Example 10: Kotlin -- Property Delegation as Proxy
 
 ```kotlin
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-// === Kotlin の Property Delegation は Proxy パターン ===
+// === Kotlin Property Delegation is the Proxy Pattern ===
 
 class LoggedProperty<T>(
     private var value: T,
@@ -1459,14 +1459,14 @@ class LazyProxy<T>(
     }
 }
 
-// === 使用例 ===
+// === Usage Example ===
 
 class UserProfile {
     var name: String by LoggedProperty("", "name")
     var age: Int by ValidatedProperty(0, { it in 0..150 }, "Age must be 0-150")
     var email: String by ValidatedProperty("", { "@" in it }, "Invalid email")
 
-    // 重いリソースの遅延読み込み
+    // Lazy loading of a heavy resource
     var avatar: ByteArray by LazyProxy {
         println("[LazyProxy] Loading avatar from storage...")
         ByteArray(1_000_000) // 1MB
@@ -1489,7 +1489,7 @@ fun main() {
     profile.email = "taro@example.com" // OK
     // profile.email = "invalid" // IllegalArgumentException
 
-    // avatar はアクセスするまでロードされない
+    // avatar is not loaded until accessed
     println("Profile created, avatar not loaded yet")
     val size = profile.avatar.size
     // [LazyProxy] Creating avatar
@@ -1498,72 +1498,72 @@ fun main() {
 }
 ```
 
-**ポイント**: Kotlin の `by` キーワード（Property Delegation）は Proxy パターンのネイティブサポート。`LoggedProperty`, `ValidatedProperty`, `LazyProxy` はすべて Proxy として機能する。
+**Key point**: Kotlin's `by` keyword (Property Delegation) is native support for the Proxy pattern. `LoggedProperty`, `ValidatedProperty`, and `LazyProxy` all function as Proxies.
 
 ---
 
-## 4. 比較表
+## 4. Comparison Tables
 
-### 比較表 1: Proxy vs Decorator vs Adapter
+### Comparison Table 1: Proxy vs Decorator vs Adapter
 
-| 観点 | Proxy | Decorator | Adapter |
+| Aspect | Proxy | Decorator | Adapter |
 |------|-------|-----------|---------|
-| **目的** | アクセス制御 | 機能追加 | インタフェース変換 |
-| **インタフェース** | 同一 | 同一 | 異なる |
-| **ライフサイクル管理** | する（遅延生成等） | しない | しない |
-| **クライアントの認識** | 透過的 | 透過的 | 意図的 |
-| **典型的な責務** | 認証、キャッシュ、遅延 | ログ、圧縮、暗号化 | API 変換 |
-| **RealSubject の生成** | Proxy が管理可能 | 外部から渡される | 外部から渡される |
-| **構造** | 1:1 | N:1（スタック） | 1:1 |
+| **Purpose** | Access control | Adding functionality | Interface conversion |
+| **Interface** | Same | Same | Different |
+| **Lifecycle management** | Yes (lazy creation, etc.) | No | No |
+| **Client awareness** | Transparent | Transparent | Intentional |
+| **Typical responsibilities** | Auth, caching, lazy loading | Logging, compression, encryption | API conversion |
+| **RealSubject creation** | Can be managed by Proxy | Passed from outside | Passed from outside |
+| **Structure** | 1:1 | N:1 (stack) | 1:1 |
 
-### 比較表 2: Proxy の種類と適用場面
+### Comparison Table 2: Proxy Types and Use Cases
 
-| 種類 | ユースケース | パフォーマンス影響 | 複雑度 | 実装コスト |
+| Type | Use Case | Performance Impact | Complexity | Implementation Cost |
 |------|-------------|:-:|:-:|:-:|
-| **Virtual** | 重いリソースの遅延読み込み | 初回のみ遅延 | 低 | 低 |
-| **Protection** | RBAC / 認証・認可ガード | 微小 | 中 | 中 |
-| **Cache** | API/DB 結果のメモ化 | 大幅に改善 | 高 | 高 |
-| **Remote** | RPC/gRPC 呼び出し | ネットワーク依存 | 高 | 高 |
-| **Logging** | 監査ログ・メトリクス | 微小 | 低 | 低 |
-| **Smart Ref** | 参照カウント・変更通知 | 微小 | 中 | 中 |
+| **Virtual** | Lazy loading of heavy resources | Delay on first access only | Low | Low |
+| **Protection** | RBAC / authentication guard | Minimal | Medium | Medium |
+| **Cache** | Memoization of API/DB results | Significant improvement | High | High |
+| **Remote** | RPC/gRPC calls | Network-dependent | High | High |
+| **Logging** | Audit logs / metrics | Minimal | Low | Low |
+| **Smart Ref** | Reference counting / change notification | Minimal | Medium | Medium |
 
-### 比較表 3: GoF Proxy vs ES6 Proxy
+### Comparison Table 3: GoF Proxy vs ES6 Proxy
 
-| 観点 | GoF Proxy（クラスベース） | ES6 Proxy（メタプログラミング） |
+| Aspect | GoF Proxy (class-based) | ES6 Proxy (metaprogramming) |
 |------|--------------------------|-------------------------------|
-| **実装方式** | 同一インタフェースを実装 | Handler オブジェクトでトラップ |
-| **対象** | メソッド呼び出し | プロパティアクセス、代入、削除、列挙等 |
-| **型安全性** | 高い（インタフェース準拠） | 低い（any に近い） |
-| **トラップ対象** | メソッドのみ | 13 種のトラップ（get, set, has, etc.） |
-| **用途** | 設計パターン | メタプログラミング、リアクティブ |
-| **パフォーマンス** | 良好 | プロパティアクセスごとにオーバーヘッド |
-| **例** | `ImageProxy implements Image` | `new Proxy(target, handler)` |
+| **Implementation** | Implements the same interface | Intercepts via handler object traps |
+| **Target** | Method calls | Property access, assignment, deletion, enumeration, etc. |
+| **Type safety** | High (interface-compliant) | Low (close to any) |
+| **Trap targets** | Methods only | 13 types of traps (get, set, has, etc.) |
+| **Use case** | Design patterns | Metaprogramming, reactive systems |
+| **Performance** | Good | Overhead per property access |
+| **Example** | `ImageProxy implements Image` | `new Proxy(target, handler)` |
 
 ---
 
-## 5. アンチパターン
+## 5. Anti-Patterns
 
-### アンチパターン 1: Proxy と RealSubject の密結合
+### Anti-Pattern 1: Tight Coupling Between Proxy and RealSubject
 
 ```typescript
-// NG: Proxy が具象クラスに直接依存し、new で生成
+// BAD: Proxy directly depends on a concrete class and instantiates it with new
 class BadProxy {
-  private real = new SpecificDatabaseService("localhost", 5432); // 直接 new
+  private real = new SpecificDatabaseService("localhost", 5432); // direct new
 
   query(sql: string): Result {
     console.log("Logging:", sql);
-    return this.real.query(sql); // インタフェースなし
+    return this.real.query(sql); // no interface
   }
 }
 
-// 問題:
-// 1. SpecificDatabaseService を差し替えられない
-// 2. テストでモックに差し替えられない
-// 3. Proxy が RealSubject のコンストラクタ引数を知る必要がある
+// Problems:
+// 1. Cannot swap out SpecificDatabaseService
+// 2. Cannot replace with a mock in tests
+// 3. Proxy must know the constructor arguments of RealSubject
 ```
 
 ```typescript
-// OK: インタフェース経由で依存し、DI で注入
+// GOOD: Depend via interface, inject with DI
 
 interface DatabaseService {
   query(sql: string): Result;
@@ -1578,53 +1578,53 @@ class LoggingProxy implements DatabaseService {
   }
 }
 
-// テスト
+// Testing
 const mockDb: DatabaseService = { query: jest.fn() };
 const proxy = new LoggingProxy(mockDb);
 ```
 
-**判断基準**: Proxy 内で `new RealSubject()` があったら密結合の警告サイン（Virtual Proxy は例外）。
+**Guideline**: If there is a `new RealSubject()` inside a Proxy, it is a warning sign of tight coupling (Virtual Proxy is an exception).
 
 ---
 
-### アンチパターン 2: God Proxy（1つの Proxy に複数の責務）
+### Anti-Pattern 2: God Proxy (Multiple Responsibilities in One Proxy)
 
 ```typescript
-// NG: キャッシュ + 認証 + ログ + レート制限を 1 つの Proxy で
+// BAD: One Proxy handles cache + auth + logging + rate limiting
 class GodProxy implements Service {
   private cache = new Map();
   private requestCount = 0;
 
   doSomething(args: unknown): Result {
-    // 認証チェック
+    // Auth check
     if (!this.currentUser.isAdmin) throw new Error("Access denied");
 
-    // レート制限
+    // Rate limiting
     this.requestCount++;
     if (this.requestCount > 100) throw new Error("Rate limited");
 
-    // キャッシュ
+    // Caching
     const key = JSON.stringify(args);
     if (this.cache.has(key)) return this.cache.get(key);
 
-    // ログ
+    // Logging
     console.log(`[${new Date().toISOString()}] doSomething called`);
 
-    // 実行
+    // Execution
     const result = this.real.doSomething(args);
     this.cache.set(key, result);
     return result;
   }
 }
 
-// 問題:
-// 1. SRP 違反: 4 つの責務が混在
-// 2. テストが困難（すべての責務をテストする必要がある）
-// 3. 責務の組み合わせを変更できない
+// Problems:
+// 1. SRP violation: 4 responsibilities mixed together
+// 2. Hard to test (all responsibilities must be tested together)
+// 3. Cannot change the combination of responsibilities
 ```
 
 ```typescript
-// OK: 責務ごとに Proxy を分離し、チェーンする
+// GOOD: Separate Proxies per responsibility, then chain them
 
 class AuthProxy implements Service {
   constructor(private real: Service, private user: User) {}
@@ -1663,7 +1663,7 @@ class LogProxy implements Service {
   }
 }
 
-// チェーン: Auth -> RateLimit -> Cache -> Log -> Real
+// Chain: Auth -> RateLimit -> Cache -> Log -> Real
 const service: Service =
   new AuthProxy(
     new RateLimitProxy(
@@ -1676,65 +1676,65 @@ const service: Service =
   );
 ```
 
-**判断基準**: 1 Proxy = 1 責務。複数の責務があればチェーンで合成する。
+**Guideline**: 1 Proxy = 1 responsibility. If there are multiple responsibilities, compose them with a chain.
 
 ---
 
-### アンチパターン 3: 不必要な Proxy（YAGNI 違反）
+### Anti-Pattern 3: Unnecessary Proxy (YAGNI Violation)
 
 ```typescript
-// NG: 何の付加価値もない Proxy
+// BAD: A Proxy that provides no added value
 class UselessProxy implements Service {
   constructor(private real: Service) {}
 
   doSomething(args: unknown): Result {
-    return this.real.doSomething(args); // ただの委譲
+    return this.real.doSomething(args); // pure delegation
   }
 }
 
-// 問題:
-// 1. 間接層の追加による複雑さだけが増える
-// 2. デバッグ時のスタックトレースが深くなる
-// 3. パフォーマンスオーバーヘッド（わずかだが不要）
+// Problems:
+// 1. Only adds indirection complexity
+// 2. Deeper stack traces during debugging
+// 3. Performance overhead (minor but unnecessary)
 ```
 
-**判断基準**: Proxy を導入する前に「何を制御するのか」を明確にする。制御すべきものがなければ Proxy は不要。
+**Guideline**: Before introducing a Proxy, clarify "what is being controlled." If there is nothing to control, a Proxy is unnecessary.
 
 ---
 
-## 6. エッジケースと注意点
+## 6. Edge Cases and Caveats
 
-### 6.1 ES6 Proxy のパフォーマンス
+### 6.1 ES6 Proxy Performance
 
 ```typescript
-// ES6 Proxy はプロパティアクセスごとにトラップが呼ばれるため、
-// ホットパスでの使用に注意
+// ES6 Proxy traps are called on every property access,
+// so be careful when using them in hot paths
 
-// NG: ホットループ内で ES6 Proxy
+// BAD: ES6 Proxy inside a hot loop
 const proxied = new Proxy(array, handler);
 for (let i = 0; i < 1_000_000; i++) {
-  proxied[i]; // 毎回 get トラップが呼ばれる
+  proxied[i]; // get trap is called every iteration
 }
 
-// OK: ホットパスでは直接アクセス、Proxy は外部API向け
+// GOOD: Direct access in hot paths, Proxy only for external APIs
 const raw = array;
 for (let i = 0; i < 1_000_000; i++) {
-  raw[i]; // 直接アクセス
+  raw[i]; // direct access
 }
 ```
 
-### 6.2 Proxy の透過性とデバッグ
+### 6.2 Proxy Transparency and Debugging
 
 ```typescript
-// ES6 Proxy は typeof, instanceof で RealSubject と区別できない
+// ES6 Proxy is indistinguishable from RealSubject with typeof, instanceof
 const target = { x: 1 };
 const proxy = new Proxy(target, {});
 
-console.log(typeof proxy);           // "object" (target と同じ)
+console.log(typeof proxy);           // "object" (same as target)
 console.log(proxy instanceof Object); // true
-console.log(proxy === target);        // false (参照は異なる)
+console.log(proxy === target);        // false (different reference)
 
-// デバッグ時は Proxy であることを示すメタデータを追加すると便利
+// Adding metadata to indicate it is a Proxy helps during debugging
 const debugProxy = new Proxy(target, {
   get(obj, prop) {
     if (prop === Symbol.for("isProxy")) return true;
@@ -1743,47 +1743,47 @@ const debugProxy = new Proxy(target, {
 });
 ```
 
-### 6.3 キャッシュ Proxy の Invalidation 戦略
+### 6.3 Cache Proxy Invalidation Strategies
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│          キャッシュ Invalidation 戦略の選択               │
+│          Cache Invalidation Strategy Selection            │
 │                                                          │
 │  ┌─────────────┬─────────────────────────────────────┐  │
-│  │ TTL         │ 一定時間後に自動失効                 │  │
-│  │             │ 簡単だが鮮度に制約                    │  │
+│  │ TTL         │ Automatically expires after a set time│ │
+│  │             │ Simple but freshness is limited       │  │
 │  ├─────────────┼─────────────────────────────────────┤  │
-│  │ Event-based │ データ変更イベントで明示的に無効化   │  │
-│  │             │ 正確だが実装が複雑                    │  │
+│  │ Event-based │ Explicitly invalidated on data change │ │
+│  │             │ Accurate but complex to implement     │  │
 │  ├─────────────┼─────────────────────────────────────┤  │
-│  │ LRU         │ 容量超過時に最古のエントリを削除     │  │
-│  │             │ メモリ制約に有効                      │  │
+│  │ LRU         │ Evicts oldest entry when capacity full│ │
+│  │             │ Effective for memory constraints      │  │
 │  ├─────────────┼─────────────────────────────────────┤  │
-│  │ Write-through│ 書き込み時にキャッシュも更新        │  │
-│  │             │ 一貫性は高いが書き込みが遅い          │  │
+│  │ Write-through│ Updates cache on every write        │  │
+│  │             │ High consistency but slow writes      │  │
 │  ├─────────────┼─────────────────────────────────────┤  │
-│  │ Stale-while │ 期限切れでも古い値を返しつつ         │  │
-│  │ -revalidate │ バックグラウンドで更新               │  │
-│  │             │ 可用性が高い                          │  │
+│  │ Stale-while │ Returns stale value while             │  │
+│  │ -revalidate │ updating in the background           │  │
+│  │             │ High availability                    │  │
 │  └─────────────┴─────────────────────────────────────┘  │
 │                                                          │
-│  推奨: 最初は TTL + LRU のシンプルな組み合わせから始め、 │
-│  必要に応じて Event-based を追加する。                    │
+│  Recommendation: Start with a simple TTL + LRU           │
+│  combination, then add Event-based if needed.            │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 6.4 スレッドセーフな Proxy
+### 6.4 Thread-Safe Proxy
 
 ```typescript
-// ブラウザでは問題ないが、Node.js Worker Threads や
-// マルチスレッド環境ではキャッシュ Proxy にロックが必要
+// Not an issue in browsers, but cache Proxies in
+// Node.js Worker Threads or multithreaded environments require locking
 
 class ThreadSafeCacheProxy implements Service {
   private cache = new Map();
   private locks = new Map<string, Promise<void>>();
 
   async doSomething(key: string): Promise<Result> {
-    // 同じキーに対する同時リクエストを防ぐ
+    // Prevent concurrent requests for the same key
     if (this.locks.has(key)) {
       await this.locks.get(key);
       const cached = this.cache.get(key);
@@ -1807,56 +1807,57 @@ class ThreadSafeCacheProxy implements Service {
 
 ---
 
-## 7. トレードオフ分析
+## 7. Trade-off Analysis
 
-### 導入すべき場面
+### When to Use
 
-| 場面 | 推奨 Proxy 種類 | 理由 |
+| Situation | Recommended Proxy Type | Reason |
 |------|----------------|------|
-| 画像ギャラリー（大量の画像） | Virtual | メモリ節約、初期化コスト削減 |
-| マルチテナント API | Protection | テナントごとのアクセス制御 |
-| 外部 API 呼び出し | Cache + Logging | コスト削減、デバッグ容易性 |
-| マイクロサービス間通信 | Remote + Circuit Breaker | 障害伝搬の防止 |
-| 監査要件のあるシステム | Logging | コンプライアンス対応 |
+| Image gallery (many images) | Virtual | Memory savings, reduced initialization cost |
+| Multi-tenant API | Protection | Per-tenant access control |
+| External API calls | Cache + Logging | Cost reduction, debuggability |
+| Microservice communication | Remote + Circuit Breaker | Prevent failure propagation |
+| Systems with audit requirements | Logging | Compliance support |
 
-### 導入すべきでない場面
+### When Not to Use
 
-| 場面 | 理由 |
+| Situation | Reason |
 |------|------|
-| 単純な直接呼び出しで十分 | YAGNI: 不要な間接層 |
-| ホットパスの内部処理 | パフォーマンスオーバーヘッド |
-| 横断的関心事がない | Proxy の付加価値がない |
-| AOP フレームワークが利用可能 | Proxy を手動実装する必要がない |
+| Simple direct call is sufficient | YAGNI: unnecessary indirection |
+| Inner processing in a hot path | Performance overhead |
+| No cross-cutting concerns | Proxy adds no value |
+| AOP framework is available | No need to manually implement Proxy |
 
-### Proxy のコスト
+### The Cost of Proxy
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│                 Proxy のコスト分析                        │
+│                 Proxy Cost Analysis                       │
 │                                                          │
-│  メリット                    デメリット                   │
+│  Benefits                    Drawbacks                   │
 │  ┌──────────────────────┐    ┌──────────────────────┐    │
-│  │ + 横断的関心事の分離  │    │ - 間接層の追加       │    │
-│  │ + OCP 準拠           │    │ - デバッグの複雑化   │    │
-│  │ + 遅延初期化         │    │ - God Proxy のリスク │    │
-│  │ + テスト容易性       │    │ - ES6 Proxy の       │    │
-│  │ + 透過的             │    │   パフォーマンス     │    │
-│  │ + 組み合わせ可能     │    │ - キャッシュの       │    │
-│  │   （チェーン）       │    │   一貫性管理         │    │
+│  │ + Separation of cross-│   │ - Added indirection  │    │
+│  │   cutting concerns   │    │ - More complex debug │    │
+│  │ + OCP compliance     │    │ - God Proxy risk     │    │
+│  │ + Lazy initialization│    │ - ES6 Proxy          │    │
+│  │ + Testability        │    │   performance        │    │
+│  │ + Transparent        │    │ - Cache consistency  │    │
+│  │ + Composable         │    │   management         │    │
+│  │   (chainable)        │    │                      │    │
 │  └──────────────────────┘    └──────────────────────┘    │
 │                                                          │
-│  判断: 横断的関心事（認証、キャッシュ、ログ）が           │
-│  ビジネスロジックに混入している場合に Proxy を検討する。  │
+│  Guideline: Consider Proxy when cross-cutting concerns   │
+│  (auth, caching, logging) are mixed into business logic. │
 └──────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 8. 演習問題
+## 8. Exercises
 
-### 演習 1: 基本 -- Virtual Proxy（難易度: ★☆☆）
+### Exercise 1: Basic -- Virtual Proxy (Difficulty: ★☆☆)
 
-以下の `ExpensiveReport` クラスに対する Virtual Proxy を実装してください。
+Implement a Virtual Proxy for the following `ExpensiveReport` class.
 
 ```typescript
 interface Report {
@@ -1868,7 +1869,7 @@ class ExpensiveReport implements Report {
   private data: string;
 
   constructor(private title: string) {
-    // 重い初期化処理（DB クエリ、集計処理等）
+    // Heavy initialization (DB queries, aggregation, etc.)
     console.log(`[Report] Generating "${title}" (takes 3 seconds)...`);
     this.data = `Report data for "${title}" with 10000 rows`;
   }
@@ -1882,12 +1883,12 @@ class ExpensiveReport implements Report {
   }
 }
 
-// TODO: ReportProxy を実装
-// - getTitle() は RealSubject を生成せずに返す
-// - generate() は初回アクセス時のみ RealSubject を生成
+// TODO: Implement ReportProxy
+// - getTitle() returns without creating the RealSubject
+// - generate() creates the RealSubject only on first access
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 Creating 3 report proxies...
@@ -1902,7 +1903,7 @@ Report data for "Monthly Sales" with 10000 rows
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Sample Solution (click to expand)</summary>
 
 ```typescript
 class ReportProxy implements Report {
@@ -1913,7 +1914,7 @@ class ReportProxy implements Report {
   }
 
   getTitle(): string {
-    // タイトルは Proxy が知っているので RealSubject 不要
+    // Title is known by Proxy, so no RealSubject needed
     return this.title;
   }
 
@@ -1925,7 +1926,7 @@ class ReportProxy implements Report {
   }
 }
 
-// テスト
+// Test
 console.log("Creating 3 report proxies...");
 const reports: Report[] = [
   new ReportProxy("Monthly Sales"),
@@ -1947,15 +1948,15 @@ console.log(reports[0].generate());
 
 ---
 
-### 演習 2: 応用 -- Protection + Logging Proxy チェーン（難易度: ★★☆）
+### Exercise 2: Applied -- Protection + Logging Proxy Chain (Difficulty: ★★☆)
 
-以下の要件を満たす Proxy チェーンを実装してください。
+Implement a Proxy chain that satisfies the following requirements.
 
-**要件**:
-1. `FileService` インタフェースに対して、Protection Proxy と Logging Proxy を作成
-2. Protection Proxy: `"admin"` ロール以外は `delete` を禁止
-3. Logging Proxy: 全メソッド呼び出しを `[LOG]` プレフィックスで記録
-4. チェーン順序: Client -> Logging -> Protection -> RealSubject
+**Requirements**:
+1. Create a Protection Proxy and a Logging Proxy for the `FileService` interface
+2. Protection Proxy: forbid `delete` for any role other than `"admin"`
+3. Logging Proxy: log all method calls with a `[LOG]` prefix
+4. Chain order: Client -> Logging -> Protection -> RealSubject
 
 ```typescript
 interface FileService {
@@ -1970,7 +1971,7 @@ interface User {
 }
 ```
 
-**期待される出力（admin ユーザー）**:
+**Expected output (admin user)**:
 
 ```
 [LOG] read("/data/file.txt")
@@ -1980,7 +1981,7 @@ interface User {
 [File] Deleting /data/old.txt
 ```
 
-**期待される出力（viewer ユーザー）**:
+**Expected output (viewer user)**:
 
 ```
 [LOG] read("/data/file.txt")
@@ -1991,7 +1992,7 @@ Error: Access denied
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Sample Solution (click to expand)</summary>
 
 ```typescript
 class RealFileService implements FileService {
@@ -2014,7 +2015,7 @@ class ProtectionProxy implements FileService {
   ) {}
 
   read(path: string): string {
-    return this.real.read(path); // 全ロール許可
+    return this.real.read(path); // all roles allowed
   }
 
   write(path: string, content: string): void {
@@ -2054,7 +2055,7 @@ class LoggingProxy implements FileService {
   }
 }
 
-// チェーン構築
+// Build chain
 function createFileService(user: User): FileService {
   const real = new RealFileService();
   const protected_ = new ProtectionProxy(real, user);
@@ -2062,12 +2063,12 @@ function createFileService(user: User): FileService {
   return logged;
 }
 
-// Admin テスト
+// Admin test
 const adminFs = createFileService({ name: "Alice", role: "admin" });
 adminFs.read("/data/file.txt");
 adminFs.delete("/data/old.txt");
 
-// Viewer テスト
+// Viewer test
 const viewerFs = createFileService({ name: "Bob", role: "viewer" });
 viewerFs.read("/data/file.txt");
 try {
@@ -2081,17 +2082,17 @@ try {
 
 ---
 
-### 演習 3: 発展 -- 汎用 Proxy ファクトリ（難易度: ★★★）
+### Exercise 3: Advanced -- Generic Proxy Factory (Difficulty: ★★★)
 
-ES6 Proxy を使って、任意のオブジェクトに対して以下の機能を自動付加する汎用ファクトリを実装してください。
+Using ES6 Proxy, implement a generic factory that automatically adds the following features to any object.
 
-**要件**:
-1. `createSmartProxy<T>(target, options)` ファクトリ関数
-2. `options.cache`: true の場合、同じ引数のメソッド呼び出し結果をキャッシュ
-3. `options.log`: true の場合、メソッド呼び出しをログ出力
-4. `options.readonly`: true の場合、プロパティの set と delete を禁止
-5. `options.onAccess`: プロパティアクセス時のコールバック
-6. 同期・非同期メソッドの両方に対応
+**Requirements**:
+1. `createSmartProxy<T>(target, options)` factory function
+2. `options.cache`: if true, cache method call results for the same arguments
+3. `options.log`: if true, log method calls
+4. `options.readonly`: if true, forbid property `set` and `delete`
+5. `options.onAccess`: callback on property access
+6. Support both synchronous and asynchronous methods
 
 ```typescript
 interface SmartProxyOptions {
@@ -2105,11 +2106,11 @@ function createSmartProxy<T extends object>(
   target: T,
   options: SmartProxyOptions,
 ): T {
-  // TODO: 実装
+  // TODO: implement
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```typescript
 const obj = createSmartProxy(
@@ -2124,7 +2125,7 @@ obj.greet("World");
 // [Log] greet("World") -> "Hello, World!" [0ms]
 // "Hello, World!"
 
-obj.greet("World"); // 2回目: キャッシュヒット
+obj.greet("World"); // 2nd call: cache hit
 // [Cache] HIT: greet:["World"]
 // "Hello, World!"
 
@@ -2132,7 +2133,7 @@ obj.value = 100; // Error: Cannot modify readonly proxy
 ```
 
 <details>
-<summary>解答例（クリックで展開）</summary>
+<summary>Sample Solution (click to expand)</summary>
 
 ```typescript
 function createSmartProxy<T extends object>(
@@ -2145,19 +2146,19 @@ function createSmartProxy<T extends object>(
     get(obj, prop, receiver) {
       const value = Reflect.get(obj, prop, receiver);
 
-      // onAccess コールバック
+      // onAccess callback
       if (options.onAccess && typeof prop === "string") {
         options.onAccess(prop);
       }
 
-      // メソッドでなければそのまま返す
+      // Return non-methods as-is
       if (typeof value !== "function") return value;
 
-      // メソッドをラップ
+      // Wrap method
       return function (this: unknown, ...args: unknown[]) {
         const methodName = String(prop);
 
-        // キャッシュチェック
+        // Cache check
         if (options.cache) {
           const key = `${methodName}:${JSON.stringify(args)}`;
           if (cache.has(key)) {
@@ -2166,11 +2167,11 @@ function createSmartProxy<T extends object>(
           }
         }
 
-        // 実行
+        // Execute
         const start = performance.now();
         const result = (value as Function).apply(obj, args);
 
-        // Promise の場合
+        // If Promise
         if (result instanceof Promise) {
           return result.then((resolved: unknown) => {
             const elapsed = Math.round(performance.now() - start);
@@ -2184,7 +2185,7 @@ function createSmartProxy<T extends object>(
           });
         }
 
-        // 同期の場合
+        // Synchronous case
         const elapsed = Math.round(performance.now() - start);
         if (options.log) {
           console.log(`[Log] ${methodName}(${args.map(a => JSON.stringify(a)).join(", ")}) -> ${JSON.stringify(result)} [${elapsed}ms]`);
@@ -2212,7 +2213,7 @@ function createSmartProxy<T extends object>(
   });
 }
 
-// テスト
+// Test
 const calculator = createSmartProxy(
   {
     add(a: number, b: number) { return a + b; },
@@ -2229,7 +2230,7 @@ console.log(calculator.add(1, 2));
 // [Log] add(1, 2) -> 3 [0ms]
 // 3
 
-console.log(calculator.add(1, 2)); // キャッシュヒット
+console.log(calculator.add(1, 2)); // cache hit
 // [Cache] HIT: add:[1,2]
 // 3
 
@@ -2250,92 +2251,92 @@ try {
 
 ## 9. FAQ
 
-### Q1: JavaScript の Proxy オブジェクトは GoF の Proxy パターンと同じですか？
+### Q1: Is the JavaScript Proxy object the same as the GoF Proxy pattern?
 
-本質は同じですが、抽象度が異なります。GoF Proxy はクラスベースで「同じインタフェースを持つ代理クラス」を作ります。ES6 Proxy はメタプログラミングの仕組みで、13 種のトラップ（get, set, has, deleteProperty, apply, construct 等）を通じてあらゆるオブジェクト操作をインターセプトできます。GoF Proxy の全パターン（Virtual, Protection, Cache, Logging）を ES6 Proxy で実装できますが、逆は成り立ちません（ES6 Proxy のプロパティトラップは GoF にはない概念）。
+The essence is the same, but the level of abstraction differs. The GoF Proxy creates a "proxy class with the same interface" in a class-based approach. ES6 Proxy is a metaprogramming mechanism that can intercept any object operation through 13 types of traps (get, set, has, deleteProperty, apply, construct, etc.). All GoF Proxy patterns (Virtual, Protection, Cache, Logging) can be implemented with ES6 Proxy, but not vice versa (ES6 Proxy's property traps are concepts not found in GoF).
 
-### Q2: Proxy はパフォーマンスに影響しますか？
+### Q2: Does Proxy affect performance?
 
-Proxy 層の処理内容に依存します。GoF スタイルのクラス Proxy は単純な委譲なのでオーバーヘッドはほぼゼロです。ES6 Proxy の handler はプロパティアクセスごとに呼ばれるため、ホットパス（1 秒に 100 万回以上のアクセス）では注意が必要です。V8 エンジンのベンチマークでは、ES6 Proxy 経由のプロパティアクセスは直接アクセスの 5-10 倍遅くなることがあります。
+It depends on what the Proxy layer does. A GoF-style class Proxy with simple delegation has virtually zero overhead. ES6 Proxy handlers are called on every property access, so caution is needed in hot paths (more than 1 million accesses per second). V8 engine benchmarks show that property access via ES6 Proxy can be 5-10x slower than direct access.
 
-### Q3: キャッシュ Proxy の Invalidation はどうすべきですか？
+### Q3: How should cache Proxy invalidation be handled?
 
-「キャッシュの無効化はコンピュータサイエンスで最も難しい問題の 1 つ」と言われます。以下の順序で段階的に導入してください。
+"Cache invalidation is one of the hardest problems in computer science." Introduce it incrementally in the following order:
 
-1. **TTL（時間ベース）**: 最もシンプル。60 秒後に自動失効
-2. **TTL + LRU**: メモリ制約があれば LRU を追加
-3. **Event-based**: データ更新イベントで明示的に無効化（必要になったら）
-4. **Stale-while-revalidate**: 高可用性が必要な場合
+1. **TTL (time-based)**: Simplest. Automatically expires after 60 seconds
+2. **TTL + LRU**: Add LRU if there are memory constraints
+3. **Event-based**: Explicitly invalidate on data update events (when needed)
+4. **Stale-while-revalidate**: When high availability is required
 
-### Q4: Proxy と AOP（アスペクト指向プログラミング）の関係は？
+### Q4: What is the relationship between Proxy and AOP (Aspect-Oriented Programming)?
 
-AOP のウィービング（横断的関心事の織り込み）を手動で実装したものが Proxy パターンです。Spring AOP や AspectJ は Proxy パターンを内部で使用しています。フレームワークが AOP をサポートしていれば、手動 Proxy は不要です。
+Proxy pattern is a manual implementation of AOP weaving (the weaving-in of cross-cutting concerns). Spring AOP and AspectJ use the Proxy pattern internally. If your framework supports AOP, manual Proxy is unnecessary.
 
-### Q5: React の Suspense は Virtual Proxy ですか？
+### Q5: Is React's Suspense a Virtual Proxy?
 
-はい、概念的に Virtual Proxy の一形態です。`React.lazy()` はコンポーネントの遅延ロードを行い、ロード完了まで Suspense フォールバックを表示します。これは Virtual Proxy の「必要になるまで RealSubject を生成しない」という特性と同じです。
+Yes, conceptually it is a form of Virtual Proxy. `React.lazy()` lazily loads components and shows the Suspense fallback until loading is complete. This is the same characteristic as Virtual Proxy's "don't create RealSubject until needed."
 
-### Q6: Proxy チェーンの順序はどう決めるべきですか？
+### Q6: How should the order of a Proxy chain be decided?
 
-外側から順に評価されることを意識して、以下の順序を推奨します。
+Keeping in mind that chains are evaluated from the outermost layer, the following order is recommended:
 
 ```
 Client
-  -> Logging（全アクセスを記録）
-    -> Rate Limiting（早い段階で制限）
-      -> Authentication（認証チェック）
-        -> Caching（キャッシュで高速化）
+  -> Logging (record all accesses)
+    -> Rate Limiting (restrict early)
+      -> Authentication (auth check)
+        -> Caching (speed up with cache)
           -> RealSubject
 ```
 
-理由: ログは全リクエストを記録したいので最外層、レート制限は早い段階で弾きたいので認証の前、キャッシュは認証済みリクエストのみ対象にしたいので最内層。
+Reason: Logging should be at the outermost layer to record all requests. Rate limiting should come before auth to reject early. Caching should be innermost to target only authenticated requests.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point to keep in mind when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not just through theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the foundational concepts explained in this guide before moving to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world development?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| **目的** | オブジェクトへのアクセスを制御する代理オブジェクト |
-| **本質** | 同一インタフェース + 透過的なアクセス制御 |
-| **主な種類** | Virtual, Protection, Cache, Remote, Logging, Smart Reference |
-| **GoF vs ES6** | GoF はクラスベース、ES6 はメタプログラミング |
-| **利点** | 横断的関心事の分離、遅延初期化、OCP 準拠 |
-| **チェーン** | 1 Proxy = 1 責務、チェーンで合成 |
-| **注意** | ES6 Proxy のパフォーマンス、キャッシュ Invalidation |
-| **テスト** | DI で RealSubject を注入、モックに差し替え可能 |
+| **Purpose** | A surrogate object that controls access to another object |
+| **Essence** | Same interface + transparent access control |
+| **Main Types** | Virtual, Protection, Cache, Remote, Logging, Smart Reference |
+| **GoF vs ES6** | GoF is class-based, ES6 is metaprogramming |
+| **Benefits** | Separation of cross-cutting concerns, lazy initialization, OCP compliance |
+| **Chaining** | 1 Proxy = 1 responsibility, compose with chains |
+| **Caveats** | ES6 Proxy performance, cache invalidation |
+| **Testing** | Inject RealSubject via DI, replaceable with mocks |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [Decorator パターン](./01-decorator.md) -- 動的な機能追加（Proxy との違いを理解）
-- [Facade パターン](./02-facade.md) -- サブシステムの簡素化
-- [Adapter パターン](./00-adapter.md) -- インタフェース変換
-- [Composite パターン](./04-composite.md) -- ツリー構造の統一操作
-- [Observer パターン](../02-behavioral/00-observer.md) -- リアクティブな変更通知
-- [キャッシュ戦略](../../../system-design-guide/docs/01-components/01-caching.md) -- システムレベルのキャッシュ設計
+- [Decorator Pattern](./01-decorator.md) -- Dynamic feature addition (understand the difference from Proxy)
+- [Facade Pattern](./02-facade.md) -- Simplifying subsystems
+- [Adapter Pattern](./00-adapter.md) -- Interface conversion
+- [Composite Pattern](./04-composite.md) -- Unified operations on tree structures
+- [Observer Pattern](../02-behavioral/00-observer.md) -- Reactive change notification
+- [Caching Strategy](../../../system-design-guide/docs/01-components/01-caching.md) -- System-level cache design
 
 ---
 
-## 参考文献
+## References
 
 1. Gamma, E. et al. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley.
 2. MDN Web Docs -- Proxy. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy

--- a/03-software-design/design-patterns-guide/docs/01-structural/04-composite.md
+++ b/03-software-design/design-patterns-guide/docs/01-structural/04-composite.md
@@ -1,65 +1,61 @@
-# Composite パターン
+# Composite Pattern
 
-> オブジェクトを **ツリー構造** に構成し、個別オブジェクト（Leaf）とその集合（Composite）を同一インタフェースで扱えるようにする構造パターン。クライアントは再帰的なツリー構造全体を統一的に操作でき、個別要素か集合かを意識する必要がなくなる。
-
----
-
-## この章で学ぶこと
-
-1. Composite パターンの構造と再帰的構成の仕組み、GoF による設計意図を深く理解する
-2. ファイルシステム、UIツリー、組織図、メニュー構造、数式ツリーなど実践的な適用場面を習得する
-3. 透過性と安全性のトレードオフ、循環参照防止、パフォーマンス最適化の設計判断ができるようになる
+> A structural pattern that organizes objects into a **tree structure**, enabling individual objects (Leaf) and their collections (Composite) to be handled through a unified interface. Clients can uniformly operate on an entire recursive tree structure without needing to distinguish between individual elements and collections.
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-このガイドを読む前に、以下の概念を理解しておくことを推奨します。
+1. Deeply understand the structure of the Composite pattern, the mechanism of recursive composition, and the GoF design intent
+2. Master practical application scenarios such as file systems, UI trees, organizational charts, menu structures, and expression trees
+3. Be able to make informed design decisions around the transparency-vs-safety tradeoff, circular reference prevention, and performance optimization
 
-| 前提知識 | 説明 | 参照リンク |
+---
+
+## Prerequisites
+
+Before reading this guide, it is recommended to understand the following concepts.
+
+| Prerequisite | Description | Reference |
 |---------|------|-----------|
-| インタフェースとポリモーフィズム | 共通のインタフェースを通じて異なる型を統一的に扱う概念 | [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) |
-| 再帰 | 関数やデータ構造が自分自身を参照する概念 | CS 基礎 |
-| ツリーデータ構造 | ノードとエッジで構成される階層的なデータ構造 | データ構造 |
-| 合成（Composition）と継承 | オブジェクトの組み立て方法の違い | [合成優先の原則](../../../clean-code-principles/docs/03-practices-advanced/01-composition-over-inheritance.md) |
+| Interfaces and Polymorphism | The concept of treating different types uniformly through a common interface | [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Recursion | The concept of a function or data structure referencing itself | CS Fundamentals |
+| Tree Data Structures | A hierarchical data structure composed of nodes and edges | Data Structures |
+| Composition vs Inheritance | The difference between approaches to assembling objects | [Composition Over Inheritance](../../../clean-code-principles/docs/03-practices-advanced/01-composition-over-inheritance.md) |
 
 ---
 
-## 1. Composite パターンとは何か
+## 1. What Is the Composite Pattern?
 
-### 1.1 解決する問題
+### 1.1 The Problem It Solves
 
-ソフトウェア開発では「部分と全体」の関係を扱う場面が頻繁にある。例えば:
+Software development frequently involves dealing with "part-whole" relationships. For example:
 
-- ファイルとフォルダ（フォルダはファイルとサブフォルダを含む）
-- UIの基本要素とコンテナ（コンテナはボタンやテキストやサブコンテナを含む）
-- 組織の従業員と部門（部門は従業員やサブ部門を含む）
+- Files and folders (folders contain files and subfolders)
+- UI primitives and containers (containers hold buttons, text, and sub-containers)
+- Organizational employees and departments (departments contain employees and sub-departments)
 
-これらに共通するのは「**個別の要素と、要素のグループを同じように扱いたい**」という要求である。Composite パターンなしでは、クライアントコードが「これは Leaf か？ Composite か？」を常にチェックする必要があり、コードが複雑化する。
+What all of these have in common is the requirement to **treat individual elements and groups of elements in the same way**. Without the Composite pattern, client code must constantly check "is this a Leaf or a Composite?", leading to increased complexity.
 
-### 1.2 パターンの意図
+### 1.2 Intent of the Pattern
 
-GoF の定義:
+GoF definition:
 
 > Compose objects into tree structures to represent part-whole hierarchies. Composite lets clients treat individual objects and compositions of objects uniformly.
 
-日本語に訳すと:
+### 1.3 WHY: Why Is the Composite Pattern Needed?
 
-> オブジェクトをツリー構造に組み立てて部分-全体の階層を表現する。Composite パターンにより、クライアントは個々のオブジェクトとオブジェクトの合成物を統一的に扱うことができる。
+The fundamental reason is to **align the level of abstraction**.
 
-### 1.3 WHY: なぜ Composite パターンが必要なのか
-
-根本的な理由は **抽象化のレベルを揃える** ことにある。
-
-1. **クライアントコードの簡素化**: `if (isLeaf)` のような分岐が不要になり、再帰的に統一操作を適用できる
-2. **Open/Closed Principle の遵守**: 新しい Leaf 型や Composite 型を追加しても、既存のクライアントコードを変更する必要がない
-3. **再帰的構造の自然な表現**: ツリー構造を言語の型システムで直接表現でき、操作も自然に再帰的に定義できる
+1. **Simplification of client code**: Eliminates branches like `if (isLeaf)`, allowing recursive uniform operations to be applied
+2. **Adherence to the Open/Closed Principle**: Adding new Leaf or Composite types does not require changing existing client code
+3. **Natural expression of recursive structures**: Tree structures can be represented directly in the language's type system, and operations can be defined recursively in a natural way
 
 ---
 
-## 2. Composite の構造
+## 2. Structure of Composite
 
-### 2.1 クラス図
+### 2.1 Class Diagram
 
 ```
 +------------------+
@@ -77,22 +73,22 @@ GoF の定義:
 |  Leaf  | | Composite  |
 +--------+ +------------+
 |+operation| | -children[]|
-+--------+ | +operation()|  -- 子に委譲して再帰
++--------+ | +operation()|  -- delegates to children recursively
            | +add(c)     |
            | +remove(c)  |
            +------------+
 ```
 
-### 2.2 構成要素の役割
+### 2.2 Roles of Each Component
 
-| 構成要素 | 役割 | 例（ファイルシステム） |
+| Component | Role | Example (File System) |
 |---------|------|---------------------|
-| Component | 統一インタフェース | FileSystemNode |
-| Leaf | 子を持たない末端ノード | File |
-| Composite | 子を持つノード、操作を子に委譲 | Directory |
-| Client | Component を通じて操作 | アプリケーション |
+| Component | Unified interface | FileSystemNode |
+| Leaf | Terminal node with no children | File |
+| Composite | Node with children; delegates operations to children | Directory |
+| Client | Operates through Component | Application |
 
-### 2.3 ツリー構造の図解
+### 2.3 Illustration of Tree Structure
 
 ```
         Composite (root)
@@ -101,7 +97,7 @@ GoF の定義:
    /      \
 Leaf A   Leaf B
 
-operation() の呼び出し:
+Calling operation():
 root.operation()
   +-- composite.operation()
   |     +-- leafA.operation()
@@ -109,10 +105,10 @@ root.operation()
   +-- leafC.operation()
 ```
 
-### 2.4 再帰処理の詳細フロー
+### 2.4 Detailed Recursive Processing Flow
 
 ```
-getSize() の呼び出しスタック:
+Call stack for getSize():
 
 root.getSize()
   |
@@ -125,23 +121,23 @@ root.getSize()
   |
   return 8 + 1 = 9
 
-[コールスタックの深さ]
+[Call stack depth]
 depth 0: root.getSize()
 depth 1: components.getSize(), index.getSize()
 depth 2: Button.getSize(), Modal.getSize()
 
-時間計算量: O(N) — 全ノードを1回ずつ訪問
-空間計算量: O(D) — D はツリーの最大深さ（再帰スタック）
+Time complexity:  O(N) — visits each node exactly once
+Space complexity: O(D) — D is the maximum depth of the tree (recursion stack)
 ```
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: ファイルシステム（TypeScript）
+### Code Example 1: File System (TypeScript)
 
 ```typescript
-// file-system.ts — Composite パターンの典型例
+// file-system.ts — Classic example of the Composite pattern
 interface FileSystemNode {
   getName(): string;
   getSize(): number;
@@ -207,7 +203,7 @@ class Directory implements FileSystemNode {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const root = new Directory("src");
 const components = new Directory("components");
 components.add(new File("Button.tsx", 3, "tsx"));
@@ -219,7 +215,7 @@ root.add(utils);
 root.add(new File("index.ts", 1, "ts"));
 
 root.print();
-// 出力:
+// Output:
 // src/
 //   components/
 //     Button.tsx (3KB)
@@ -230,16 +226,16 @@ root.print();
 
 console.log(`Total size: ${root.getSize()}KB`); // 11
 
-// find で条件に合うノードを検索
+// Search for nodes matching a condition using find
 const largeFiles = root.find(node => node.getSize() > 3);
 console.log(largeFiles.map(f => f.getName()));
-// ["components", "Modal.tsx"] — Directory は合計サイズで評価される
+// ["components", "Modal.tsx"] — Directory is evaluated by its total size
 ```
 
-### コード例 2: UI コンポーネントツリー（TypeScript）
+### Code Example 2: UI Component Tree (TypeScript)
 
 ```typescript
-// ui-component.ts — UI のレンダリングツリー
+// ui-component.ts — UI rendering tree
 interface UIComponent {
   render(): string;
   getBoundingBox(): { width: number; height: number };
@@ -328,7 +324,7 @@ class Container implements UIComponent {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const page = new Container("page", "div")
   .add(new Container("header", "header", "horizontal")
     .add(new ImageElement("logo", "/logo.png", 100, 50))
@@ -346,10 +342,10 @@ const logo = page.findById("logo");
 console.log(logo !== null); // true
 ```
 
-### コード例 3: 価格計算 ── 商品とバンドル（TypeScript）
+### Code Example 3: Price Calculation — Products and Bundles (TypeScript)
 
 ```typescript
-// pricing.ts — ECサイトのバンドル商品の価格計算
+// pricing.ts — Price calculation for bundled products in an e-commerce site
 interface PriceItem {
   getPrice(): number;
   getDescription(): string;
@@ -412,7 +408,7 @@ class Bundle implements PriceItem {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const starterPack = new Bundle("Starter Pack", 0.1)
   .add(new Product("Mouse", 3000))
   .add(new Product("Keyboard", 8000))
@@ -431,40 +427,40 @@ console.log(starterPack.getItemCount()); // 4
 console.log(JSON.stringify(starterPack.toJSON(), null, 2));
 ```
 
-### コード例 4: Python ── 組織図
+### Code Example 4: Python — Organizational Chart
 
 ```python
-# organization.py — 組織構造の Composite パターン
+# organization.py — Composite pattern for organizational structure
 from abc import ABC, abstractmethod
 from typing import Iterator
 
 
 class OrganizationUnit(ABC):
-    """組織の構成単位（Component）"""
+    """A unit of organization (Component)"""
 
     @abstractmethod
     def get_salary_cost(self) -> float:
-        """人件費の合計を返す"""
+        """Returns the total personnel cost"""
         ...
 
     @abstractmethod
     def get_headcount(self) -> int:
-        """所属人数を返す"""
+        """Returns the number of members"""
         ...
 
     @abstractmethod
     def print_structure(self, indent: int = 0) -> None:
-        """組織構造を表示する"""
+        """Displays the organizational structure"""
         ...
 
     @abstractmethod
     def find_by_name(self, name: str) -> list["OrganizationUnit"]:
-        """名前で検索する"""
+        """Searches by name"""
         ...
 
 
 class Employee(OrganizationUnit):
-    """個人（Leaf）"""
+    """Individual person (Leaf)"""
 
     def __init__(self, name: str, role: str, salary: float):
         self.name = name
@@ -486,7 +482,7 @@ class Employee(OrganizationUnit):
 
 
 class Department(OrganizationUnit):
-    """部門（Composite）"""
+    """Department (Composite)"""
 
     def __init__(self, name: str):
         self.name = name
@@ -509,7 +505,7 @@ class Department(OrganizationUnit):
         prefix = " " * indent
         cost = self.get_salary_cost()
         count = self.get_headcount()
-        print(f"{prefix}[{self.name}] ({count}名, 人件費: {cost:,.0f})")
+        print(f"{prefix}[{self.name}] ({count} members, personnel cost: {cost:,.0f})")
         for m in self._members:
             m.print_structure(indent + 2)
 
@@ -525,7 +521,7 @@ class Department(OrganizationUnit):
         return iter(self._members)
 
 
-# --- 使用例 ---
+# --- Usage example ---
 eng = Department("Engineering")
 eng.add(Employee("Alice", "Tech Lead", 800_000))
 eng.add(Employee("Bob", "Senior Engineer", 700_000))
@@ -545,13 +541,13 @@ company.add(product)
 company.add(Employee("Grace", "CEO", 1_200_000))
 
 company.print_structure()
-# [Acme Corp] (7名, 人件費: 5,450,000)
-#   [Product] (6名, 人件費: 4,250,000)
-#     [Engineering] (3名, 人件費: 2,050,000)
+# [Acme Corp] (7 members, personnel cost: 5,450,000)
+#   [Product] (6 members, personnel cost: 4,250,000)
+#     [Engineering] (3 members, personnel cost: 2,050,000)
 #       - Alice (Tech Lead, 800,000)
 #       - Bob (Senior Engineer, 700,000)
 #       - Charlie (Engineer, 550,000)
-#     [Design] (2名, 人件費: 1,350,000)
+#     [Design] (2 members, personnel cost: 1,350,000)
 #       - Diana (Design Lead, 750,000)
 #       - Eve (Designer, 600,000)
 #     - Frank (Product Manager, 850,000)
@@ -566,10 +562,10 @@ for r in results:
 # Engineering, Bob, Charlie
 ```
 
-### コード例 5: 条件式ツリー（仕様パターン）
+### Code Example 5: Conditional Expression Tree (Specification Pattern)
 
 ```typescript
-// specification.ts — Composite + Specification パターン
+// specification.ts — Composite + Specification pattern
 interface Specification<T> {
   isSatisfiedBy(item: T): boolean;
   and(other: Specification<T>): Specification<T>;
@@ -631,7 +627,7 @@ class NotSpec<T> extends BaseSpec<T> {
   }
 }
 
-// --- Leaf Specification の例 ---
+// --- Example Leaf Specifications ---
 interface Product {
   name: string;
   price: number;
@@ -662,8 +658,8 @@ class IsNew extends BaseSpec<Product> {
   toString(): string { return `isNew`; }
 }
 
-// --- 使用例 ---
-// 「安くてかつ在庫あり」OR「新商品」
+// --- Usage example ---
+// "affordable AND in stock" OR "new product"
 const spec = new PriceBelow(1000)
   .and(new InStock())
   .or(new IsNew());
@@ -681,23 +677,23 @@ const products: Product[] = [
 const matching = products.filter(p => spec.isSatisfiedBy(p));
 console.log(matching.map(p => p.name));
 // ["A", "B", "D"]
-// A: 500 < 1000 かつ在庫あり -> true
-// B: 新商品 -> true
-// C: 800 < 1000 だが在庫なし、新商品でもない -> false
-// D: 200 < 1000 かつ在庫あり -> true
+// A: 500 < 1000 and in stock -> true
+// B: new product -> true
+// C: 800 < 1000 but not in stock, and not a new product -> false
+// D: 200 < 1000 and in stock -> true
 ```
 
-### コード例 6: 数式ツリー（AST）
+### Code Example 6: Expression Tree (AST)
 
 ```typescript
-// expression.ts — 数式の抽象構文木 (AST) を Composite で構築
+// expression.ts — Build an abstract syntax tree (AST) for mathematical expressions using Composite
 interface Expression {
   evaluate(): number;
   toString(): string;
   simplify(): Expression;
 }
 
-// Leaf: リテラル値
+// Leaf: literal value
 class NumberLiteral implements Expression {
   constructor(private value: number) {}
 
@@ -706,7 +702,7 @@ class NumberLiteral implements Expression {
   simplify(): Expression { return this; }
 }
 
-// Leaf: 変数参照
+// Leaf: variable reference
 class Variable implements Expression {
   constructor(
     private name: string,
@@ -723,7 +719,7 @@ class Variable implements Expression {
   simplify(): Expression { return this; }
 }
 
-// Composite: 二項演算
+// Composite: binary operation
 class BinaryOp implements Expression {
   constructor(
     private op: '+' | '-' | '*' | '/',
@@ -752,14 +748,14 @@ class BinaryOp implements Expression {
     const left = this.left.simplify();
     const right = this.right.simplify();
 
-    // 定数畳み込み: 両辺がリテラルなら計算結果に置換
+    // Constant folding: if both sides are literals, replace with the computed result
     if (left instanceof NumberLiteral && right instanceof NumberLiteral) {
       return new NumberLiteral(
         new BinaryOp(this.op, left, right).evaluate()
       );
     }
 
-    // x + 0 = x, x * 1 = x 等の簡略化
+    // Simplifications such as x + 0 = x, x * 1 = x
     if (this.op === '+' && right instanceof NumberLiteral && right.evaluate() === 0) {
       return left;
     }
@@ -774,7 +770,7 @@ class BinaryOp implements Expression {
   }
 }
 
-// Composite: 関数呼び出し
+// Composite: function call
 class FunctionCall implements Expression {
   constructor(
     private fnName: string,
@@ -802,7 +798,7 @@ class FunctionCall implements Expression {
   }
 }
 
-// --- 使用例: (x + 3) * max(y, 5) ---
+// --- Usage example: (x + 3) * max(y, 5) ---
 const env = new Map<string, number>([["x", 7], ["y", 2]]);
 
 const expr = new BinaryOp('*',
@@ -816,22 +812,22 @@ console.log(expr.toString());
 console.log(expr.evaluate());
 // (7 + 3) * max(2, 5) = 10 * 5 = 50
 
-// 簡略化のテスト
+// Test simplification
 const simpleExpr = new BinaryOp('+',
   new BinaryOp('*', new NumberLiteral(2), new NumberLiteral(3)),
   new NumberLiteral(0)
 );
 console.log(simpleExpr.simplify().toString());
-// "6" — 定数畳み込み + 0 の除去
+// "6" — constant folding + removal of + 0
 ```
 
-### コード例 7: メニュー構造
+### Code Example 7: Menu Structure
 
 ```typescript
-// menu.ts — レストランのメニュー（Composite パターン）
+// menu.ts — Restaurant menu (Composite pattern)
 interface MenuItem {
   getName(): string;
-  getPrice(): number | null; // カテゴリには価格がない
+  getPrice(): number | null; // categories have no price
   isVegetarian(): boolean;
   print(indent?: string): void;
 }
@@ -850,7 +846,7 @@ class Dish implements MenuItem {
 
   print(indent = ""): void {
     const veg = this.vegetarian ? " [V]" : "";
-    console.log(`${indent}${this.name}${veg} - ${this.price}円`);
+    console.log(`${indent}${this.name}${veg} - $${this.price}`);
     console.log(`${indent}  ${this.description}`);
   }
 }
@@ -868,7 +864,7 @@ class MenuCategory implements MenuItem {
   getName(): string { return this.name; }
 
   getPrice(): null {
-    return null; // カテゴリ自体に価格はない
+    return null; // the category itself has no price
   }
 
   isVegetarian(): boolean {
@@ -888,55 +884,55 @@ class MenuCategory implements MenuItem {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const menu = new MenuCategory("Grand Menu")
   .add(new MenuCategory("Appetizers")
-    .add(new Dish("Caesar Salad", 850, true, "ロメインレタス、パルメザン"))
-    .add(new Dish("Bruschetta", 600, true, "トマト、バジル、オリーブオイル"))
-    .add(new Dish("Carpaccio", 1200, false, "牛フィレ薄切り"))
+    .add(new Dish("Caesar Salad", 850, true, "Romaine lettuce, Parmesan"))
+    .add(new Dish("Bruschetta", 600, true, "Tomato, basil, olive oil"))
+    .add(new Dish("Carpaccio", 1200, false, "Thinly sliced beef tenderloin"))
   )
   .add(new MenuCategory("Main Courses")
-    .add(new Dish("Margherita Pizza", 1400, true, "モッツァレラ、バジル"))
-    .add(new Dish("Grilled Salmon", 1800, false, "ノルウェーサーモン"))
+    .add(new Dish("Margherita Pizza", 1400, true, "Mozzarella, basil"))
+    .add(new Dish("Grilled Salmon", 1800, false, "Norwegian salmon"))
   );
 
 menu.print();
 // === Grand Menu ===
 //   === Appetizers ===
-//     Caesar Salad [V] - 850円
-//       ロメインレタス、パルメザン
-//     Bruschetta [V] - 600円
-//       トマト、バジル、オリーブオイル
-//     Carpaccio - 1200円
-//       牛フィレ薄切り
+//     Caesar Salad [V] - $850
+//       Romaine lettuce, Parmesan
+//     Bruschetta [V] - $600
+//       Tomato, basil, olive oil
+//     Carpaccio - $1200
+//       Thinly sliced beef tenderloin
 //   === Main Courses ===
-//     Margherita Pizza [V] - 1400円
-//       モッツァレラ、バジル
-//     Grilled Salmon - 1800円
-//       ノルウェーサーモン
+//     Margherita Pizza [V] - $1400
+//       Mozzarella, basil
+//     Grilled Salmon - $1800
+//       Norwegian salmon
 ```
 
 ---
 
-## 4. 透過設計 vs 安全設計：深い考察
+## 4. Transparent Design vs. Safe Design: A Deep Dive
 
-Composite パターンの設計において、最も重要なトレードオフが「透過性（Transparency）」と「安全性（Safety）」の選択である。
+The most important tradeoff in designing the Composite pattern is the choice between "Transparency" and "Safety".
 
-### 4.1 透過設計（GoF 原書の提案）
+### 4.1 Transparent Design (Proposed in the Original GoF Book)
 
 ```typescript
-// 透過設計: Component に add/remove を定義
+// Transparent design: add/remove defined on Component
 interface Component {
   operation(): void;
-  add(child: Component): void;    // Leaf にも存在
-  remove(child: Component): void; // Leaf にも存在
+  add(child: Component): void;    // also exists on Leaf
+  remove(child: Component): void; // also exists on Leaf
   getChild(index: number): Component | null;
 }
 
 class Leaf implements Component {
   operation(): void { /* ... */ }
 
-  // Leaf では例外をスロー
+  // Throws an exception on Leaf
   add(child: Component): void {
     throw new Error("Leaf cannot have children");
   }
@@ -951,25 +947,25 @@ class Leaf implements Component {
 }
 ```
 
-**利点**: クライアントは Component 型だけを扱えば良い。Leaf か Composite かの判定が不要。
-**欠点**: Leaf に対して add() を呼ぶと実行時エラー。型安全性が低い。
+**Advantage**: The client only needs to work with the Component type. No need to determine whether something is a Leaf or Composite.
+**Disadvantage**: Calling add() on a Leaf causes a runtime error. Type safety is low.
 
-### 4.2 安全設計（現代の推奨）
+### 4.2 Safe Design (Modern Recommendation)
 
 ```typescript
-// 安全設計: add/remove は Composite のみに定義
+// Safe design: add/remove defined only on Composite
 interface Component {
   operation(): void;
 }
 
-// Composite を判定するユーティリティ
+// Utility to check whether a Component is a Composite
 function isComposite(c: Component): c is Composite {
   return 'add' in c && typeof (c as any).add === 'function';
 }
 
 class Leaf implements Component {
   operation(): void { /* ... */ }
-  // add/remove は存在しない
+  // add/remove do not exist
 }
 
 class Composite implements Component {
@@ -989,41 +985,41 @@ class Composite implements Component {
 }
 ```
 
-**利点**: 型安全。Leaf に対して add() を呼ぶことがコンパイル時に検出される。
-**欠点**: Composite 固有の操作を使うにはダウンキャストや型ガードが必要。
+**Advantage**: Type safe. Calling add() on a Leaf is detected at compile time.
+**Disadvantage**: A downcast or type guard is required to use Composite-specific operations.
 
-### 4.3 比較表
+### 4.3 Comparison Table
 
 ```
-透過設計 vs 安全設計の判断フロー:
+Decision flow for Transparent Design vs. Safe Design:
 
-             クライアントは add/remove を頻繁に使うか？
+             Does the client frequently use add/remove?
                     /              \
                   Yes               No
                   /                   \
-         透過設計を検討          安全設計を採用
+         Consider transparent design    Adopt safe design
                 |
-    型安全性は重要か？
+    Is type safety important?
           /        \
         Yes         No
         /             \
-   安全設計を採用    透過設計を採用
+   Adopt safe design   Adopt transparent design
 ```
 
-| 方式 | Leaf にも add/remove | 型安全性 | 透過性 | コンパイル時検出 |
+| Approach | add/remove on Leaf | Type Safety | Transparency | Compile-time Detection |
 |------|:---:|:---:|:---:|:---:|
-| 透過設計 | Yes（例外スロー） | 低い | 高い | 不可 |
-| 安全設計 | No（Composite のみ） | 高い | 低い | 可能 |
-| 推奨 | - | **安全設計** | - | - |
+| Transparent Design | Yes (throws exception) | Low | High | Not possible |
+| Safe Design | No (Composite only) | High | Low | Possible |
+| Recommended | - | **Safe Design** | - | - |
 
 ---
 
-## 5. 循環参照防止の実装
+## 5. Implementing Circular Reference Prevention
 
-Composite パターンで最も危険な問題が循環参照である。以下に堅牢な循環参照チェックの実装を示す。
+The most dangerous problem with the Composite pattern is circular references. Below is an implementation of robust circular reference checking.
 
 ```typescript
-// safe-composite.ts — 循環参照を防止する Composite
+// safe-composite.ts — Composite with circular reference prevention
 interface SafeComponent {
   getName(): string;
   getSize(): number;
@@ -1043,7 +1039,7 @@ class SafeComposite implements SafeComponent {
   }
 
   add(child: SafeComponent): this {
-    // 循環参照チェック
+    // Circular reference check
     if (child === this) {
       throw new Error(`Cannot add "${this.name}" to itself`);
     }
@@ -1054,7 +1050,7 @@ class SafeComposite implements SafeComponent {
           `Cannot add "${child.name}": it is an ancestor of "${this.name}"`
         );
       }
-      // 既存の親から切り離す
+      // Detach from existing parent
       if (child.parent) {
         child.parent.remove(child);
       }
@@ -1096,7 +1092,7 @@ class SafeComposite implements SafeComponent {
   }
 }
 
-// --- 使用例: 循環参照の検出 ---
+// --- Usage example: detecting circular references ---
 const a = new SafeComposite("A");
 const b = new SafeComposite("B");
 const c = new SafeComposite("C");
@@ -1121,12 +1117,12 @@ console.log(c.getPath()); // ["A", "B", "C"]
 
 ---
 
-## 6. パフォーマンス最適化：キャッシュ戦略
+## 6. Performance Optimization: Caching Strategy
 
-深いツリー構造で集計操作（getSize(), getCount() 等）を頻繁に呼び出す場合、毎回再帰的に計算するとパフォーマンスが問題になる。キャッシュを使って最適化する方法を示す。
+When aggregation operations (getSize(), getCount(), etc.) are called frequently on deep tree structures, computing them recursively each time can become a performance bottleneck. Below is a method for optimizing with caching.
 
 ```typescript
-// cached-composite.ts — キャッシュ付き Composite
+// cached-composite.ts — Composite with caching
 interface CachedComponent {
   getName(): string;
   getSize(): number;
@@ -1143,7 +1139,7 @@ class CachedDirectory implements CachedComponent {
 
   add(child: CachedComponent): this {
     this.children.push(child);
-    this.invalidateCache(); // キャッシュを無効化
+    this.invalidateCache(); // Invalidate cache
     return this;
   }
 
@@ -1161,36 +1157,36 @@ class CachedDirectory implements CachedComponent {
 
   invalidateCache(): void {
     this.sizeCache = null;
-    // 親のキャッシュも無効化する必要がある
-    // （親への参照を持つ場合）
+    // The parent's cache also needs to be invalidated
+    // (when a reference to the parent is held)
   }
 }
 
-// --- パフォーマンス比較 ---
-// キャッシュなし: getSize() を N 回呼ぶと O(N * M) — M はノード数
-// キャッシュあり: 初回は O(M)、以降は O(1)、変更時は O(D) — D は深さ
+// --- Performance comparison ---
+// Without cache: calling getSize() N times costs O(N * M) — M is the number of nodes
+// With cache: O(M) on first call, O(1) thereafter, O(D) on change — D is the depth
 ```
 
 ```
-キャッシュの無効化伝搬:
+Cache invalidation propagation:
 
-  変更されたノード     親に伝搬      ルートまで伝搬
+  Changed node       propagates to parent    propagates to root
        [D]  --------> [B]  -------> [root]
        cache=null      cache=null     cache=null
 
-  次に root.getSize() が呼ばれたとき:
-  root → B を再計算 → D を再計算
-  root → C は変更されていない場合、キャッシュからそのまま返す（差分更新）
+  When root.getSize() is called next:
+  root -> recomputes B -> recomputes D
+  root -> C has not changed, so it is returned from cache as-is (incremental update)
 ```
 
 ---
 
-## 7. Composite パターンと Visitor パターンの併用
+## 7. Combining Composite Pattern with Visitor Pattern
 
-Composite で構造を表現し、Visitor で操作を追加するのは GoF でも推奨される強力な組み合わせである。
+Using Composite to represent structure and Visitor to add operations is a powerful combination also recommended by GoF.
 
 ```typescript
-// visitor.ts — Composite + Visitor パターン
+// visitor.ts — Composite + Visitor pattern
 interface FileSystemVisitor {
   visitFile(file: VisitableFile): void;
   visitDirectory(dir: VisitableDirectory): void;
@@ -1228,7 +1224,7 @@ class VisitableDirectory implements VisitableNode {
   }
 }
 
-// --- 操作1: ファイルサイズ集計 ---
+// --- Operation 1: Aggregate file sizes ---
 class SizeCalculator implements FileSystemVisitor {
   totalSize = 0;
 
@@ -1237,11 +1233,11 @@ class SizeCalculator implements FileSystemVisitor {
   }
 
   visitDirectory(_dir: VisitableDirectory): void {
-    // ディレクトリ自体にはサイズなし
+    // The directory itself has no size
   }
 }
 
-// --- 操作2: 拡張子別ファイル一覧 ---
+// --- Operation 2: List files grouped by extension ---
 class ExtensionGrouper implements FileSystemVisitor {
   groups = new Map<string, string[]>();
 
@@ -1255,7 +1251,7 @@ class ExtensionGrouper implements FileSystemVisitor {
   visitDirectory(_dir: VisitableDirectory): void {}
 }
 
-// --- 操作3: 大きなファイルの検出 ---
+// --- Operation 3: Detect large files ---
 class LargeFileFinder implements FileSystemVisitor {
   largeFiles: { name: string; size: number }[] = [];
 
@@ -1270,46 +1266,46 @@ class LargeFileFinder implements FileSystemVisitor {
   visitDirectory(_dir: VisitableDirectory): void {}
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const root = new VisitableDirectory("project")
   .add(new VisitableDirectory("src")
     .add(new VisitableFile("app.ts", 10, "ts"))
     .add(new VisitableFile("style.css", 50, "css")))
   .add(new VisitableFile("README.md", 3, "md"));
 
-// 操作1: サイズ集計
+// Operation 1: Aggregate sizes
 const calc = new SizeCalculator();
 root.accept(calc);
 console.log(`Total: ${calc.totalSize}KB`); // 63
 
-// 操作2: 拡張子グルーピング
+// Operation 2: Group by extension
 const grouper = new ExtensionGrouper();
 root.accept(grouper);
 console.log(grouper.groups);
 // Map { 'ts' => ['app.ts'], 'css' => ['style.css'], 'md' => ['README.md'] }
 
-// 操作3: 大きなファイル検出
+// Operation 3: Find large files
 const finder = new LargeFileFinder(5);
 root.accept(finder);
 console.log(finder.largeFiles);
 // [{ name: 'app.ts', size: 10 }, { name: 'style.css', size: 50 }]
 ```
 
-**Visitor との併用の利点**:
-- ツリー構造のクラスを変更せずに新しい操作を追加できる
-- Single Responsibility Principle を満たす（構造と操作の分離）
-- 同じツリーに対して複数の操作を独立して定義できる
+**Benefits of combining with Visitor**:
+- New operations can be added without modifying the tree structure classes
+- Satisfies the Single Responsibility Principle (separation of structure and operations)
+- Multiple operations can be independently defined for the same tree
 
 ---
 
-## 8. 実世界での Composite パターン
+## 8. Composite Pattern in the Real World
 
-### 8.1 React の仮想 DOM
+### 8.1 React's Virtual DOM
 
-React のコンポーネントツリーは Composite パターンの典型例である。
+React's component tree is a classic example of the Composite pattern.
 
 ```
-ReactElement ツリー:
+ReactElement tree:
   <App>                    ← Composite
     <Header>               ← Composite
       <Logo />             ← Leaf
@@ -1323,7 +1319,7 @@ ReactElement ツリー:
     </Main>
   </App>
 
-render() の再帰的呼び出し:
+Recursive calls to render():
   App.render()
     -> Header.render()
       -> Logo.render()
@@ -1336,7 +1332,7 @@ render() の再帰的呼び出し:
 
 ### 8.2 DOM API
 
-ブラウザの DOM 自体が Composite パターンである。
+The browser's DOM itself is the Composite pattern.
 
 ```
 Node (Component)
@@ -1346,13 +1342,13 @@ Node (Component)
        +-- children: Node[]
        +-- appendChild()
        +-- removeChild()
-       +-- textContent    ← 再帰的に取得
-       +-- innerHTML      ← 再帰的に取得
+       +-- textContent    ← retrieved recursively
+       +-- innerHTML      ← retrieved recursively
 ```
 
-### 8.3 JSONパーサー
+### 8.3 JSON Parser
 
-JSON の値は Composite 構造である。
+JSON values have a Composite structure.
 
 ```
 JsonValue (Component)
@@ -1366,58 +1362,58 @@ JsonValue (Component)
 
 ---
 
-## 9. 比較表
+## 9. Comparison Tables
 
-### 比較表 1: Composite vs 通常のコレクション
+### Comparison Table 1: Composite vs. Ordinary Collections
 
-| 観点 | Composite | 配列/リスト |
+| Aspect | Composite | Array/List |
 |------|:---:|:---:|
-| ネスト | 再帰的（ツリー） | フラット |
-| 統一インタフェース | Yes | No |
-| 操作の委譲 | 自動（再帰） | 手動ループ |
-| 型安全性 | 高い | 要キャスト |
-| 適用場面 | 階層構造 | 均一なコレクション |
-| 柔軟性 | 高い（深さ任意） | 固定（1レベル） |
-| 実装コスト | 中 | 低い |
+| Nesting | Recursive (tree) | Flat |
+| Unified interface | Yes | No |
+| Operation delegation | Automatic (recursion) | Manual loop |
+| Type safety | High | Requires casting |
+| Use case | Hierarchical structures | Uniform collections |
+| Flexibility | High (arbitrary depth) | Fixed (1 level) |
+| Implementation cost | Medium | Low |
 
-### 比較表 2: 透過設計 vs 安全設計
+### Comparison Table 2: Transparent Design vs. Safe Design
 
-| 方式 | Leaf にも add/remove | 型安全性 | 透過性 | 実行時エラーリスク |
+| Approach | add/remove on Leaf | Type Safety | Transparency | Runtime Error Risk |
 |------|:---:|:---:|:---:|:---:|
-| 透過設計 | Yes（例外スロー） | 低い | 高い | 高い |
-| 安全設計 | No（Composite のみ） | 高い | 低い | 低い |
-| ハイブリッド | Optional メソッド | 中 | 中 | 中 |
-| 推奨 | - | **安全設計** | - | - |
+| Transparent Design | Yes (throws exception) | Low | High | High |
+| Safe Design | No (Composite only) | High | Low | Low |
+| Hybrid | Optional methods | Medium | Medium | Medium |
+| Recommended | - | **Safe Design** | - | - |
 
-### 比較表 3: 関連パターンとの比較
+### Comparison Table 3: Comparison with Related Patterns
 
-| パターン | 目的 | 構造 | 再帰 | 典型例 |
+| Pattern | Purpose | Structure | Recursive | Typical Example |
 |---------|------|------|:---:|-------|
-| **Composite** | 部分-全体の統一操作 | ツリー | Yes | ファイルシステム |
-| **Decorator** | 動的な機能追加 | チェーン | 可能 | ストリーム |
-| **Chain of Responsibility** | 処理の委譲チェーン | リスト | No | ミドルウェア |
-| **Iterator** | 走査の抽象化 | - | No | コレクション |
-| **Visitor** | 構造と操作の分離 | - | Yes | AST 処理 |
+| **Composite** | Uniform operations on part-whole | Tree | Yes | File system |
+| **Decorator** | Dynamic feature addition | Chain | Possible | Streams |
+| **Chain of Responsibility** | Chain of processing delegation | List | No | Middleware |
+| **Iterator** | Abstraction of traversal | - | No | Collections |
+| **Visitor** | Separation of structure and operations | - | Yes | AST processing |
 
 ---
 
-## 10. アンチパターン
+## 10. Anti-Patterns
 
-### アンチパターン 1: 循環参照の許容
+### Anti-Pattern 1: Allowing Circular References
 
 ```typescript
-// NG: 循環参照を防止していない
+// NG: no circular reference prevention
 class BadComposite {
   private children: BadComposite[] = [];
 
   add(child: BadComposite): void {
-    this.children.push(child); // 自分自身を追加できてしまう！
+    this.children.push(child); // can add itself as a child!
   }
 
   getSize(): number {
     let size = 1;
     for (const child of this.children) {
-      size += child.getSize(); // 循環参照があるとスタックオーバーフロー
+      size += child.getSize(); // stack overflow if circular reference exists
     }
     return size;
   }
@@ -1426,21 +1422,21 @@ class BadComposite {
 const a = new BadComposite();
 const b = new BadComposite();
 a.add(b);
-b.add(a); // 循環参照！
-// a.getSize() -> b.getSize() -> a.getSize() -> ... スタックオーバーフロー
+b.add(a); // circular reference!
+// a.getSize() -> b.getSize() -> a.getSize() -> ... stack overflow
 
-// OK: 循環参照チェック付き
+// OK: with circular reference check
 class GoodComposite {
   private children: GoodComposite[] = [];
   private parent: GoodComposite | null = null;
 
   add(child: GoodComposite): void {
-    // 自分自身のチェック
+    // Check for self-reference
     if (child === this) {
       throw new Error("Cannot add self as child");
     }
 
-    // 祖先チェック（child が自分の祖先でないことを確認）
+    // Ancestor check (ensure child is not an ancestor of this node)
     let current: GoodComposite | null = this;
     while (current !== null) {
       if (current === child) {
@@ -1449,7 +1445,7 @@ class GoodComposite {
       current = current.parent;
     }
 
-    // 既存の親から切り離す
+    // Detach from existing parent
     if (child.parent) {
       child.parent.children = child.parent.children.filter(c => c !== child);
     }
@@ -1468,41 +1464,41 @@ class GoodComposite {
 }
 ```
 
-### アンチパターン 2: Composite が Leaf 固有のロジックに依存
+### Anti-Pattern 2: Composite Depending on Leaf-Specific Logic
 
 ```typescript
-// NG: Composite が子の具象型を知っている
+// NG: Composite knows about the concrete types of its children
 class BadDirectory {
   private children: FileSystemNode[] = [];
 
   getSize(): number {
     return this.children.reduce((sum, c) => {
-      if (c instanceof File) {        // 型チェック！
-        return sum + c.getRawSize();   // Leaf 固有メソッド呼び出し
+      if (c instanceof File) {        // type check!
+        return sum + c.getRawSize();   // calling a Leaf-specific method
       }
       if (c instanceof Directory) {
         return sum + c.getSize();
       }
-      return sum; // 新しい型が来たら対応漏れ
+      return sum; // will miss new types
     }, 0);
   }
 }
 
-// OK: Component インタフェースの getSize() に統一
+// OK: unified through the Component interface's getSize()
 class GoodDirectory {
   private children: FileSystemNode[] = [];
 
   getSize(): number {
-    // 型チェックなし、インタフェースに委譲
+    // no type checks, delegating to the interface
     return this.children.reduce((sum, c) => sum + c.getSize(), 0);
   }
 }
 ```
 
-### アンチパターン 3: 不要な Composite パターンの適用
+### Anti-Pattern 3: Applying Composite Pattern Unnecessarily
 
 ```typescript
-// NG: フラットなリストに Composite を適用（過剰設計）
+// NG: applying Composite to a flat list (over-engineering)
 interface Task {
   getName(): string;
   getDuration(): number;
@@ -1524,28 +1520,28 @@ class TaskGroup implements Task {
   }
 }
 
-// もしネストする必要がないなら、単純な配列で十分:
+// If nesting is not needed, a simple array is sufficient:
 // const tasks: SimpleTask[] = [...];
 // const total = tasks.reduce((sum, t) => sum + t.getDuration(), 0);
 
-// OK: 実際にツリー構造が必要な場合のみ Composite を使う
-// 判断基準: ネストの深さが2以上になり得るか？
+// OK: use Composite only when a tree structure is actually needed
+// Decision criterion: can the nesting depth be 2 or more?
 ```
 
 ---
 
-## 11. 実践演習
+## 11. Practice Exercises
 
-### 演習 1: 基礎 ── ファイルシステムの実装
+### Exercise 1: Basic — Implementing a File System
 
-**課題**: 以下の要件を満たすファイルシステムを Composite パターンで実装せよ。
+**Task**: Implement a file system that satisfies the following requirements using the Composite pattern.
 
-1. `FileSystemNode` インタフェースに `getName()`, `getSize()`, `print()` メソッドを定義
-2. `File` クラス（Leaf）: 名前、サイズ、拡張子を保持
-3. `Directory` クラス（Composite）: 子ノードを保持、再帰的にサイズを計算
-4. ツリーの文字列表現を返す `toString()` メソッドを追加
+1. Define `getName()`, `getSize()`, and `print()` methods on the `FileSystemNode` interface
+2. `File` class (Leaf): holds name, size, and extension
+3. `Directory` class (Composite): holds child nodes, calculates size recursively
+4. Add a `toString()` method that returns a string representation of the tree
 
-**テストケース**:
+**Test case**:
 
 ```typescript
 const root = new Directory("project");
@@ -1562,7 +1558,7 @@ console.log(root.getSize()); // 35
 root.print();
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 project/
@@ -1576,18 +1572,18 @@ project/
 
 ---
 
-### 演習 2: 応用 ── 権限管理ツリー
+### Exercise 2: Applied — Permission Management Tree
 
-**課題**: 組織の権限管理システムを Composite パターンで実装せよ。
+**Task**: Implement an organizational permission management system using the Composite pattern.
 
-要件:
-1. `Permission` インタフェース: `hasPermission(action: string): boolean`
-2. `Role` クラス（Leaf）: 特定の権限セットを保持
-3. `RoleGroup` クラス（Composite）: 複数のロールを階層的に組み合わせ
-4. 子のいずれかが権限を持っていれば `true` を返す（OR 結合）
-5. 権限の一覧を取得する `getAllPermissions(): string[]` メソッド
+Requirements:
+1. `Permission` interface: `hasPermission(action: string): boolean`
+2. `Role` class (Leaf): holds a specific set of permissions
+3. `RoleGroup` class (Composite): hierarchically combines multiple roles
+4. Returns `true` if any child has the permission (OR combination)
+5. `getAllPermissions(): string[]` method to retrieve a list of all permissions
 
-**テストケース**:
+**Test case**:
 
 ```typescript
 const reader = new Role("reader", ["read", "list"]);
@@ -1609,26 +1605,26 @@ console.log(superAdmin.getAllPermissions());
 // ["read", "list", "write", "update", "delete", "manage"]
 ```
 
-**期待される出力**: 上記のコメント通り。
+**Expected output**: As shown in the comments above.
 
 ---
 
-### 演習 3: 発展 ── Visitor 付きの数式評価器
+### Exercise 3: Advanced — Expression Evaluator with Visitor
 
-**課題**: Composite パターンと Visitor パターンを組み合わせて、数式の抽象構文木（AST）を構築し、複数の操作を適用できる評価器を実装せよ。
+**Task**: Combine the Composite pattern with the Visitor pattern to build an abstract syntax tree (AST) for mathematical expressions and implement an evaluator that can apply multiple operations.
 
-要件:
-1. `Expression` インタフェース（Component）: `accept(visitor)` メソッド
-2. `NumberLiteral`, `Variable`（Leaf）
-3. `BinaryOp`, `UnaryOp`（Composite）
-4. Visitor 1: `Evaluator` — 式を評価して数値を返す
-5. Visitor 2: `PrettyPrinter` — 式を文字列に整形する
-6. Visitor 3: `Simplifier` — 式を簡略化する（0の加算、1の乗算の除去等）
+Requirements:
+1. `Expression` interface (Component): `accept(visitor)` method
+2. `NumberLiteral`, `Variable` (Leaf)
+3. `BinaryOp`, `UnaryOp` (Composite)
+4. Visitor 1: `Evaluator` — evaluates the expression and returns a number
+5. Visitor 2: `PrettyPrinter` — formats the expression as a string
+6. Visitor 3: `Simplifier` — simplifies the expression (removes addition of 0, multiplication by 1, etc.)
 
-**テストケース**:
+**Test case**:
 
 ```typescript
-// 式: (x + 0) * (1 * y)  →  簡略化後: x * y
+// Expression: (x + 0) * (1 * y)  →  after simplification: x * y
 const env = new Map([["x", 3], ["y", 7]]);
 
 const expr = new BinaryOp('*',
@@ -1652,84 +1648,84 @@ simplified.accept(printer2);
 console.log(printer2.getResult()); // "(x * y)"
 ```
 
-**期待される出力**: 上記のコメント通り。
+**Expected output**: As shown in the comments above.
 
 ---
 
 ## 12. FAQ
 
-### Q1: React の仮想 DOM は Composite パターンですか？
+### Q1: Is React's virtual DOM the Composite pattern?
 
-はい。React のコンポーネントツリーは Composite パターンの典型例です。各コンポーネントは `render()` を持ち、子コンポーネントに再帰的に処理を委譲します。JSX の `<Parent><Child /></Parent>` という構文は、Composite の add() に相当します。React 18 の Suspense や Server Components も、このツリー構造の上に構築されています。
+Yes. React's component tree is a classic example of the Composite pattern. Each component has a `render()` method and recursively delegates processing to child components. The JSX syntax `<Parent><Child /></Parent>` is equivalent to Composite's add(). React 18's Suspense and Server Components are also built on top of this tree structure.
 
-### Q2: Visitor パターンと Composite は併用できますか？
+### Q2: Can the Visitor pattern be combined with Composite?
 
-はい。Composite でツリー構造を表現し、Visitor で操作を追加するのは GoF でも推奨される組み合わせです。新しい操作を追加する際にツリーのクラスを変更する必要がなくなります。ただし、ツリーのノード型を頻繁に追加する場合は Visitor の `visit` メソッドも追加が必要になるため、変更の方向を考慮して選択してください。
+Yes. Using Composite to represent the tree structure and Visitor to add operations is a combination recommended by GoF. It eliminates the need to modify tree classes when adding new operations. However, if node types in the tree are frequently added, the Visitor's `visit` methods also need to be added, so consider the direction of change when making your choice.
 
-### Q3: 深いネストはパフォーマンス問題になりますか？
+### Q3: Can deep nesting cause performance problems?
 
-再帰の深さが数百レベルを超えるとスタックオーバーフローのリスクがあります。対策として:
-1. **反復（イテレーティブ）なトラバーサル**: 明示的なスタックを使って再帰をループに変換
-2. **末尾呼出し最適化**: 言語がサポートする場合（Scala の `@tailrec` 等）
-3. **遅延評価**: 必要なノードのみを展開する
-4. **キャッシュ**: 集計結果をキャッシュして再計算を避ける
+When the recursion depth exceeds several hundred levels, there is a risk of stack overflow. Countermeasures include:
+1. **Iterative traversal**: Convert recursion to a loop using an explicit stack
+2. **Tail call optimization**: When the language supports it (e.g., Scala's `@tailrec`)
+3. **Lazy evaluation**: Expand only the necessary nodes
+4. **Caching**: Cache aggregation results to avoid recomputation
 
-### Q4: Composite パターンで子ノードの順序は保証すべきですか？
+### Q4: Should the order of child nodes be guaranteed in the Composite pattern?
 
-用途によります。ファイルシステムでは名前順のソートが一般的です。UI ツリーではレイアウト順（描画順）が重要です。数式 AST では演算子の左右が意味を持ちます。一般的には、用途に応じてソート済みコレクション（`SortedSet`）や順序付きリスト（`ArrayList`）を使い分けます。
+It depends on the use case. For file systems, sorting by name is common. For UI trees, layout order (rendering order) is important. For expression ASTs, left and right operands of operators carry meaning. In general, choose between a sorted collection (`SortedSet`) or an ordered list (`ArrayList`) according to the use case.
 
-### Q5: Composite と Decorator の違いは何ですか？
+### Q5: What is the difference between Composite and Decorator?
 
-構造は似ていますが意図が異なります。Composite はツリー構造で「部分-全体」を表現し、子の集合に操作を委譲します。Decorator はチェーン構造で単一オブジェクトに機能を動的に追加します。Composite は「1対多」、Decorator は「1対1」の関係です。
+Although the structures are similar, the intent differs. Composite uses a tree structure to represent "part-whole" relationships and delegates operations to a collection of children. Decorator uses a chain structure to dynamically add functionality to a single object. Composite is a "one-to-many" relationship, while Decorator is "one-to-one".
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not only through theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the fundamental concepts explained in this guide before moving on to the next steps.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world development?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## 13. まとめ
+## 13. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| 目的 | ツリー構造を統一インタフェースで操作 |
-| 構成 | Component（統一IF）, Leaf（末端）, Composite（集合） |
-| 再帰 | Composite が子に操作を委譲し、結果を集約 |
-| 典型例 | ファイルシステム、UI ツリー、組織図、数式 AST |
-| 透過 vs 安全 | 現代は安全設計（add/remove は Composite のみ）推奨 |
-| 循環参照 | 親参照と祖先チェックで防止 |
-| パフォーマンス | キャッシュで再帰的集計を最適化 |
-| Visitor 併用 | 構造を変えずに操作を追加する強力な組み合わせ |
+| Purpose | Operate on tree structures through a unified interface |
+| Components | Component (unified IF), Leaf (terminal), Composite (collection) |
+| Recursion | Composite delegates operations to children and aggregates results |
+| Typical Examples | File system, UI tree, org chart, expression AST |
+| Transparent vs. Safe | Modern practice recommends safe design (add/remove on Composite only) |
+| Circular References | Prevented via parent reference and ancestor checks |
+| Performance | Cache recursive aggregations for optimization |
+| With Visitor | Powerful combination for adding operations without changing structure |
 
 ---
 
-## 次に読むべきガイド
+## Further Reading
 
-- [Iterator パターン](../02-behavioral/04-iterator.md) -- ツリー走査の抽象化
-- [Decorator パターン](./01-decorator.md) -- 動的な機能追加
-- [Visitor パターン](../02-behavioral/) -- Composite との併用
-- [合成優先の原則](../../../clean-code-principles/docs/03-practices-advanced/01-composition-over-inheritance.md) -- 継承より合成を選ぶ理由
-- [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) -- Open/Closed Principle
+- [Iterator Pattern](../02-behavioral/04-iterator.md) -- Abstracting tree traversal
+- [Decorator Pattern](./01-decorator.md) -- Dynamic feature addition
+- [Visitor Pattern](../02-behavioral/) -- Combining with Composite
+- [Composition Over Inheritance](../../../clean-code-principles/docs/03-practices-advanced/01-composition-over-inheritance.md) -- Why to prefer composition over inheritance
+- [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) -- Open/Closed Principle
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Composite パターンの原典。透過設計と安全設計のトレードオフについて詳しい。
-2. Freeman, E., Robson, E. (2020). *Head First Design Patterns* (2nd Edition). O'Reilly Media. -- 視覚的に Composite パターンを学べる。
-3. Refactoring.Guru -- Composite. https://refactoring.guru/design-patterns/composite -- 図解と多言語の実装例。
-4. Martin, R.C. (2008). *Clean Architecture: A Craftsman's Guide to Software Structure and Design*. Prentice Hall. -- SOLID 原則と Composite の関連。
-5. React Documentation -- Composition vs Inheritance. https://react.dev/learn/thinking-in-react -- React におけるコンポーネント合成の考え方。
+1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- The original source of the Composite pattern. Provides detailed coverage of the tradeoff between transparent and safe design.
+2. Freeman, E., Robson, E. (2020). *Head First Design Patterns* (2nd Edition). O'Reilly Media. -- Learn the Composite pattern visually.
+3. Refactoring.Guru -- Composite. https://refactoring.guru/design-patterns/composite -- Diagrams and implementation examples in multiple languages.
+4. Martin, R.C. (2008). *Clean Architecture: A Craftsman's Guide to Software Structure and Design*. Prentice Hall. -- The relationship between SOLID principles and Composite.
+5. React Documentation -- Composition vs Inheritance. https://react.dev/learn/thinking-in-react -- The concept of component composition in React.

--- a/03-software-design/design-patterns-guide/docs/02-behavioral/00-observer.md
+++ b/03-software-design/design-patterns-guide/docs/02-behavioral/00-observer.md
@@ -1,81 +1,77 @@
-# Observer パターン
+# Observer Pattern
 
-> オブジェクト間に **1対多** の依存関係を定義し、あるオブジェクトの状態変化を依存するすべてのオブジェクトに自動通知する振る舞いパターン。イベント駆動設計の基盤であり、疎結合なシステムを構築するための最重要パターンの1つである。
-
----
-
-## この章で学ぶこと
-
-1. Observer パターン（Pub/Sub）の構造とイベント駆動設計の基礎を理解し、GoF の設計意図と現代の適用を把握する
-2. Push 型と Pull 型の通知モデルの違いと使い分け、型安全な EventEmitter の設計方法を習得する
-3. メモリリーク防止、イベントの順序保証、非同期通知、バックプレッシャーなど実運用上の課題と対策を身につける
+> A behavioral pattern that defines a **one-to-many** dependency between objects, automatically notifying all dependent objects when one object changes state. It is the foundation of event-driven design and one of the most important patterns for building loosely coupled systems.
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-このガイドを読む前に、以下の概念を理解しておくことを推奨します。
+1. Understand the structure of the Observer pattern (Pub/Sub) and the fundamentals of event-driven design, grasping the GoF design intent and modern applications
+2. Learn the differences between Push and Pull notification models, when to use each, and how to design a type-safe EventEmitter
+3. Acquire practical knowledge of real-world challenges and countermeasures: memory leak prevention, event ordering guarantees, asynchronous notifications, and backpressure
 
-| 前提知識 | 説明 | 参照リンク |
+---
+
+## Prerequisites
+
+Before reading this guide, it is recommended to understand the following concepts.
+
+| Prerequisite | Description | Reference Link |
 |---------|------|-----------|
-| インタフェースとポリモーフィズム | 共通の契約を通じて異なる型を統一的に扱う概念 | [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) |
-| コールバック関数 | 他の関数に渡されて後から呼び出される関数 | [関数型パターン](../03-functional/02-fp-patterns.md) |
-| 依存性の方向と結合度 | モジュール間の依存関係の管理 | [クリーンコード原則](../../../clean-code-principles/docs/00-principles/) |
-| Promise/async-await | 非同期処理の基礎（非同期 Observer の理解に必要） | [モナドパターン](../03-functional/00-monad.md) |
+| Interfaces and Polymorphism | The concept of treating different types uniformly through a common contract | [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Callback Functions | Functions passed to other functions to be called later | [Functional Patterns](../03-functional/02-fp-patterns.md) |
+| Dependency Direction and Coupling | Managing dependencies between modules | [Clean Code Principles](../../../clean-code-principles/docs/00-principles/) |
+| Promise/async-await | Fundamentals of asynchronous processing (required for understanding async Observer) | [Monad Pattern](../03-functional/00-monad.md) |
 
 ---
 
-## 1. Observer パターンとは何か
+## 1. What Is the Observer Pattern?
 
-### 1.1 解決する問題
+### 1.1 The Problem It Solves
 
-ソフトウェアシステムでは「ある部分の状態が変わったとき、それに依存する他の部分を更新したい」という要求が頻繁にある。
+In software systems, there is a frequent requirement: "when one part changes state, update all other parts that depend on it."
 
-- ユーザーが商品を購入したら、メール送信・在庫更新・分析データ記録を行いたい
-- データが変更されたら、関連するUIを全て再描画したい
-- センサーの値が変わったら、モニター・アラーム・ログの全てに反映したい
+- When a user purchases a product, send an email, update inventory, and record analytics data
+- When data changes, redraw all related UI elements
+- When a sensor value changes, reflect it in all monitors, alarms, and logs
 
-これらを直接的な関数呼び出しで実装すると、呼び出し元が全ての依存先を知る必要があり、**密結合**になる。新しい依存先を追加するたびに呼び出し元のコードを変更しなければならず、Open/Closed Principle に違反する。
+Implementing these with direct function calls requires the caller to know all its dependents, resulting in **tight coupling**. Every time a new dependent is added, the caller's code must be changed, violating the Open/Closed Principle.
 
-### 1.2 パターンの意図
+### 1.2 Pattern Intent
 
-GoF の定義:
+GoF definition:
 
 > Define a one-to-many dependency between objects so that when one object changes state, all its dependents are notified and updated automatically.
 
-日本語訳:
+### 1.3 WHY: Why Is the Observer Pattern Needed?
 
-> オブジェクト間に1対多の依存関係を定義し、あるオブジェクトの状態が変化したとき、依存する全てのオブジェクトに自動的に通知され更新されるようにする。
-
-### 1.3 WHY: なぜ Observer パターンが必要なのか
-
-根本的な理由は **依存関係の方向を逆転させる** ことにある。
+The fundamental reason is to **reverse the direction of dependencies**.
 
 ```
-直接呼び出し（密結合）:
+Direct calls (tight coupling):
   OrderService ----> EmailService
               |----> InventoryService
               |----> AnalyticsService
-  問題: OrderService が全ての後続処理を知っている
+  Problem: OrderService knows all downstream processes
 
-Observer パターン（疎結合）:
+Observer Pattern (loose coupling):
   OrderService --emit("ordered")--> EventBus
                                       |
   EmailService      <--- subscribe ---+
   InventoryService  <--- subscribe ---+
   AnalyticsService  <--- subscribe ---+
-  利点: OrderService は後続処理を知らない
+  Benefit: OrderService does not know about downstream processes
 ```
 
-1. **疎結合**: Subject は Observer の具体的な型を知らない。インタフェースのみに依存する
-2. **Open/Closed Principle**: 新しい Observer を追加しても Subject のコードは変更不要
-3. **実行時の動的構成**: Observer の登録・解除を実行時に自由に行える
+1. **Loose Coupling**: The Subject does not know the concrete types of its Observers. It depends only on interfaces
+2. **Open/Closed Principle**: Adding a new Observer requires no changes to the Subject's code
+3. **Runtime Dynamic Configuration**: Observers can be freely registered and deregistered at runtime
 
 ---
 
-## 2. Observer の構造
+## 2. Observer Structure
 
-### 2.1 クラス図
+### 2.1 Class Diagram
 
 ```
 +------------------+          +------------------+
@@ -92,26 +88,26 @@ Observer パターン（疎結合）:
                         +----------+  +----------+
 ```
 
-### 2.2 構成要素の役割
+### 2.2 Role of Each Component
 
-| 構成要素 | 役割 | 責務 |
+| Component | Role | Responsibility |
 |---------|------|------|
-| Subject (Publisher) | 状態を保持し、変更時に通知を発行 | Observer の登録/解除/通知の管理 |
-| Observer (Subscriber) | Subject の変更に反応 | update() で通知を受け取り処理 |
-| ConcreteSubject | 具体的な状態を持つ Subject | 状態変更時に notify() を呼ぶ |
-| ConcreteObserver | 具体的な反応ロジック | update() に応じた処理を実行 |
+| Subject (Publisher) | Holds state and publishes notifications on change | Manages Observer registration/deregistration/notification |
+| Observer (Subscriber) | Reacts to Subject changes | Receives notifications via update() and processes them |
+| ConcreteSubject | A Subject with concrete state | Calls notify() when state changes |
+| ConcreteObserver | Concrete reaction logic | Executes processing in response to update() |
 
-### 2.3 処理シーケンス
+### 2.3 Processing Sequence
 
 ```
-時系列の処理フロー:
+Temporal processing flow:
 
 Client          Subject              ObserverA       ObserverB
   |                |                    |               |
   |-- subscribe(A) -->|                 |               |
-  |                |-- 登録 ----------->|               |
+  |                |-- register ------->|               |
   |-- subscribe(B) -->|                 |               |
-  |                |-- 登録 --------------------------->|
+  |                |-- register --------------------------->|
   |                |                    |               |
   |-- setState() --->|                  |               |
   |                |-- notify() ------->|               |
@@ -120,57 +116,57 @@ Client          Subject              ObserverA       ObserverB
   |                |                    |   update(data)|
   |                |                    |               |
   |-- unsubscribe(A)->|                |               |
-  |                |-- 解除 ----------->|               |
+  |                |-- deregister ----->|               |
   |                |                    |               |
   |-- setState() --->|                  |               |
   |                |-- notify() --------------------------->|
   |                |                    |   update(data)|
-  |                |   (A には通知されない)              |
+  |                |   (A is not notified)              |
 ```
 
 ---
 
-## 3. Push 型 vs Pull 型
+## 3. Push vs Pull
 
-Observer パターンの通知モデルには Push 型と Pull 型の2種類がある。
+The Observer pattern has two notification models: Push and Pull.
 
 ```
-Push型: Subject が変更データを直接渡す
+Push: Subject directly passes changed data
 Subject --notify(data)--> Observer
-  利点: Observer は必要なデータをすぐ取得できる
-  欠点: 不要なデータも送られる、データ量が大きいと非効率
+  Benefit: Observer can immediately get the needed data
+  Drawback: Unnecessary data is also sent; inefficient for large data
 
-Pull型: Subject は通知のみ、Observer が取りに行く
+Pull: Subject only notifies; Observer fetches data
 Subject --notify()--> Observer --getState()--> Subject
-  利点: Observer が必要なデータだけ取得できる
-  欠点: Subject への追加アクセスが必要、Subject の公開インタフェースが増える
+  Benefit: Observer can fetch only the data it needs
+  Drawback: Requires additional access to Subject; increases Subject's public interface
 
-ハイブリッド型: イベント種別を通知し、Observer が詳細を取得
+Hybrid: Notify event type; Observer fetches details
 Subject --notify(eventType)--> Observer --getRelevantData()--> Subject
-  利点: Push と Pull の良いとこ取り
-  欠点: 設計がやや複雑
+  Benefit: Best of both Push and Pull
+  Drawback: Slightly more complex design
 ```
 
-### Push 型 vs Pull 型の判断基準
+### Decision Criteria for Push vs Pull
 
-| 判断基準 | Push 型 | Pull 型 |
+| Criteria | Push | Pull |
 |---------|---------|---------|
-| データが小さく固定的 | 適切 | 過剰 |
-| Observer ごとに必要なデータが異なる | 非効率 | 適切 |
-| Subject の状態が頻繁に変わる | 変更データのみ送信で効率的 | 毎回取得で非効率 |
-| Observer 数が多い | 各 Observer に同じデータを送信 | 各 Observer が個別に取得 |
-| リアルタイム性が重要 | 適切（遅延なし） | 追加通信による遅延 |
+| Data is small and fixed | Appropriate | Excessive |
+| Each Observer needs different data | Inefficient | Appropriate |
+| Subject state changes frequently | Efficient (send only changed data) | Inefficient (fetch each time) |
+| Many Observers | Send same data to each Observer | Each Observer fetches individually |
+| Real-time responsiveness is critical | Appropriate (no delay) | Delay due to additional communication |
 
 ---
 
-## 4. コード例
+## 4. Code Examples
 
-### コード例 1: 型安全な EventEmitter（TypeScript）
+### Code Example 1: Type-Safe EventEmitter (TypeScript)
 
 ```typescript
-// typed-event-emitter.ts — TypeScript で型安全な Observer パターン
+// typed-event-emitter.ts — Type-safe Observer pattern in TypeScript
 
-// イベントマップ: イベント名とそのデータ型を定義
+// Event map: defines event names and their data types
 type EventMap = {
   userCreated: { id: string; name: string; email: string };
   userDeleted: { id: string; reason: string };
@@ -183,8 +179,8 @@ class TypedEventEmitter<T extends Record<string, any>> {
   private onceListeners = new Map<keyof T, Set<Function>>();
 
   /**
-   * イベントを購読する
-   * @returns unsubscribe 関数
+   * Subscribe to an event
+   * @returns unsubscribe function
    */
   on<K extends keyof T>(event: K, handler: (data: T[K]) => void): () => void {
     if (!this.listeners.has(event)) {
@@ -192,14 +188,14 @@ class TypedEventEmitter<T extends Record<string, any>> {
     }
     this.listeners.get(event)!.add(handler);
 
-    // unsubscribe 関数を返す（クリーンアップ用）
+    // Return unsubscribe function (for cleanup)
     return () => {
       this.listeners.get(event)?.delete(handler);
     };
   }
 
   /**
-   * 一度だけ購読する
+   * Subscribe only once
    */
   once<K extends keyof T>(event: K, handler: (data: T[K]) => void): () => void {
     if (!this.onceListeners.has(event)) {
@@ -213,13 +209,13 @@ class TypedEventEmitter<T extends Record<string, any>> {
   }
 
   /**
-   * イベントを発行する
+   * Emit an event
    */
   emit<K extends keyof T>(event: K, data: T[K]): void {
-    // 通常のリスナー
+    // Regular listeners
     this.listeners.get(event)?.forEach(fn => fn(data));
 
-    // once リスナー（実行後に削除）
+    // once listeners (deleted after execution)
     const onceHandlers = this.onceListeners.get(event);
     if (onceHandlers) {
       onceHandlers.forEach(fn => fn(data));
@@ -228,7 +224,7 @@ class TypedEventEmitter<T extends Record<string, any>> {
   }
 
   /**
-   * 特定イベントの全リスナーを解除
+   * Remove all listeners for a specific event
    */
   removeAllListeners<K extends keyof T>(event?: K): void {
     if (event) {
@@ -241,7 +237,7 @@ class TypedEventEmitter<T extends Record<string, any>> {
   }
 
   /**
-   * リスナー数を取得（デバッグ・監視用）
+   * Get listener count (for debugging/monitoring)
    */
   listenerCount<K extends keyof T>(event: K): number {
     return (this.listeners.get(event)?.size ?? 0) +
@@ -249,20 +245,20 @@ class TypedEventEmitter<T extends Record<string, any>> {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 const bus = new TypedEventEmitter<EventMap>();
 
-// 型安全: handler の引数は自動推論される
+// Type-safe: handler argument types are automatically inferred
 const unsubUser = bus.on("userCreated", (user) => {
   console.log(`Welcome, ${user.name}! (${user.email})`);
-  // user.id, user.name, user.email が型安全にアクセス可能
+  // user.id, user.name, user.email are type-safely accessible
 });
 
 bus.on("orderPlaced", (order) => {
   console.log(`Order ${order.orderId}: $${order.total}`);
 });
 
-// once: 最初の1回だけ
+// once: fires only for the first occurrence
 bus.once("userCreated", (user) => {
   console.log(`First user bonus for ${user.name}!`);
 });
@@ -273,27 +269,27 @@ bus.emit("userCreated", { id: "1", name: "Taro", email: "taro@example.com" });
 
 bus.emit("userCreated", { id: "2", name: "Hanako", email: "hanako@example.com" });
 // "Welcome, Hanako! (hanako@example.com)"
-// (once は実行されない)
+// (once is not executed)
 
-unsubUser(); // 購読解除
+unsubUser(); // Unsubscribe
 
 bus.emit("userCreated", { id: "3", name: "Jiro", email: "jiro@example.com" });
-// (何も出力されない — 解除済み)
+// (no output — already unsubscribed)
 ```
 
-### コード例 2: React ── カスタム Observable Hook
+### Code Example 2: React — Custom Observable Hook
 
 ```typescript
-// use-observable.ts — React でリアクティブデータを扱う Hook
+// use-observable.ts — Hook for handling reactive data in React
 import { useState, useEffect, useRef, useCallback } from 'react';
 
-// Observable インタフェース
+// Observable interface
 interface Observable<T> {
   subscribe(observer: (value: T) => void): { unsubscribe: () => void };
   getValue(): T;
 }
 
-// SimpleObservable 実装
+// SimpleObservable implementation
 class SimpleObservable<T> implements Observable<T> {
   private observers = new Set<(value: T) => void>();
   private currentValue: T;
@@ -324,17 +320,17 @@ function useObservable<T>(observable$: Observable<T>): T {
   const [value, setValue] = useState<T>(() => observable$.getValue());
 
   useEffect(() => {
-    // 値が変わっている可能性があるので同期
+    // Sync in case the value has changed
     setValue(observable$.getValue());
 
     const subscription = observable$.subscribe(setValue);
-    return () => subscription.unsubscribe(); // クリーンアップ
+    return () => subscription.unsubscribe(); // Cleanup
   }, [observable$]);
 
   return value;
 }
 
-// 複数の Observable を組み合わせる Hook
+// Hook for combining multiple Observables
 function useCombinedObservable<T extends Record<string, Observable<any>>>(
   observables: T
 ): { [K in keyof T]: T[K] extends Observable<infer U> ? U : never } {
@@ -359,8 +355,8 @@ function useCombinedObservable<T extends Record<string, Observable<any>>>(
   return values;
 }
 
-// --- 使用例 ---
-// グローバルな Observable ストア
+// --- Usage example ---
+// Global Observable store
 const priceStore = new SimpleObservable<number>(100);
 const statusStore = new SimpleObservable<string>("idle");
 
@@ -376,14 +372,14 @@ function StockPrice({ symbol }: { symbol: string }) {
   );
 }
 
-// 外部から値を更新
-priceStore.next(105); // 全ての購読コンポーネントが自動再描画
+// Update value from outside
+priceStore.next(105); // All subscribed components automatically re-render
 ```
 
-### コード例 3: Node.js EventEmitter ── ドメインイベント
+### Code Example 3: Node.js EventEmitter — Domain Events
 
 ```typescript
-// order-service.ts — Node.js EventEmitter を使ったドメインイベント
+// order-service.ts — Domain events using Node.js EventEmitter
 import { EventEmitter } from "events";
 
 interface Order {
@@ -394,7 +390,7 @@ interface Order {
   status: string;
 }
 
-// ドメインサービス: 注文処理
+// Domain service: order processing
 class OrderService extends EventEmitter {
   private orders = new Map<string, Order>();
 
@@ -409,7 +405,7 @@ class OrderService extends EventEmitter {
 
     this.orders.set(order.id, order);
 
-    // ドメインイベントを発行（OrderService は後続処理を知らない）
+    // Emit domain event (OrderService does not know about downstream processes)
     this.emit("orderPlaced", order);
     return order;
   }
@@ -423,34 +419,34 @@ class OrderService extends EventEmitter {
   }
 }
 
-// --- Observer の登録（アプリケーション起動時） ---
+// --- Register Observers (at application startup) ---
 const orderService = new OrderService();
 
-// メール送信
+// Send email
 orderService.on("orderPlaced", (order: Order) => {
   console.log(`[Email] Sending confirmation for order ${order.id}`);
   // emailService.sendConfirmation(order);
 });
 
-// 在庫管理
+// Inventory management
 orderService.on("orderPlaced", (order: Order) => {
   console.log(`[Inventory] Decrementing stock for ${order.items.length} items`);
   // order.items.forEach(item => inventoryService.decrement(item.productId, item.quantity));
 });
 
-// 分析
+// Analytics
 orderService.on("orderPlaced", (order: Order) => {
   console.log(`[Analytics] Recording purchase: $${order.total}`);
   // analyticsService.trackPurchase(order);
 });
 
-// キャンセル時のハンドラ
+// Handler for cancellations
 orderService.on("orderCancelled", (order: Order) => {
   console.log(`[Email] Sending cancellation notice for ${order.id}`);
   console.log(`[Inventory] Restoring stock for ${order.items.length} items`);
 });
 
-// --- 使用例 ---
+// --- Usage example ---
 orderService.placeOrder("user-1", [
   { productId: "p-1", quantity: 2, price: 1000 },
   { productId: "p-2", quantity: 1, price: 3000 },
@@ -460,10 +456,10 @@ orderService.placeOrder("user-1", [
 // [Analytics] Recording purchase: $5000
 ```
 
-### コード例 4: Python ── Observer with WeakRef
+### Code Example 4: Python — Observer with WeakRef
 
 ```python
-# event_bus.py — WeakRef でメモリリークを防ぐ Observer パターン
+# event_bus.py — Observer pattern using WeakRef to prevent memory leaks
 from __future__ import annotations
 import weakref
 from typing import Any, Callable, Dict, List, Optional
@@ -473,7 +469,7 @@ from datetime import datetime
 
 @dataclass
 class Event:
-    """イベントの基底クラス"""
+    """Base class for events"""
     timestamp: datetime
     source: str
 
@@ -493,7 +489,7 @@ class OrderPlacedEvent(Event):
 
 
 class EventBus:
-    """WeakRef 対応の EventBus"""
+    """WeakRef-compatible EventBus"""
 
     def __init__(self) -> None:
         self._subscribers: Dict[str, List[weakref.ref]] = {}
@@ -501,19 +497,19 @@ class EventBus:
 
     def subscribe(self, event_type: str, handler: Callable) -> Callable[[], None]:
         """
-        イベントを購読する。
-        handler がメソッドの場合は WeakRef で保持し、
-        GC 時に自動的に解除される。
+        Subscribe to an event.
+        If handler is a method, held via WeakRef
+        and automatically deregistered when GC'd.
         """
         if hasattr(handler, '__self__'):
-            # バウンドメソッドの場合: WeakRef で保持
+            # Bound method: hold via WeakRef
             if event_type not in self._subscribers:
                 self._subscribers[event_type] = []
             ref = weakref.ref(handler.__self__)
             method_name = handler.__func__.__name__
             self._subscribers[event_type].append(ref)
         else:
-            # 通常の関数の場合
+            # Regular function
             if event_type not in self._function_subscribers:
                 self._function_subscribers[event_type] = []
             self._function_subscribers[event_type].append(handler)
@@ -528,25 +524,25 @@ class EventBus:
         return unsubscribe
 
     def publish(self, event_type: str, data: Any = None) -> None:
-        """イベントを発行する"""
-        # 通常の関数ハンドラ
+        """Emit an event"""
+        # Regular function handlers
         for handler in self._function_subscribers.get(event_type, []):
             handler(data)
 
-        # WeakRef ハンドラ（GC 済みのものを除去）
+        # WeakRef handlers (remove GC'd ones)
         if event_type in self._subscribers:
             alive_refs = []
             for ref in self._subscribers[event_type]:
                 obj = ref()
                 if obj is not None:
                     alive_refs.append(ref)
-                    # handle メソッドを呼び出す
+                    # Call the handle method
                     if hasattr(obj, 'handle_event'):
                         obj.handle_event(event_type, data)
             self._subscribers[event_type] = alive_refs
 
 
-# --- 使用例 ---
+# --- Usage example ---
 bus = EventBus()
 
 
@@ -565,7 +561,7 @@ bus.publish("user.created", UserCreatedEvent(
 ))
 # [Handler] Welcome email sent to taro@example.com
 
-unsub()  # 購読解除
+unsub()  # Unsubscribe
 
 bus.publish("user.created", UserCreatedEvent(
     timestamp=datetime.now(),
@@ -574,21 +570,21 @@ bus.publish("user.created", UserCreatedEvent(
     name="Hanako",
     email="hanako@example.com",
 ))
-# (何も出力されない)
+# (no output)
 ```
 
-### コード例 5: 非同期 Observer（Promise ベース）
+### Code Example 5: Async Observer (Promise-based)
 
 ```typescript
-// async-event-emitter.ts — 非同期 Observer の実装
+// async-event-emitter.ts — Async Observer implementation
 type AsyncHandler<T> = (data: T) => Promise<void> | void;
 
 interface EmitOptions {
-  /** 並列実行か順次実行か */
+  /** Parallel or sequential execution */
   mode: 'parallel' | 'sequential';
-  /** タイムアウト（ms） */
+  /** Timeout (ms) */
   timeout?: number;
-  /** エラー時に他のハンドラを継続するか */
+  /** Whether to continue other handlers on error */
   continueOnError?: boolean;
 }
 
@@ -604,8 +600,8 @@ class AsyncEventEmitter<T extends Record<string, any>> {
   }
 
   /**
-   * 並列実行: 全ハンドラを同時に実行
-   * 順序保証は不要だがスループットを最大化したい場合に使用
+   * Parallel execution: run all handlers simultaneously
+   * Use when order is not required but throughput should be maximized
    */
   async emitParallel<K extends keyof T>(
     event: K,
@@ -648,8 +644,8 @@ class AsyncEventEmitter<T extends Record<string, any>> {
   }
 
   /**
-   * 順次実行: ハンドラを登録順に1つずつ実行
-   * 順序保証が必要な場合に使用
+   * Sequential execution: run handlers one by one in registration order
+   * Use when order must be guaranteed
    */
   async emitSequential<K extends keyof T>(
     event: K,
@@ -664,7 +660,7 @@ class AsyncEventEmitter<T extends Record<string, any>> {
   }
 }
 
-// --- 使用例 ---
+// --- Usage example ---
 type AppEvents = {
   orderPlaced: { orderId: string; total: number };
   paymentProcessed: { orderId: string; amount: number };
@@ -682,7 +678,7 @@ emitter.on("orderPlaced", async (order) => {
   console.log(`[Inventory] Updated for ${order.orderId}`);
 });
 
-// 並列実行: 全ハンドラが同時に開始、最も遅いもので完了
+// Parallel execution: all handlers start simultaneously, completes when the slowest finishes
 const result = await emitter.emitParallel(
   "orderPlaced",
   { orderId: "ORD-1", total: 5000 },
@@ -690,14 +686,14 @@ const result = await emitter.emitParallel(
 );
 console.log(`Success: ${result.successes}, Errors: ${result.errors.length}`);
 
-// 順次実行: Email -> Inventory の順番で実行
+// Sequential execution: runs in order Email -> Inventory
 await emitter.emitSequential("orderPlaced", { orderId: "ORD-2", total: 3000 });
 ```
 
-### コード例 6: AbortController 統合 ── 安全な購読管理
+### Code Example 6: AbortController Integration — Safe Subscription Management
 
 ```typescript
-// abort-event-emitter.ts — AbortController で一括解除
+// abort-event-emitter.ts — Bulk deregistration via AbortController
 class ManagedEventEmitter<T extends Record<string, any>> {
   private listeners = new Map<keyof T, Set<Function>>();
 
@@ -715,7 +711,7 @@ class ManagedEventEmitter<T extends Record<string, any>> {
       this.listeners.get(event)?.delete(handler);
     };
 
-    // AbortSignal と連携: signal が abort されたら自動解除
+    // Integrate with AbortSignal: auto-deregister when signal is aborted
     if (signal) {
       signal.addEventListener('abort', unsubscribe, { once: true });
     }
@@ -728,12 +724,12 @@ class ManagedEventEmitter<T extends Record<string, any>> {
   }
 }
 
-// --- 使用例: コンポーネントのライフサイクルで一括管理 ---
+// --- Usage example: bulk management via component lifecycle ---
 class DashboardComponent {
   private abortController = new AbortController();
 
   constructor(private emitter: ManagedEventEmitter<AppEvents>) {
-    // AbortController の signal を渡す
+    // Pass the AbortController's signal
     const signal = this.abortController.signal;
 
     emitter.on("orderPlaced", (order) => {
@@ -746,7 +742,7 @@ class DashboardComponent {
   }
 
   destroy(): void {
-    // 全ての購読を一括解除
+    // Deregister all subscriptions at once
     this.abortController.abort();
     console.log("Dashboard: All subscriptions removed");
   }
@@ -762,13 +758,13 @@ dashboard.destroy();
 // Dashboard: All subscriptions removed
 
 emitter.emit("orderPlaced", { orderId: "2", total: 200 });
-// (何も出力されない — 全て解除済み)
+// (no output — all subscriptions removed)
 ```
 
-### コード例 7: Reactive Store（Redux 風 Observer）
+### Code Example 7: Reactive Store (Redux-style Observer)
 
 ```typescript
-// reactive-store.ts — Observer パターンで状態管理
+// reactive-store.ts — State management with Observer pattern
 type Reducer<S, A> = (state: S, action: A) => S;
 type Listener = () => void;
 type Middleware<S, A> = (store: Store<S, A>) =>
@@ -788,13 +784,13 @@ class Store<S, A extends { type: string }> {
     this.reducer = reducer;
     this.state = initialState;
 
-    // ミドルウェアチェーンの構築
+    // Build middleware chain
     let dispatch = (action: A) => {
       this.state = this.reducer(this.state, action);
-      this.listeners.forEach(listener => listener()); // 全 Observer に通知
+      this.listeners.forEach(listener => listener()); // Notify all Observers
     };
 
-    // ミドルウェアを逆順に適用
+    // Apply middlewares in reverse order
     for (let i = middlewares.length - 1; i >= 0; i--) {
       dispatch = middlewaresi(dispatch);
     }
@@ -816,7 +812,7 @@ class Store<S, A extends { type: string }> {
   }
 }
 
-// --- 使用例: カウンターストア ---
+// --- Usage example: counter store ---
 type CounterState = { count: number; history: number[] };
 type CounterAction =
   | { type: 'INCREMENT'; amount: number }
@@ -842,7 +838,7 @@ const counterReducer: Reducer<CounterState, CounterAction> = (state, action) => 
   }
 };
 
-// ロギングミドルウェア
+// Logging middleware
 const logger: Middleware<CounterState, CounterAction> =
   (store) => (next) => (action) => {
     console.log(`[Logger] Action: ${action.type}, Before: ${store.getState().count}`);
@@ -852,7 +848,7 @@ const logger: Middleware<CounterState, CounterAction> =
 
 const store = new Store(counterReducer, { count: 0, history: [0] }, [logger]);
 
-// Observer (購読者) の登録
+// Register Observer (subscriber)
 const unsub = store.subscribe(() => {
   console.log(`[UI] Count changed to: ${store.getState().count}`);
 });
@@ -867,12 +863,12 @@ store.send({ type: 'DECREMENT', amount: 2 });
 // [UI] Count changed to: 3
 // [Logger] After: 3
 
-unsub(); // UI の購読解除
+unsub(); // Unsubscribe UI
 
 store.send({ type: 'RESET' });
 // [Logger] Action: RESET, Before: 3
 // [Logger] After: 0
-// (UI には通知されない)
+// (UI is not notified)
 ```
 
 ---
@@ -880,99 +876,99 @@ store.send({ type: 'RESET' });
 ## 5. Observer vs Pub/Sub vs Reactive Streams
 
 ```
-Observer パターン（直接参照）
+Observer Pattern (direct reference)
   Subject <--------- Observer
     |  notify()  -->  |
     +---------------->+
-  特徴: Subject と Observer が互いを知る
-  用途: 単純な通知、UIバインディング
+  Characteristic: Subject and Observer know each other
+  Use case: simple notifications, UI binding
 
-Pub/Sub パターン（仲介者あり）
+Pub/Sub Pattern (with mediator)
   Publisher --> EventBus/Broker --> Subscriber
     publish()       |           subscribe()
                     |
-  特徴: 完全に疎結合（互いを知らない）
-  用途: マイクロサービス間通信、分散システム
+  Characteristic: Fully decoupled (neither knows the other)
+  Use case: inter-microservice communication, distributed systems
 
-Reactive Streams（ストリーム処理）
+Reactive Streams (stream processing)
   Observable --pipe(operators)--> Observer
     |                                |
     + map, filter, debounce,         + subscribe
       merge, switchMap etc.
-  特徴: オペレータによるデータ変換パイプライン
-  用途: 複雑なイベント処理、リアルタイムストリーム
+  Characteristic: Data transformation pipeline via operators
+  Use case: complex event processing, real-time streams
 ```
 
 ---
 
-## 6. 比較表
+## 6. Comparison Tables
 
-### 比較表 1: Observer vs Pub/Sub vs Reactive Streams
+### Comparison Table 1: Observer vs Pub/Sub vs Reactive Streams
 
-| 観点 | Observer | Pub/Sub | Reactive (RxJS) |
+| Aspect | Observer | Pub/Sub | Reactive (RxJS) |
 |------|:---:|:---:|:---:|
-| 結合度 | 中（Subject を知る） | 低（Bus 経由） | 低（ストリーム） |
-| 非同期対応 | 手動 | 手動/組み込み | 組み込み |
-| バックプレッシャー | なし | なし | あり |
-| オペレータ | なし | なし | 豊富（200+） |
-| エラーハンドリング | 手動 | 手動 | 組み込み |
-| メモリ管理 | 手動解除 | 手動解除 | 自動（complete） |
-| 適用規模 | 小〜中 | 中〜大 | 中〜大 |
-| 使用場面 | シンプルな通知 | マイクロサービス | ストリーム処理 |
+| Coupling | Medium (knows Subject) | Low (via Bus) | Low (stream) |
+| Async support | Manual | Manual/Built-in | Built-in |
+| Backpressure | None | None | Available |
+| Operators | None | None | Rich (200+) |
+| Error handling | Manual | Manual | Built-in |
+| Memory management | Manual unsubscribe | Manual unsubscribe | Automatic (complete) |
+| Scale | Small to medium | Medium to large | Medium to large |
+| Use case | Simple notifications | Microservices | Stream processing |
 
-### 比較表 2: 同期 vs 非同期通知
+### Comparison Table 2: Synchronous vs Asynchronous Notification
 
-| 観点 | 同期通知 | 非同期通知（並列） | 非同期通知（順次） |
+| Aspect | Sync Notification | Async (Parallel) | Async (Sequential) |
 |------|:---:|:---:|:---:|
-| 実装難易度 | 低い | 中 | 中 |
-| エラーハンドリング | 容易（try/catch） | 要設計（Promise.allSettled） | 容易（for await） |
-| パフォーマンス | ブロッキング | 高スループット | 中 |
-| 順序保証 | 自然に保証 | なし | あり |
-| デバッグ | 容易 | 困難 | 中 |
-| タイムアウト | 不要 | 推奨 | 推奨 |
+| Implementation complexity | Low | Medium | Medium |
+| Error handling | Easy (try/catch) | Requires design (Promise.allSettled) | Easy (for await) |
+| Performance | Blocking | High throughput | Medium |
+| Order guarantee | Naturally guaranteed | None | Available |
+| Debugging | Easy | Difficult | Medium |
+| Timeout | Not needed | Recommended | Recommended |
 
-### 比較表 3: フレームワークの Observer 実装
+### Comparison Table 3: Observer Implementations in Frameworks
 
-| フレームワーク | メカニズム | 購読解除 | 型安全性 |
+| Framework | Mechanism | Unsubscribe | Type Safety |
 |--------------|----------|---------|---------|
-| Node.js EventEmitter | on/emit | removeListener | 低い |
-| DOM EventTarget | addEventListener | removeEventListener | 中 |
-| React (useState) | setState + 再描画 | 自動 | 高い |
-| Vue (Reactive) | Proxy ベース | 自動 | 高い |
-| RxJS | Observable.subscribe | unsubscribe | 高い |
-| Redux | store.subscribe | 返り値の関数 | 高い |
-| Angular (Signals) | signal/effect | 自動 | 高い |
+| Node.js EventEmitter | on/emit | removeListener | Low |
+| DOM EventTarget | addEventListener | removeEventListener | Medium |
+| React (useState) | setState + re-render | Automatic | High |
+| Vue (Reactive) | Proxy-based | Automatic | High |
+| RxJS | Observable.subscribe | unsubscribe | High |
+| Redux | store.subscribe | Return value function | High |
+| Angular (Signals) | signal/effect | Automatic | High |
 
 ---
 
-## 7. アンチパターン
+## 7. Anti-Patterns
 
-### アンチパターン 1: メモリリーク（購読解除忘れ）
+### Anti-Pattern 1: Memory Leak (Forgetting to Unsubscribe)
 
 ```typescript
-// NG: コンポーネント破棄後もリスナーが残る
+// BAD: listener remains after component is destroyed
 class BadComponent {
   constructor(private emitter: EventEmitter) {
-    // 登録はするが、解除しない！
+    // Registers but does not unsubscribe!
     emitter.on("data", this.handleData);
   }
 
   handleData = (data: any) => {
-    this.element.textContent = data; // 破棄済みの要素にアクセス → エラー
+    this.element.textContent = data; // Accessing a destroyed element -> error
   };
 
   destroy(): void {
-    // handleData の解除を忘れている
+    // Forgot to unsubscribe handleData
     this.element.remove();
   }
 }
 
-// OK: 確実に購読解除する（複数の方法）
+// GOOD: reliably unsubscribe (multiple approaches)
 class GoodComponent {
   private unsubscribers: (() => void)[] = [];
 
   constructor(private emitter: TypedEventEmitter<AppEvents>) {
-    // 方法1: unsubscribe 関数を保持
+    // Method 1: retain unsubscribe functions
     this.unsubscribers.push(
       emitter.on("orderPlaced", this.handleOrder)
     );
@@ -985,22 +981,22 @@ class GoodComponent {
   handlePayment = (payment: any) => { /* ... */ };
 
   destroy(): void {
-    // 全ての購読を一括解除
+    // Deregister all subscriptions at once
     this.unsubscribers.forEach(unsub => unsub());
     this.unsubscribers = [];
     this.element.remove();
   }
 }
 
-// OK: React での正しいクリーンアップ
+// GOOD: correct cleanup in React
 function GoodReactComponent() {
   useEffect(() => {
     const unsub = emitter.on("data", handleData);
-    return () => unsub(); // useEffect のクリーンアップで確実に解除
+    return () => unsub(); // Reliably unsubscribed in useEffect cleanup
   }, []);
 }
 
-// OK: AbortController による一括管理
+// GOOD: bulk management via AbortController
 class BetterComponent {
   private controller = new AbortController();
 
@@ -1014,15 +1010,15 @@ class BetterComponent {
   handlePayment = (payment: any) => { /* ... */ };
 
   destroy(): void {
-    this.controller.abort(); // 全購読を一括解除
+    this.controller.abort(); // Deregister all subscriptions at once
   }
 }
 ```
 
-### アンチパターン 2: イベントの連鎖による無限ループ
+### Anti-Pattern 2: Infinite Loop from Event Chains
 
 ```typescript
-// NG: A の変更が B に通知 -> B の変更が A に通知 -> ...
+// BAD: change to A notifies B -> change to B notifies A -> ...
 const emitter = new TypedEventEmitter<{
   priceChanged: { price: number };
   taxChanged: { tax: number };
@@ -1030,19 +1026,19 @@ const emitter = new TypedEventEmitter<{
 
 emitter.on("priceChanged", ({ price }) => {
   const newTax = price * 0.1;
-  emitter.emit("taxChanged", { tax: newTax }); // taxChanged を発行
+  emitter.emit("taxChanged", { tax: newTax }); // emits taxChanged
 });
 
 emitter.on("taxChanged", ({ tax }) => {
   const newPrice = tax / 0.1;
-  emitter.emit("priceChanged", { price: newPrice }); // priceChanged を再発行！
-  // -> 無限ループ
+  emitter.emit("priceChanged", { price: newPrice }); // re-emits priceChanged!
+  // -> infinite loop
 });
 
-// OK: 循環検出ガード付き EventEmitter
+// GOOD: EventEmitter with circular detection guard
 class SafeEventEmitter<T extends Record<string, any>> {
   private listeners = new Map<keyof T, Set<Function>>();
-  private emitting = new Set<keyof T>(); // 現在発行中のイベント
+  private emitting = new Set<keyof T>(); // currently emitting events
 
   on<K extends keyof T>(event: K, handler: (data: T[K]) => void): () => void {
     if (!this.listeners.has(event)) {
@@ -1055,7 +1051,7 @@ class SafeEventEmitter<T extends Record<string, any>> {
   emit<K extends keyof T>(event: K, data: T[K]): void {
     if (this.emitting.has(event)) {
       console.warn(`[SafeEmitter] Circular emit detected for "${String(event)}". Skipping.`);
-      return; // 循環を防止
+      return; // Prevent circular emission
     }
 
     this.emitting.add(event);
@@ -1068,10 +1064,10 @@ class SafeEventEmitter<T extends Record<string, any>> {
 }
 ```
 
-### アンチパターン 3: God Observer（1つの Observer が全てを処理）
+### Anti-Pattern 3: God Observer (One Observer Handles Everything)
 
 ```typescript
-// NG: 1つの巨大な handler が全イベントを処理
+// BAD: one massive handler processes all events
 class GodObserver {
   handle(eventType: string, data: any): void {
     switch (eventType) {
@@ -1085,12 +1081,12 @@ class GodObserver {
         this.updateInventory(data);
         this.processPayment(data);
         break;
-      // ... 数十のイベントタイプ
+      // ... dozens of event types
     }
   }
 }
 
-// OK: 責務ごとに Observer を分離
+// GOOD: separate Observers by responsibility
 class EmailObserver {
   constructor(private emitter: EventEmitter) {
     emitter.on("userCreated", this.sendWelcome);
@@ -1098,9 +1094,9 @@ class EmailObserver {
     emitter.on("orderCancelled", this.sendCancellation);
   }
 
-  private sendWelcome = (data: any) => { /* メール送信のみ */ };
-  private sendConfirmation = (data: any) => { /* メール送信のみ */ };
-  private sendCancellation = (data: any) => { /* メール送信のみ */ };
+  private sendWelcome = (data: any) => { /* email sending only */ };
+  private sendConfirmation = (data: any) => { /* email sending only */ };
+  private sendCancellation = (data: any) => { /* email sending only */ };
 }
 
 class InventoryObserver {
@@ -1109,21 +1105,21 @@ class InventoryObserver {
     emitter.on("orderCancelled", this.restoreStock);
   }
 
-  private decrementStock = (data: any) => { /* 在庫管理のみ */ };
-  private restoreStock = (data: any) => { /* 在庫管理のみ */ };
+  private decrementStock = (data: any) => { /* inventory management only */ };
+  private restoreStock = (data: any) => { /* inventory management only */ };
 }
 ```
 
 ---
 
-## 8. 実世界での Observer パターン
+## 8. Observer Pattern in the Real World
 
-### 8.1 ブラウザ DOM イベント
+### 8.1 Browser DOM Events
 
 ```
-DOM のイベント伝搬（Observer パターンの実装）:
+DOM event propagation (Observer pattern implementation):
 
-     [window]          Capture Phase（上→下）
+     [window]          Capture Phase (top to bottom)
         |
      [document]
         |
@@ -1135,40 +1131,40 @@ DOM のイベント伝搬（Observer パターンの実装）:
         |
      [div.parent]
         |
-     [body]            Bubble Phase（下→上）
+     [body]            Bubble Phase (bottom to top)
         |
      [document]
         |
      [window]
 
 addEventListener(event, handler, { capture: true/false })
-  capture: true  → Capture Phase で実行
-  capture: false → Bubble Phase で実行（デフォルト）
+  capture: true  → executes in Capture Phase
+  capture: false → executes in Bubble Phase (default)
 ```
 
-### 8.2 React のリアクティブシステム
+### 8.2 React's Reactive System
 
 ```
-React の状態更新フロー:
+React state update flow:
 
   setState(newValue)
       |
       v
-  [Reconciler] -- 差分計算 (Virtual DOM diff)
+  [Reconciler] -- diff calculation (Virtual DOM diff)
       |
       v
-  [Commit Phase] -- DOM 更新
+  [Commit Phase] -- DOM update
       |
       v
   useEffect cleanup  → useEffect callback
-  (前の副作用のクリーン)   (新しい副作用の実行)
+  (clean previous side effects)   (execute new side effects)
 
-  本質: useState は Observer パターン
+  Essence: useState is the Observer pattern
   - setState = Subject.notify()
-  - コンポーネントの再描画 = Observer.update()
+  - Component re-render = Observer.update()
 ```
 
-### 8.3 マイクロサービスの Event-Driven Architecture
+### 8.3 Event-Driven Architecture in Microservices
 
 ```
 Event-Driven Architecture:
@@ -1180,28 +1176,28 @@ Event-Driven Architecture:
   Analytics Service   <--- subscribe("order.*") ----+
   Payment Service     <--- subscribe("order.created")+
 
-  メリット:
-  - サービス間の完全な疎結合
-  - 独立したデプロイとスケーリング
-  - 障害の伝搬を防止
-  - イベントの永続化と再生が可能
+  Benefits:
+  - Complete loose coupling between services
+  - Independent deployment and scaling
+  - Prevents fault propagation
+  - Events can be persisted and replayed
 ```
 
 ---
 
-## 9. 実践演習
+## 9. Practical Exercises
 
-### 演習 1: 基礎 ── 型安全な EventEmitter の実装
+### Exercise 1: Basic — Implement a Type-Safe EventEmitter
 
-**課題**: 以下の要件を満たす型安全な EventEmitter を実装せよ。
+**Task**: Implement a type-safe EventEmitter that satisfies the following requirements.
 
-1. `on(event, handler)`: イベントを購読し、購読解除関数を返す
-2. `once(event, handler)`: 1回だけ購読する
-3. `emit(event, data)`: イベントを発行する
-4. `listenerCount(event)`: リスナー数を返す
-5. イベント名とデータ型がジェネリクスで型安全に連携する
+1. `on(event, handler)`: subscribes to an event and returns an unsubscribe function
+2. `once(event, handler)`: subscribes only once
+3. `emit(event, data)`: emits an event
+4. `listenerCount(event)`: returns the number of listeners
+5. Event names and data types are linked type-safely via generics
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 type Events = {
@@ -1228,16 +1224,16 @@ console.log(emitter.listenerCount("error"));   // 1
 emitter.emit("error", { code: 404, message: "Not Found" });
 // "Error 404: Not Found"
 
-console.log(emitter.listenerCount("error"));   // 0 (once は消費済み)
+console.log(emitter.listenerCount("error"));   // 0 (once has been consumed)
 
 unsub();
 console.log(emitter.listenerCount("message")); // 0
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As indicated in the comments above.
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
 class TypedEventEmitter<T extends Record<string, any>> {
@@ -1291,27 +1287,27 @@ class TypedEventEmitter<T extends Record<string, any>> {
 }
 ```
 
-**設計ポイント:**
-- `on` と `once` を別の Map で管理し、`once` は emit 時に clear する
-- 各メソッドが unsubscribe 関数を返すことで、クリーンアップを容易にする
-- `listenerCount` は両方の Map のサイズを合算する
+**Design Points:**
+- Manage `on` and `once` in separate Maps; `once` is cleared on emit
+- Each method returns an unsubscribe function, making cleanup easy
+- `listenerCount` sums the sizes of both Maps
 
 </details>
 
 ---
 
-### 演習 2: 応用 ── リアクティブ Store の実装
+### Exercise 2: Applied — Implement a Reactive Store
 
-**課題**: Redux 風のリアクティブ Store を Observer パターンで実装せよ。
+**Task**: Implement a Redux-style reactive Store using the Observer pattern.
 
-要件:
-1. `Store<S, A>` クラス: Reducer で状態を管理
-2. `getState()`: 現在の状態を取得
-3. `dispatch(action)`: アクションを発行し、全 Observer に通知
-4. `subscribe(listener)`: 状態変更を購読
-5. `select(selector)`: 状態の一部だけを監視し、変更時のみ通知
+Requirements:
+1. `Store<S, A>` class: manages state with a Reducer
+2. `getState()`: returns current state
+3. `dispatch(action)`: dispatches an action and notifies all Observers
+4. `subscribe(listener)`: subscribes to state changes
+5. `select(selector)`: watches only part of the state and notifies only on changes
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 type State = { count: number; name: string };
@@ -1330,14 +1326,14 @@ const store = new Store<State, Action>(
   { count: 0, name: "initial" }
 );
 
-// count だけを監視
+// Watch only count
 const unsubCount = store.select(
   s => s.count,
   (count) => console.log(`Count: ${count}`)
 );
 
 store.dispatch({ type: 'SET_NAME', name: 'Taro' });
-// (count は変わっていないので何も出力されない)
+// (count has not changed, so no output)
 
 store.dispatch({ type: 'INCREMENT' });
 // "Count: 1"
@@ -1345,10 +1341,10 @@ store.dispatch({ type: 'INCREMENT' });
 unsubCount();
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As indicated in the comments above.
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
 type Reducer<S, A> = (state: S, action: A) => S;
@@ -1380,8 +1376,8 @@ class Store<S, A extends { type: string }> {
   }
 
   /**
-   * 状態の一部を監視し、変更時のみコールバックを呼ぶ
-   * 前回の選択結果と比較して変更があった場合のみ通知する
+   * Watch part of the state and call callback only when it changes.
+   * Notifies only when the result differs from the previous selected value.
    */
   select<R>(selector: Selector<S, R>, callback: (value: R) => void): () => void {
     let previousValue = selector(this.state);
@@ -1397,27 +1393,27 @@ class Store<S, A extends { type: string }> {
 }
 ```
 
-**設計ポイント:**
-- `select` は内部で `subscribe` を利用し、セレクタの結果が変わった場合のみコールバックを呼ぶ
-- 前回値との比較には `!==`（参照等価性）を使い、プリミティブ値とオブジェクト参照の両方に対応
-- `dispatch` は Reducer で新しい状態を生成してから全 Observer に通知する
+**Design Points:**
+- `select` internally uses `subscribe` and calls the callback only when the selector result changes
+- Comparison with previous value uses `!==` (reference equality), handling both primitives and object references
+- `dispatch` generates new state via the Reducer, then notifies all Observers
 
 </details>
 
 ---
 
-### 演習 3: 発展 ── 非同期 Event Bus with Retry
+### Exercise 3: Advanced — Async Event Bus with Retry
 
-**課題**: 非同期ハンドラをサポートし、失敗時にリトライ機能を持つ EventBus を実装せよ。
+**Task**: Implement an EventBus that supports async handlers and has retry functionality on failure.
 
-要件:
-1. `on(event, handler)`: 非同期ハンドラを登録
-2. `emit(event, data, options)`: イベント発行（並列/順次を選択可能）
-3. リトライ: 失敗したハンドラを指数バックオフで最大3回リトライ
-4. Dead Letter Queue: 全リトライが失敗したイベントを記録
-5. タイムアウト: 各ハンドラに制限時間を設定
+Requirements:
+1. `on(event, handler)`: register an async handler
+2. `emit(event, data, options)`: emit an event (selectable parallel/sequential)
+3. Retry: retry failed handlers up to 3 times with exponential backoff
+4. Dead Letter Queue: record events that fail all retries
+5. Timeout: set a time limit for each handler
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 const bus = new ResilientEventBus();
@@ -1436,17 +1432,17 @@ await bus.emit("process", { id: "item-1" }, {
   retry: { maxAttempts: 3, backoffMs: 100 },
   timeoutMs: 5000,
 });
-// 1回目: 失敗 (100ms 待機)
-// 2回目: 失敗 (200ms 待機)
-// 3回目: "Processed: item-1"
+// 1st attempt: fails (wait 100ms)
+// 2nd attempt: fails (wait 200ms)
+// 3rd attempt: "Processed: item-1"
 
-console.log(bus.getDeadLetterQueue().length); // 0 (成功したため)
+console.log(bus.getDeadLetterQueue().length); // 0 (succeeded)
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As indicated in the comments above.
 
 <details>
-<summary>模範解答（クリックで展開）</summary>
+<summary>Reference Answer (click to expand)</summary>
 
 ```typescript
 type AsyncHandler<T> = (data: T) => Promise<void> | void;
@@ -1521,14 +1517,14 @@ class ResilientEventBus {
         } else {
           await promise;
         }
-        return; // 成功
+        return; // Success
       } catch (error) {
         if (attempt < maxAttempts) {
-          // 指数バックオフで待機
+          // Wait with exponential backoff
           const delay = backoffMs * Math.pow(2, attempt - 1);
           await new Promise(resolve => setTimeout(resolve, delay));
         } else {
-          // 全リトライ失敗 → Dead Letter Queue に記録
+          // All retries failed -> record in Dead Letter Queue
           this.deadLetterQueue.push({
             event,
             data,
@@ -1551,11 +1547,11 @@ class ResilientEventBus {
 }
 ```
 
-**設計ポイント:**
-- `executeWithRetry` で指数バックオフ（`backoffMs * 2^(attempt-1)`）を実装
-- タイムアウトは `Promise.race` でハンドラの Promise と競合させる
-- 全リトライが失敗したイベントは Dead Letter Queue に記録し、後から調査可能にする
-- `parallel` モードでは `Promise.allSettled` を使い、1つの失敗が他のハンドラに影響しないようにする
+**Design Points:**
+- `executeWithRetry` implements exponential backoff (`backoffMs * 2^(attempt-1)`)
+- Timeout races the handler's Promise against a timeout Promise using `Promise.race`
+- Events that fail all retries are recorded in the Dead Letter Queue for later investigation
+- In `parallel` mode, `Promise.allSettled` is used so one failure does not affect other handlers
 
 </details>
 
@@ -1563,73 +1559,73 @@ class ResilientEventBus {
 
 ## 10. FAQ
 
-### Q1: Observer パターンはどの言語/フレームワークで使われていますか？
+### Q1: In which languages/frameworks is the Observer pattern used?
 
-DOM の EventListener、Node.js の EventEmitter、Vue.js のリアクティブシステム、RxJS の Observable、Android の LiveData/Flow、React の useState/useEffect、Redux の store.subscribe、Angular の Signals、Swift の Combine フレームワークなど、ほぼ全てのUI/イベント駆動フレームワークで使われています。Observer パターンを知らずにモダンなフロントエンド/バックエンド開発を行うことは不可能です。
+It is used in virtually all UI/event-driven frameworks: DOM EventListener, Node.js EventEmitter, Vue.js reactive system, RxJS Observable, Android LiveData/Flow, React useState/useEffect, Redux store.subscribe, Angular Signals, Swift Combine framework, and more. It is impossible to do modern frontend/backend development without knowing the Observer pattern.
 
-### Q2: Observer が多すぎるとパフォーマンスに影響しますか？
+### Q2: Does having too many Observers affect performance?
 
-はい。通知が同期的な場合、Observer の数に比例してブロッキング時間が増えます。対策として: (1) 非同期通知に切り替える、(2) バッチ処理（React の自動バッチングのように複数の更新を1回にまとめる）、(3) デバウンス/スロットル（高頻度の通知を間引く）、(4) セレクタベースの購読（変更された部分のみ通知する）を検討してください。
+Yes. When notifications are synchronous, blocking time increases proportionally to the number of Observers. Countermeasures: (1) switch to asynchronous notifications, (2) batch processing (combining multiple updates into one, like React's automatic batching), (3) debounce/throttle (reducing high-frequency notifications), (4) selector-based subscriptions (notify only the parts that changed).
 
-### Q3: Redux と Observer パターンの関係は？
+### Q3: What is the relationship between Redux and the Observer pattern?
 
-Redux の `store.subscribe()` は Observer パターンそのものです。Action の dispatch で状態が変更され、購読しているコンポーネントに通知されます。React-Redux の `useSelector` は、セレクタの結果が変わった場合のみ再描画する最適化された Observer です。
+Redux's `store.subscribe()` is the Observer pattern itself. When an action is dispatched, the state changes and subscribed components are notified. React-Redux's `useSelector` is an optimized Observer that re-renders only when the selector result changes.
 
-### Q4: EventEmitter と Promise/async-await の使い分けは？
+### Q4: How do I decide between EventEmitter and Promise/async-await?
 
-一回限りの非同期操作（API呼び出し、ファイル読み込み）は Promise が適切です。繰り返し発生するイベント（クリック、メッセージ受信、状態変更）は EventEmitter が適切です。両方の特性が必要な場合は AsyncIterator や RxJS の Observable を検討してください。
+Promise is appropriate for one-time async operations (API calls, file reads). EventEmitter is appropriate for repeatedly occurring events (clicks, message reception, state changes). If you need characteristics of both, consider AsyncIterator or RxJS Observable.
 
-### Q5: WeakRef を使った Observer はいつ有効ですか？
+### Q5: When is a WeakRef-based Observer effective?
 
-WeakRef は Observer のライフサイクルが不明確な場合に有効です。例えば、プラグインシステムでプラグインが動的にロード/アンロードされる場合、WeakRef を使えばプラグインが GC された時点で自動的に購読が解除されます。ただし、GC のタイミングは不確定なため、明示的な購読解除が可能な場合はそちらを優先してください。
+WeakRef is effective when the Observer's lifecycle is unclear. For example, in a plugin system where plugins are dynamically loaded and unloaded, using WeakRef allows subscriptions to be automatically deregistered when the plugin is GC'd. However, since GC timing is non-deterministic, prefer explicit unsubscription when possible.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not just through theory, but by actually writing code and verifying behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the fundamental concepts explained in this guide before moving to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architectural design.
 
 ---
 
-## 11. まとめ
+## 11. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| 目的 | 1対多の状態変化通知。疎結合なイベント駆動設計 |
-| Push 型 | データを直接渡す（シンプル、データが小さい場合に最適） |
-| Pull 型 | Observer が取りに行く（柔軟、Observer ごとに必要なデータが異なる場合） |
-| 購読解除 | メモリリーク防止のため**必須**。AbortController で一括管理が便利 |
-| 非同期通知 | 並列（高スループット）と順次（順序保証）を使い分ける |
-| 循環防止 | emitting ガードで同一イベントの再帰発行を防止 |
-| 進化系 | Pub/Sub（完全疎結合）、Reactive Streams（オペレータ付き） |
+| Purpose | One-to-many state change notification. Loosely coupled event-driven design |
+| Push | Passes data directly (simple, optimal when data is small) |
+| Pull | Observer fetches data (flexible, when each Observer needs different data) |
+| Unsubscribe | **Essential** to prevent memory leaks. AbortController is convenient for bulk management |
+| Async notifications | Choose between parallel (high throughput) and sequential (order guaranteed) |
+| Preventing circular calls | Use an emitting guard to prevent recursive emission of the same event |
+| Evolution | Pub/Sub (fully decoupled), Reactive Streams (with operators) |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [Strategy パターン](./01-strategy.md) -- アルゴリズムの交換
-- [Command パターン](./02-command.md) -- 操作のカプセル化と Undo/Redo
-- [State パターン](./03-state.md) -- 状態遷移の管理
-- [イベント駆動アーキテクチャ](../../../system-design-guide/docs/02-architecture/03-event-driven.md) -- マイクロサービスでの Observer
-- [モナドパターン](../03-functional/00-monad.md) -- Promise/async-await の理論的基盤
+- [Strategy Pattern](./01-strategy.md) -- Algorithm switching
+- [Command Pattern](./02-command.md) -- Encapsulating operations and Undo/Redo
+- [State Pattern](./03-state.md) -- Managing state transitions
+- [Event-Driven Architecture](../../../system-design-guide/docs/02-architecture/03-event-driven.md) -- Observer in microservices
+- [Monad Pattern](../03-functional/00-monad.md) -- Theoretical foundation of Promise/async-await
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Observer パターンの原典。
-2. ReactiveX Documentation. https://reactivex.io/ -- リアクティブプログラミングの包括的リファレンス。
-3. Node.js Events Documentation. https://nodejs.org/api/events.html -- Node.js の EventEmitter の公式ドキュメント。
-4. Redux Documentation. https://redux.js.org/ -- Observer パターンに基づく状態管理ライブラリ。
-5. MDN Web Docs -- EventTarget. https://developer.mozilla.org/en-US/docs/Web/API/EventTarget -- ブラウザのイベントシステム。
+1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- The original source of the Observer pattern.
+2. ReactiveX Documentation. https://reactivex.io/ -- Comprehensive reference for reactive programming.
+3. Node.js Events Documentation. https://nodejs.org/api/events.html -- Official documentation for Node.js EventEmitter.
+4. Redux Documentation. https://redux.js.org/ -- State management library based on the Observer pattern.
+5. MDN Web Docs -- EventTarget. https://developer.mozilla.org/en-US/docs/Web/API/EventTarget -- Browser event system.

--- a/03-software-design/design-patterns-guide/docs/02-behavioral/01-strategy.md
+++ b/03-software-design/design-patterns-guide/docs/02-behavioral/01-strategy.md
@@ -1,84 +1,80 @@
-# Strategy パターン
+# Strategy Pattern
 
-> アルゴリズムのファミリーを定義し、それぞれを **カプセル化** して交換可能にする振る舞いパターン。実行時にアルゴリズムを切り替えられ、条件分岐の爆発を防止してOpen/Closed Principle を遵守する。
-
----
-
-## この章で学ぶこと
-
-1. Strategy パターンの構造と、条件分岐の排除によるOCP準拠の設計手法を理解する
-2. DI（依存性注入）との関係、関数型アプローチでの実現方法、Registry パターンとの組み合わせを習得する
-3. Strategy の過剰適用を避ける判断基準と、Template Method/State パターンとの使い分けを身につける
+> A behavioral pattern that defines a family of algorithms, **encapsulates** each one, and makes them interchangeable. Algorithms can be switched at runtime, preventing conditional branch explosion and adhering to the Open/Closed Principle.
 
 ---
 
-## 前提知識
+## What You Will Learn
 
-このガイドを読む前に、以下の概念を理解しておくことを推奨します。
+1. Understand the structure of the Strategy pattern and how to design OCP-compliant systems by eliminating conditional branches
+2. Learn the relationship with DI (Dependency Injection), how to implement it with a functional approach, and how to combine it with the Registry pattern
+3. Develop judgment criteria to avoid over-applying Strategy, and learn when to use Template Method or State patterns instead
 
-| 前提知識 | 説明 | 参照リンク |
+---
+
+## Prerequisites
+
+Before reading this guide, it is recommended to understand the following concepts.
+
+| Prerequisite | Description | Reference |
 |---------|------|-----------|
-| SOLID 原則（特にOCP） | 拡張に開き、修正に閉じる原則 | [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) |
-| インタフェースとポリモーフィズム | 異なる実装を統一的に扱う概念 | [クリーンコード](../../../clean-code-principles/docs/00-principles/) |
-| 依存性注入（DI） | 外部から依存オブジェクトを注入する手法 | [DI/IoC](../../../clean-code-principles/docs/01-practices/) |
-| 関数（第一級オブジェクト） | 関数を値として扱い、引数や返り値にする概念 | [関数型パターン](../03-functional/02-fp-patterns.md) |
+| SOLID Principles (especially OCP) | The principle of being open for extension and closed for modification | [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) |
+| Interfaces and Polymorphism | The concept of treating different implementations uniformly | [Clean Code](../../../clean-code-principles/docs/00-principles/) |
+| Dependency Injection (DI) | The technique of injecting dependency objects from outside | [DI/IoC](../../../clean-code-principles/docs/01-practices/) |
+| Functions (First-Class Objects) | The concept of treating functions as values, passing them as arguments or return values | [Functional Patterns](../03-functional/02-fp-patterns.md) |
 
 ---
 
-## 1. Strategy パターンとは何か
+## 1. What Is the Strategy Pattern?
 
-### 1.1 解決する問題
+### 1.1 The Problem It Solves
 
-ソフトウェアでは、同じ種類の処理に複数のアルゴリズムが存在する場面が多い。
+In software, there are many situations where multiple algorithms exist for the same type of processing.
 
-- 料金計算: 通常/プレミアム/学生/シニア
-- ソート: 名前順/日付順/価格順/関連度順
-- 認証: パスワード/OAuth/SAML/APIキー
-- 圧縮: gzip/zstd/lz4/brotli
+- Pricing calculation: regular / premium / student / senior
+- Sorting: by name / by date / by price / by relevance
+- Authentication: password / OAuth / SAML / API key
+- Compression: gzip / zstd / lz4 / brotli
 
-これらを `if/else` や `switch` で分岐すると、アルゴリズムが増えるたびに条件分岐が肥大化し、既存コードの変更が必要になる（OCP 違反）。
+When these are branched with `if/else` or `switch`, the conditional logic bloats every time an algorithm is added, requiring changes to existing code (an OCP violation).
 
 ```
-BEFORE（条件分岐の肥大化）:
+BEFORE (bloated conditional branches):
 function calculate(type, price) {
   if (type === "regular") return price;
   else if (type === "premium") return price * 0.9;
   else if (type === "student") return price * 0.7;
   else if (type === "senior") return price * 0.8;
-  else if (type === "vip") return price * 0.6;    // 追加1
-  else if (type === "family") return price * 0.75; // 追加2
-  // ... 新しい種類のたびにこの関数を修正 -> OCP 違反
+  else if (type === "vip") return price * 0.6;    // addition 1
+  else if (type === "family") return price * 0.75; // addition 2
+  // ... this function must be modified for every new type -> OCP violation
 }
 
-AFTER（Strategy パターン）:
+AFTER (Strategy pattern):
 strategies.get(type).calculate(price);
-// 新しい型は register するだけ -> OCP 準拠
+// new types only need to be registered -> OCP compliant
 ```
 
-### 1.2 パターンの意図
+### 1.2 Intent of the Pattern
 
-GoF の定義:
+GoF definition:
 
 > Define a family of algorithms, encapsulate each one, and make them interchangeable. Strategy lets the algorithm vary independently from clients that use it.
 
-日本語訳:
+### 1.3 WHY: Why Is the Strategy Pattern Needed?
 
-> アルゴリズムのファミリーを定義し、それぞれをカプセル化して交換可能にする。Strategy パターンにより、アルゴリズムをクライアントから独立して変更できる。
+The fundamental reason is to **separate the selection of an algorithm from its execution**.
 
-### 1.3 WHY: なぜ Strategy パターンが必要なのか
-
-根本的な理由は **アルゴリズムの選択と実行を分離する** ことにある。
-
-1. **Open/Closed Principle**: 新しいアルゴリズムの追加が既存コードの変更なしに行える
-2. **Single Responsibility Principle**: 各アルゴリズムが独立したクラス/関数として存在し、個別にテスト可能
-3. **実行時の切り替え**: 同じ Context で異なるアルゴリズムを動的に切り替えられる
-4. **テスタビリティ**: Strategy をモック/スタブに差し替えることでテストが容易
+1. **Open/Closed Principle**: New algorithms can be added without modifying existing code
+2. **Single Responsibility Principle**: Each algorithm exists as an independent class/function and can be tested individually
+3. **Runtime switching**: Different algorithms can be dynamically switched within the same Context
+4. **Testability**: Tests become easy by replacing Strategy with mocks/stubs
 
 ---
 
-## 2. Strategy の構造
+## 2. Structure of Strategy
 
-### 2.1 クラス図
+### 2.1 Class Diagram
 
 ```
 +-------------+       +-------------------+
@@ -97,16 +93,16 @@ GoF の定義:
                +------------+  +------------+
 ```
 
-### 2.2 構成要素の役割
+### 2.2 Roles of Each Component
 
-| 構成要素 | 役割 | 責務 |
+| Component | Role | Responsibility |
 |---------|------|------|
-| Strategy (Interface) | アルゴリズムの共通契約 | メソッドシグネチャを定義 |
-| ConcreteStrategy | 具体的なアルゴリズム実装 | Strategy インタフェースに従って実装 |
-| Context | Strategy を使用する側 | Strategy の参照を保持し、委譲する |
-| Client | Context と Strategy を組み立て | 具体的な Strategy を Context に注入 |
+| Strategy (Interface) | Common contract for algorithms | Defines method signatures |
+| ConcreteStrategy | Concrete algorithm implementation | Implements according to the Strategy interface |
+| Context | The consumer of Strategy | Holds a reference to Strategy and delegates to it |
+| Client | Assembles Context and Strategy | Injects a concrete Strategy into Context |
 
-### 2.3 処理シーケンス
+### 2.3 Processing Sequence
 
 ```
 Client            Context              Strategy
@@ -129,12 +125,12 @@ Client            Context              Strategy
 
 ---
 
-## 3. コード例
+## 3. Code Examples
 
-### コード例 1: 料金計算 Strategy（TypeScript）
+### Code Example 1: Pricing Strategy (TypeScript)
 
 ```typescript
-// pricing-strategy.ts — Strategy パターンの基本形
+// pricing-strategy.ts — Basic form of the Strategy pattern
 interface PricingStrategy {
   readonly name: string;
   calculate(basePrice: number): number;
@@ -147,41 +143,41 @@ class RegularPricing implements PricingStrategy {
     return basePrice;
   }
   getDescription(): string {
-    return "通常価格（割引なし）";
+    return "Regular price (no discount)";
   }
 }
 
 class PremiumPricing implements PricingStrategy {
   readonly name = "premium";
   calculate(basePrice: number): number {
-    return Math.round(basePrice * 0.9); // 10%割引
+    return Math.round(basePrice * 0.9); // 10% discount
   }
   getDescription(): string {
-    return "プレミアム会員価格（10%OFF）";
+    return "Premium member price (10% OFF)";
   }
 }
 
 class StudentPricing implements PricingStrategy {
   readonly name = "student";
   calculate(basePrice: number): number {
-    return Math.round(basePrice * 0.7); // 30%割引
+    return Math.round(basePrice * 0.7); // 30% discount
   }
   getDescription(): string {
-    return "学生価格（30%OFF）";
+    return "Student price (30% OFF)";
   }
 }
 
 class SeniorPricing implements PricingStrategy {
   readonly name = "senior";
   calculate(basePrice: number): number {
-    return Math.round(basePrice * 0.8); // 20%割引
+    return Math.round(basePrice * 0.8); // 20% discount
   }
   getDescription(): string {
-    return "シニア価格（20%OFF）";
+    return "Senior price (20% OFF)";
   }
 }
 
-// Context: ショッピングカート
+// Context: Shopping cart
 class ShoppingCart {
   private items: { name: string; price: number; quantity: number }[] = [];
   private pricingStrategy: PricingStrategy;
@@ -211,7 +207,7 @@ class ShoppingCart {
   }
 }
 
-// --- 使用例: 実行時に戦略を切り替え ---
+// --- Usage: switch strategy at runtime ---
 const cart = new ShoppingCart();
 cart.addItem("TypeScript Book", 3000);
 cart.addItem("Design Patterns Book", 4000);
@@ -220,7 +216,7 @@ console.log(cart.checkout());
 // { subtotal: 7000, discount: 0, total: 7000, strategy: "regular" }
 
 cart.setPricingStrategy(new StudentPricing());
-// "Pricing changed to: 学生価格（30%OFF）"
+// "Pricing changed to: Student price (30% OFF)"
 
 console.log(cart.checkout());
 // { subtotal: 7000, discount: 2100, total: 4900, strategy: "student" }
@@ -230,10 +226,10 @@ console.log(cart.checkout());
 // { subtotal: 7000, discount: 700, total: 6300, strategy: "premium" }
 ```
 
-### コード例 2: 関数型 Strategy（TypeScript）
+### Code Example 2: Functional Strategy (TypeScript)
 
 ```typescript
-// functional-strategy.ts — クラスを使わず関数で Strategy を実現
+// functional-strategy.ts — Implementing Strategy with functions instead of classes
 interface User {
   name: string;
   age: number;
@@ -242,7 +238,7 @@ interface User {
   score: number;
 }
 
-// Strategy を関数型で定義
+// Define Strategy as a function type
 type SortStrategy<T> = (a: T, b: T) => number;
 
 const byName: SortStrategy<User> = (a, b) =>
@@ -257,7 +253,7 @@ const byCreatedDesc: SortStrategy<User> = (a, b) =>
 const byScore: SortStrategy<User> = (a, b) =>
   b.score - a.score;
 
-// 合成: 複数のソート条件を組み合わせる
+// Composition: combine multiple sort criteria
 function composeStrategies<T>(...strategies: SortStrategy<T>[]): SortStrategy<T> {
   return (a, b) => {
     for (const strategy of strategies) {
@@ -268,44 +264,44 @@ function composeStrategies<T>(...strategies: SortStrategy<T>[]): SortStrategy<T>
   };
 }
 
-// 反転: 降順にする
+// Reversal: sort in descending order
 function reverse<T>(strategy: SortStrategy<T>): SortStrategy<T> {
   return (a, b) => -strategy(a, b);
 }
 
-// Context 関数
+// Context function
 function sortUsers(users: User[], strategy: SortStrategy<User>): User[] {
   return [...users].sort(strategy);
 }
 
-// --- 使用例 ---
+// --- Usage ---
 const users: User[] = [
   { name: "Charlie", age: 30, email: "c@test.com", createdAt: new Date("2024-01"), score: 85 },
   { name: "Alice", age: 25, email: "a@test.com", createdAt: new Date("2024-03"), score: 92 },
   { name: "Bob", age: 30, email: "b@test.com", createdAt: new Date("2024-02"), score: 88 },
 ];
 
-// 単一ソート
+// Single sort
 console.log(sortUsers(users, byName).map(u => u.name));
 // ["Alice", "Bob", "Charlie"]
 
 console.log(sortUsers(users, byScore).map(u => u.name));
 // ["Alice", "Bob", "Charlie"]
 
-// 合成ソート: 年齢順 -> 名前順（同じ年齢の場合）
+// Composed sort: by age -> by name (when age is equal)
 const byAgeThenName = composeStrategies(byAge, byName);
 console.log(sortUsers(users, byAgeThenName).map(u => u.name));
 // ["Alice", "Bob", "Charlie"]
 
-// 反転: 名前の逆順
+// Reversed: reverse alphabetical by name
 console.log(sortUsers(users, reverse(byName)).map(u => u.name));
 // ["Charlie", "Bob", "Alice"]
 ```
 
-### コード例 3: バリデーション Strategy（TypeScript）
+### Code Example 3: Validation Strategy (TypeScript)
 
 ```typescript
-// validation-strategy.ts — フォームバリデーション
+// validation-strategy.ts — Form validation
 interface ValidationResult {
   valid: boolean;
   errors: string[];
@@ -375,7 +371,7 @@ class PhoneValidation implements ValidationStrategy {
   }
 }
 
-// Context: フォームフィールド
+// Context: form field
 class FormField {
   private strategies: ValidationStrategy[] = [];
 
@@ -396,7 +392,7 @@ class FormField {
   }
 }
 
-// --- 使用例 ---
+// --- Usage ---
 const emailField = new FormField("email", new EmailValidation());
 console.log(emailField.validate("test@example.com"));
 // { valid: true, errors: [] }
@@ -415,17 +411,17 @@ console.log(passwordField.validate("MyP@ssw0rd!!"));
 // { valid: true, errors: [] }
 ```
 
-### コード例 4: Python ── Protocol ベースの Strategy
+### Code Example 4: Python — Protocol-Based Strategy
 
 ```python
-# compression_strategy.py — Python Protocol による Strategy
+# compression_strategy.py — Strategy using Python Protocol
 from typing import Protocol
 import gzip
 import time
 
 
 class CompressionStrategy(Protocol):
-    """圧縮戦略のプロトコル（インタフェース）"""
+    """Protocol (interface) for compression strategies"""
     @property
     def name(self) -> str: ...
     def compress(self, data: bytes) -> bytes: ...
@@ -453,7 +449,7 @@ class NoCompression:
 
 
 class FileProcessor:
-    """Context: ファイル処理器"""
+    """Context: file processor"""
     def __init__(self, compression: CompressionStrategy):
         self._compression = compression
 
@@ -484,8 +480,8 @@ class FileProcessor:
         return self._compression.decompress(compressed)
 
 
-# --- 使用例 ---
-data = b"Hello " * 1000  # 6000 bytes の繰り返しデータ
+# --- Usage ---
+data = b"Hello " * 1000  # 6000 bytes of repeated data
 
 processor = FileProcessor(GzipCompression())
 result = processor.save(data, "/tmp/data.gz")
@@ -498,7 +494,7 @@ print(result)
 # {"original_size": 6000, "compressed_size": 6000, "ratio": "100.0%", ...}
 ```
 
-### コード例 5: Strategy の動的選択（Registry パターン）
+### Code Example 5: Dynamic Strategy Selection (Registry Pattern)
 
 ```typescript
 // strategy-registry.ts — Registry + Strategy
@@ -516,7 +512,7 @@ class StrategyRegistry<T> {
     const strategy = this.strategies.get(name);
     if (strategy) return strategy;
 
-    // デフォルト戦略があれば返す
+    // Return the default strategy if one exists
     if (this.defaultKey) {
       return this.strategies.get(this.defaultKey)!;
     }
@@ -533,30 +529,30 @@ class StrategyRegistry<T> {
   }
 }
 
-// --- 料金計算の Registry ---
+// --- Pricing Registry ---
 const pricingRegistry = new StrategyRegistry<PricingStrategy>();
 pricingRegistry
-  .register("regular", new RegularPricing(), true) // デフォルト
+  .register("regular", new RegularPricing(), true) // default
   .register("premium", new PremiumPricing())
   .register("student", new StudentPricing())
   .register("senior", new SeniorPricing());
 
-// APIリクエストから動的に選択
+// Dynamically select from an API request
 function handleCheckout(req: { membershipType: string; items: any[] }) {
   const strategy = pricingRegistry.get(req.membershipType);
   const cart = new ShoppingCart(strategy);
   // ...
 }
 
-// 利用可能な戦略の一覧
+// List of available strategies
 console.log(pricingRegistry.getAvailableNames());
 // ["regular", "premium", "student", "senior"]
 ```
 
-### コード例 6: HTTP リトライ Strategy
+### Code Example 6: HTTP Retry Strategy
 
 ```typescript
-// retry-strategy.ts — リトライアルゴリズムの Strategy
+// retry-strategy.ts — Strategy for retry algorithms
 interface RetryStrategy {
   readonly name: string;
   getDelay(attempt: number, baseDelay: number): number;
@@ -591,7 +587,7 @@ class ExponentialWithJitter implements RetryStrategy {
     return Math.floor(jitter);
   }
   shouldRetry(attempt: number, maxAttempts: number, error: Error): boolean {
-    // 4xx エラーはリトライしない（クライアントエラー）
+    // Do not retry on 4xx errors (client errors)
     if ('statusCode' in error && (error as any).statusCode >= 400 && (error as any).statusCode < 500) {
       return false;
     }
@@ -599,7 +595,7 @@ class ExponentialWithJitter implements RetryStrategy {
   }
 }
 
-// Context: HTTP クライアント
+// Context: HTTP client
 class ResilientHttpClient {
   constructor(
     private retryStrategy: RetryStrategy,
@@ -633,18 +629,18 @@ class ResilientHttpClient {
   }
 }
 
-// --- 使用例 ---
-// 開発環境: リニアリトライ（予測しやすい）
+// --- Usage ---
+// Development environment: linear retry (predictable)
 const devClient = new ResilientHttpClient(new LinearRetry(), 3, 500);
 
-// 本番環境: 指数バックオフ + ジッター（サーバー負荷分散）
+// Production environment: exponential backoff + jitter (distribute server load)
 const prodClient = new ResilientHttpClient(new ExponentialWithJitter(), 5, 1000);
 ```
 
-### コード例 7: ロギング Strategy
+### Code Example 7: Logging Strategy
 
 ```typescript
-// logging-strategy.ts — ログ出力先の Strategy
+// logging-strategy.ts — Strategy for log output destinations
 interface LogEntry {
   level: 'debug' | 'info' | 'warn' | 'error';
   message: string;
@@ -730,12 +726,12 @@ class Logger {
   }
 }
 
-// --- 使用例 ---
-// 開発環境: コンソールのみ
+// --- Usage ---
+// Development environment: console only
 const devLogger = new Logger(new ConsoleLogging());
 devLogger.info("Server started", { port: 3000 });
 
-// 本番環境: コンソール + JSON ファイル
+// Production environment: console + JSON file
 const prodLogger = new Logger(new MultiLogging([
   new ConsoleLogging(),
   new JsonFileLogging("/var/log/app.jsonl"),
@@ -745,95 +741,95 @@ prodLogger.error("Database connection failed", { host: "db.example.com" });
 
 ---
 
-## 4. if/else の排除
+## 4. Eliminating if/else
 
-Strategy パターンの最も実践的な価値は、条件分岐の排除である。
+The most practical value of the Strategy pattern is the elimination of conditional branches.
 
 ```
-BEFORE (条件分岐の肥大化):
+BEFORE (bloated conditional branches):
 
   function calculate(type: string, price: number): number {
     if (type === "regular") return price;
     else if (type === "premium") return price * 0.9;
     else if (type === "student") return price * 0.7;
     else if (type === "senior") return price * 0.8;
-    // ... 追加のたびにこの関数を変更 -> OCP 違反
+    // ... this function must be changed for every new type -> OCP violation
   }
 
-  問題:
-  1. 関数の肥大化
-  2. テストの組み合わせ爆発
-  3. 新しい型の追加で既存コードを変更
+  Problems:
+  1. Function grows bloated
+  2. Combinatorial explosion of test cases
+  3. Adding a new type requires modifying existing code
 
-AFTER (Strategy パターン):
+AFTER (Strategy pattern):
 
-  // 各戦略は独立したクラス/関数
+  // Each strategy is an independent class/function
   strategies.get(type).calculate(price);
 
-  利点:
-  1. 各戦略が独立してテスト可能
-  2. 新しい戦略は register するだけ
-  3. 既存のコードは変更不要
+  Benefits:
+  1. Each strategy can be tested independently
+  2. New strategies only need to be registered
+  3. Existing code requires no changes
 
-判断フロー:
-  条件分岐は3つ以上か？ ----No----> if/else で十分
+Decision flow:
+  Are there 3 or more conditional branches? ----No----> if/else is sufficient
     |
    Yes
     |
-  将来の追加が見込まれるか？ --No----> switch + enum で可読性確保
+  Are future additions expected? --No----> switch + enum for readability
     |
    Yes
     |
-  Strategy パターンを導入
+  Introduce the Strategy pattern
 ```
 
 ---
 
-## 5. 比較表
+## 5. Comparison Tables
 
-### 比較表 1: Strategy vs State vs Command vs Template Method
+### Comparison Table 1: Strategy vs State vs Command vs Template Method
 
-| 観点 | Strategy | State | Command | Template Method |
+| Aspect | Strategy | State | Command | Template Method |
 |------|:---:|:---:|:---:|:---:|
-| 目的 | アルゴリズム交換 | 状態依存の振る舞い | 操作のカプセル化 | アルゴリズムの骨格定義 |
-| 交換タイミング | クライアントが決定 | 内部状態で自動遷移 | キュー/履歴に保存 | コンパイル時 |
-| 関係 | has-a（委譲） | has-a（委譲） | has-a（委譲） | is-a（継承） |
-| 柔軟性 | 高い（実行時交換） | 中 | 高い | 低い（継承で固定） |
-| Undo | なし | なし | あり | なし |
-| 典型的な数 | 少数〜中 | 有限個の状態 | 多数のコマンド | 1つの骨格 |
-| テスト | 個別にテスト容易 | 状態ごとにテスト | コマンドごとにテスト | サブクラスごとにテスト |
+| Purpose | Algorithm exchange | State-dependent behavior | Encapsulation of operations | Define the skeleton of an algorithm |
+| Switching timing | Decided by client | Auto-transition based on internal state | Saved in queue/history | At compile time |
+| Relationship | has-a (delegation) | has-a (delegation) | has-a (delegation) | is-a (inheritance) |
+| Flexibility | High (runtime switching) | Medium | High | Low (fixed by inheritance) |
+| Undo | None | None | Supported | None |
+| Typical count | Few to moderate | Finite number of states | Many commands | One skeleton |
+| Testing | Easy to test individually | Test per state | Test per command | Test per subclass |
 
-### 比較表 2: クラス Strategy vs 関数 Strategy
+### Comparison Table 2: Class Strategy vs Function Strategy
 
-| 観点 | クラスベース | 関数ベース |
+| Aspect | Class-Based | Function-Based |
 |------|:---:|:---:|
-| 状態保持 | フィールドで可能 | クロージャで可能 |
-| 設定パラメータ | コンストラクタで注入 | 高階関数で注入 |
-| テスト | インスタンス化して実行 | 直接呼び出し |
-| コード量 | 多い（class, implements） | 少ない（関数リテラル） |
-| 型安全性 | 高い（インタフェース強制） | 中（型エイリアスに依存） |
-| DI フレームワーク | 対応しやすい | 対応にくい場合あり |
-| 適用場面 | 複雑な戦略、状態を持つ | 単純な変換、ソート |
+| State retention | Possible via fields | Possible via closures |
+| Configuration parameters | Injected via constructor | Injected via higher-order functions |
+| Testing | Instantiate and run | Call directly |
+| Code volume | More (class, implements) | Less (function literals) |
+| Type safety | High (interface enforced) | Medium (depends on type aliases) |
+| DI framework compatibility | Easy to integrate | May be harder in some cases |
+| Use cases | Complex strategies with state | Simple transforms, sorting |
 
-### 比較表 3: Strategy の適用判断
+### Comparison Table 3: Decision Criteria for Applying Strategy
 
-| 状況 | 推奨アプローチ | 理由 |
+| Situation | Recommended Approach | Reason |
 |------|-------------|------|
-| バリエーションが2つ | 三項演算子/if-else | Strategy は過剰設計 |
-| バリエーションが3〜5 | switch/enum または Strategy | 将来の追加を考慮して判断 |
-| バリエーションが6以上 | Strategy + Registry | 条件分岐の管理が困難 |
-| 実行時に切り替え必要 | Strategy | 主目的に合致 |
-| アルゴリズムが複雑 | クラス Strategy | 状態とロジックのカプセル化 |
-| アルゴリズムが単純 | 関数 Strategy | 軽量で十分 |
+| 2 variations | Ternary/if-else | Strategy is over-engineering |
+| 3–5 variations | switch/enum or Strategy | Decide based on expected future additions |
+| 6+ variations | Strategy + Registry | Conditional branches become hard to manage |
+| Runtime switching required | Strategy | Matches the primary purpose |
+| Complex algorithm | Class Strategy | Encapsulates state and logic |
+| Simple algorithm | Function Strategy | Lightweight and sufficient |
 
 ---
 
-## 6. アンチパターン
+## 6. Anti-Patterns
 
-### アンチパターン 1: 戦略が2つしかないのに Strategy パターン
+### Anti-Pattern 1: Using Strategy Pattern for Only Two Strategies
 
 ```typescript
-// NG: 過剰設計（YAGNI 違反）
+// BAD: Over-engineering (YAGNI violation)
 interface GreetingStrategy {
   greet(name: string): string;
 }
@@ -844,65 +840,65 @@ class CasualGreeting implements GreetingStrategy {
   greet(name: string) { return `Hi ${name}`; }
 }
 
-// このためだけにインタフェース + 2クラスは過剰
-// 三項演算子で十分:
+// An interface + 2 classes just for this is excessive
+// A ternary operator is sufficient:
 
-// OK: シンプルに書く
+// OK: Write it simply
 const greet = (name: string, formal: boolean) =>
   formal ? `Dear ${name}` : `Hi ${name}`;
 ```
 
-**改善**: バリエーションが3つ以上、または将来の追加が見込まれる場合にのみ Strategy パターンを導入する。YAGNI（You Aren't Gonna Need It）の原則を忘れない。
+**Improvement**: Introduce the Strategy pattern only when there are 3 or more variations, or when future additions are expected. Never forget the YAGNI (You Aren't Gonna Need It) principle.
 
-### アンチパターン 2: Context が Strategy の内部を知っている
+### Anti-Pattern 2: Context Knows the Internals of Strategy
 
 ```typescript
-// NG: Context が Strategy の具象型をチェック
+// BAD: Context checks the concrete type of Strategy
 class Context {
   execute(): void {
     if (this.strategy instanceof StrategyA) {
-      // StrategyA 固有の前処理
+      // Pre-processing specific to StrategyA
       this.prepareForA();
     }
     if (this.strategy instanceof StrategyB) {
-      // StrategyB 固有の前処理
+      // Pre-processing specific to StrategyB
       this.prepareForB();
     }
     this.strategy.execute();
   }
 }
-// 問題: Strategy を追加するたびに Context も変更が必要 -> OCP 違反
+// Problem: Context must also change every time a Strategy is added -> OCP violation
 
-// OK: Context は Strategy インタフェースのみに依存
+// OK: Context depends only on the Strategy interface
 class Context {
   execute(): void {
-    // 前処理は Strategy 内部に閉じ込める
+    // Pre-processing is encapsulated inside Strategy
     this.strategy.execute();
   }
 }
 
-// Strategy 側で前処理を含める
+// Strategy includes its own pre-processing
 class StrategyA implements Strategy {
   execute(): void {
-    this.prepare(); // 固有の前処理
-    this.doWork();  // 本処理
+    this.prepare(); // Strategy-specific pre-processing
+    this.doWork();  // Main processing
   }
 }
 ```
 
-### アンチパターン 3: Strategy の粒度が不適切
+### Anti-Pattern 3: Inappropriate Granularity of Strategy
 
 ```typescript
-// NG: 1つの Strategy に複数の無関係な責務
+// BAD: A single Strategy has multiple unrelated responsibilities
 interface AllInOneStrategy {
   calculatePrice(price: number): number;
   formatOutput(data: any): string;
   validateInput(input: string): boolean;
   sendNotification(message: string): void;
 }
-// 問題: 料金計算を変えたいだけなのに、全てのメソッドを実装する必要がある
+// Problem: Even if you only want to change pricing, you must implement all methods
 
-// OK: 責務ごとに Strategy を分割
+// OK: Split Strategy by responsibility
 interface PricingStrategy {
   calculate(price: number): number;
 }
@@ -915,7 +911,7 @@ interface ValidationStrategy {
   validate(input: string): ValidationResult;
 }
 
-// Context は必要な Strategy だけを使う
+// Context uses only the Strategy it needs
 class OrderService {
   constructor(
     private pricing: PricingStrategy,
@@ -924,31 +920,31 @@ class OrderService {
 }
 ```
 
-### アンチパターン 4: Strategy の切り替えがスレッドセーフでない
+### Anti-Pattern 4: Strategy Switching Is Not Thread-Safe
 
 ```typescript
-// NG: マルチスレッド環境で Strategy の切り替えが競合する
+// BAD: Strategy switching causes race conditions in multi-threaded environments
 class PaymentProcessor {
   private strategy: PaymentStrategy;
 
   setStrategy(strategy: PaymentStrategy): void {
-    this.strategy = strategy; // スレッドAが書き換え中にスレッドBが読む可能性
+    this.strategy = strategy; // Thread B may read while Thread A is writing
   }
 
   process(order: Order): PaymentResult {
-    return this.strategy.process(order); // どのStrategyが使われるか不定
+    return this.strategy.process(order); // Which Strategy is used is non-deterministic
   }
 }
 
-// OK: Strategy を引数で渡すか、イミュータブルなContextを使う
+// OK: Pass Strategy as an argument, or use an immutable Context
 class PaymentProcessor {
-  // 方法1: Strategyを引数として受け取る（状態を持たない）
+  // Option 1: Receive Strategy as an argument (stateless)
   process(order: Order, strategy: PaymentStrategy): PaymentResult {
     return strategy.process(order);
   }
 }
 
-// 方法2: イミュータブルなContext（Strategyの変更時は新インスタンスを生成）
+// Option 2: Immutable Context (create a new instance when Strategy changes)
 class PaymentProcessor {
   constructor(private readonly strategy: PaymentStrategy) {}
 
@@ -962,22 +958,22 @@ class PaymentProcessor {
 }
 ```
 
-**改善**: マルチスレッド環境では、(1) Strategy を引数で渡す、(2) Context をイミュータブルにする、(3) スレッドローカルストレージを使う、のいずれかで安全性を確保する。
+**Improvement**: In multi-threaded environments, ensure safety by (1) passing Strategy as an argument, (2) making Context immutable, or (3) using thread-local storage.
 
 ---
 
-## 7. 実践演習
+## 7. Practice Exercises
 
-### 演習 1: 基礎 ── テキスト変換 Strategy
+### Exercise 1: Basic — Text Transformation Strategy
 
-**課題**: テキスト変換を Strategy パターンで実装せよ。
+**Task**: Implement text transformation using the Strategy pattern.
 
-要件:
-1. `TextTransformer` インタフェース: `transform(text: string): string`
-2. 具体 Strategy: `UpperCase`, `LowerCase`, `CamelCase`, `SnakeCase`, `KebabCase`
-3. `TextProcessor` Context: Strategy を使ってテキストを変換
+Requirements:
+1. `TextTransformer` interface: `transform(text: string): string`
+2. Concrete strategies: `UpperCase`, `LowerCase`, `CamelCase`, `SnakeCase`, `KebabCase`
+3. `TextProcessor` Context: transforms text using a Strategy
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 const processor = new TextProcessor(new UpperCase());
@@ -993,22 +989,22 @@ processor.setStrategy(new KebabCase());
 console.log(processor.process("hello world")); // "hello-world"
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As shown in the comments above.
 
 ---
 
-### 演習 2: 応用 ── 動的 Strategy Registry
+### Exercise 2: Applied — Dynamic Strategy Registry
 
-**課題**: Strategy Registry を実装し、設定ファイルやAPIパラメータから動的に Strategy を選択できるシステムを構築せよ。
+**Task**: Implement a Strategy Registry and build a system that can dynamically select a Strategy from a configuration file or API parameters.
 
-要件:
-1. `StrategyRegistry<T>` クラス: Strategy の登録と取得
-2. デフォルト Strategy のサポート
-3. 利用可能な Strategy の一覧取得
-4. 実行時の Strategy 追加（プラグイン対応）
-5. Shipping（送料計算）の具体例で実装
+Requirements:
+1. `StrategyRegistry<T>` class: registration and retrieval of strategies
+2. Support for a default Strategy
+3. Retrieve a list of available strategies
+4. Add strategies at runtime (plugin support)
+5. Implement a concrete example for Shipping (shipping cost calculation)
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 const registry = new StrategyRegistry<ShippingStrategy>();
@@ -1021,29 +1017,29 @@ console.log(registry.getAvailableNames());
 // ["standard", "express", "same-day"]
 
 const strategy = registry.get("express");
-console.log(strategy.calculate(1000, 2.5)); // 送料計算
+console.log(strategy.calculate(1000, 2.5)); // shipping cost calculation
 
-// 未登録の名前 -> デフォルト戦略
+// Unregistered name -> default strategy
 const fallback = registry.get("unknown");
 console.log(fallback === registry.get("standard")); // true
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As shown in the comments above.
 
 ---
 
-### 演習 3: 発展 ── 合成可能な Strategy パイプライン
+### Exercise 3: Advanced — Composable Strategy Pipeline
 
-**課題**: 複数の Strategy を組み合わせて、パイプライン的に処理を適用できるフレームワークを構築せよ。
+**Task**: Build a framework that combines multiple strategies and applies processing in a pipeline fashion.
 
-要件:
-1. `TransformPipeline<T>` クラス: 複数の変換 Strategy をチェーン
-2. `addStep(strategy)`: パイプラインにステップを追加
-3. `execute(input)`: パイプラインを順次実行
-4. `addConditional(predicate, strategy)`: 条件付き Strategy の適用
-5. 画像処理のパイプラインで具体例を実装
+Requirements:
+1. `TransformPipeline<T>` class: chain multiple transformation strategies
+2. `addStep(strategy)`: add a step to the pipeline
+3. `execute(input)`: execute the pipeline sequentially
+4. `addConditional(predicate, strategy)`: apply a strategy conditionally
+5. Implement a concrete example with an image processing pipeline
 
-**テストケース**:
+**Test Cases**:
 
 ```typescript
 interface ImageData {
@@ -1068,38 +1064,38 @@ console.log(result);
 // { width: 800, height: 600, format: 'jpg', quality: 85 }
 ```
 
-**期待される出力**: 上記コメントの通り。
+**Expected Output**: As shown in the comments above.
 
 
 ---
 
-## トラブルシューティング
+## Troubleshooting
 
-### よくあるエラーと解決策
+### Common Errors and Solutions
 
-| エラー | 原因 | 解決策 |
+| Error | Cause | Solution |
 |--------|------|--------|
-| 初期化エラー | 設定ファイルの不備 | 設定ファイルのパスと形式を確認 |
-| タイムアウト | ネットワーク遅延/リソース不足 | タイムアウト値の調整、リトライ処理の追加 |
-| メモリ不足 | データ量の増大 | バッチ処理の導入、ページネーションの実装 |
-| 権限エラー | アクセス権限の不足 | 実行ユーザーの権限確認、設定の見直し |
-| データ不整合 | 並行処理の競合 | ロック機構の導入、トランザクション管理 |
+| Initialization error | Misconfigured configuration file | Check the path and format of the configuration file |
+| Timeout | Network delay / insufficient resources | Adjust timeout values, add retry logic |
+| Out of memory | Increase in data volume | Introduce batch processing, implement pagination |
+| Permission error | Insufficient access rights | Check the executing user's permissions, review settings |
+| Data inconsistency | Race conditions in concurrent processing | Introduce locking mechanisms, manage transactions |
 
-### デバッグの手順
+### Debugging Steps
 
-1. **エラーメッセージの確認**: スタックトレースを読み、発生箇所を特定する
-2. **再現手順の確立**: 最小限のコードでエラーを再現する
-3. **仮説の立案**: 考えられる原因をリストアップする
-4. **段階的な検証**: ログ出力やデバッガを使って仮説を検証する
-5. **修正と回帰テスト**: 修正後、関連する箇所のテストも実行する
+1. **Check the error message**: Read the stack trace and identify where the error occurred
+2. **Establish reproduction steps**: Reproduce the error with minimal code
+3. **Form a hypothesis**: List possible causes
+4. **Incremental verification**: Use log output or a debugger to verify hypotheses
+5. **Fix and regression test**: After fixing, run tests for related areas as well
 
 ```python
-# デバッグ用ユーティリティ
+# Debugging utility
 import logging
 import traceback
 from functools import wraps
 
-# ロガーの設定
+# Logger configuration
 logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s [%(levelname)s] %(name)s: %(message)s'
@@ -1107,102 +1103,102 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 def debug_decorator(func):
-    """関数の入出力をログ出力するデコレータ"""
+    """Decorator that logs the input and output of a function"""
     @wraps(func)
     def wrapper(*args, **kwargs):
-        logger.debug(f"呼び出し: {func.__name__}(args={args}, kwargs={kwargs})")
+        logger.debug(f"Calling: {func.__name__}(args={args}, kwargs={kwargs})")
         try:
             result = func(*args, **kwargs)
-            logger.debug(f"戻り値: {func.__name__} -> {result}")
+            logger.debug(f"Return value: {func.__name__} -> {result}")
             return result
         except Exception as e:
-            logger.error(f"例外発生: {func.__name__}: {e}")
+            logger.error(f"Exception raised: {func.__name__}: {e}")
             logger.error(traceback.format_exc())
             raise
     return wrapper
 
 @debug_decorator
 def process_data(items):
-    """データ処理（デバッグ対象）"""
+    """Data processing (debug target)"""
     if not items:
-        raise ValueError("空のデータ")
+        raise ValueError("Empty data")
     return [item * 2 for item in items]
 ```
 
-### パフォーマンス問題の診断
+### Diagnosing Performance Issues
 
-パフォーマンス問題が発生した場合の診断手順:
+Steps for diagnosing performance issues:
 
-1. **ボトルネックの特定**: プロファイリングツールで計測
-2. **メモリ使用量の確認**: メモリリークの有無をチェック
-3. **I/O待ちの確認**: ディスクやネットワークI/Oの状況を確認
-4. **同時接続数の確認**: コネクションプールの状態を確認
+1. **Identify the bottleneck**: Measure with profiling tools
+2. **Check memory usage**: Check for memory leaks
+3. **Check for I/O waits**: Check the status of disk and network I/O
+4. **Check concurrent connections**: Check the state of the connection pool
 
-| 問題の種類 | 診断ツール | 対策 |
+| Problem Type | Diagnostic Tool | Countermeasure |
 |-----------|-----------|------|
-| CPU負荷 | cProfile, py-spy | アルゴリズム改善、並列化 |
-| メモリリーク | tracemalloc, objgraph | 参照の適切な解放 |
-| I/Oボトルネック | strace, iostat | 非同期I/O、キャッシュ |
-| DB遅延 | EXPLAIN, slow query log | インデックス、クエリ最適化 |
+| CPU load | cProfile, py-spy | Algorithm improvement, parallelization |
+| Memory leak | tracemalloc, objgraph | Proper release of references |
+| I/O bottleneck | strace, iostat | Asynchronous I/O, caching |
+| DB latency | EXPLAIN, slow query log | Indexes, query optimization |
 
 ---
 
-## 設計判断ガイド
+## Design Decision Guide
 
-### 選択基準マトリクス
+### Selection Criteria Matrix
 
-技術選択を行う際の判断基準を以下にまとめます。
+The following summarizes the criteria for making technology choices.
 
-| 判断基準 | 重視する場合 | 妥協できる場合 |
+| Criterion | When to prioritize | When to compromise |
 |---------|------------|-------------|
-| パフォーマンス | リアルタイム処理、大規模データ | 管理画面、バッチ処理 |
-| 保守性 | 長期運用、チーム開発 | プロトタイプ、短期プロジェクト |
-| スケーラビリティ | 成長が見込まれるサービス | 社内ツール、固定ユーザー |
-| セキュリティ | 個人情報、金融データ | 公開データ、社内利用 |
-| 開発速度 | MVP、市場投入スピード | 品質重視、ミッションクリティカル |
+| Performance | Real-time processing, large-scale data | Admin panels, batch processing |
+| Maintainability | Long-term operation, team development | Prototypes, short-term projects |
+| Scalability | Services expected to grow | Internal tools, fixed user base |
+| Security | Personal information, financial data | Public data, internal use |
+| Development speed | MVP, time-to-market | Quality-focused, mission-critical |
 
-### アーキテクチャパターンの選択
+### Choosing an Architecture Pattern
 
 ```
 ┌─────────────────────────────────────────────────┐
-│              アーキテクチャ選択フロー              │
+│           Architecture Selection Flow            │
 ├─────────────────────────────────────────────────┤
 │                                                 │
-│  ① チーム規模は？                                │
-│    ├─ 小規模（1-5人）→ モノリス                   │
-│    └─ 大規模（10人+）→ ②へ                       │
+│  1. What is the team size?                      │
+│    ├─ Small (1-5 people) -> Monolith            │
+│    └─ Large (10+ people) -> Go to 2             │
 │                                                 │
-│  ② デプロイ頻度は？                               │
-│    ├─ 週1回以下 → モノリス + モジュール分割         │
-│    └─ 毎日/複数回 → ③へ                          │
+│  2. How often do you deploy?                    │
+│    ├─ Once a week or less -> Monolith + modules │
+│    └─ Daily / multiple times -> Go to 3         │
 │                                                 │
-│  ③ チーム間の独立性は？                            │
-│    ├─ 高い → マイクロサービス                      │
-│    └─ 中程度 → モジュラーモノリス                   │
+│  3. How independent are the teams?              │
+│    ├─ High -> Microservices                     │
+│    └─ Moderate -> Modular monolith              │
 │                                                 │
 └─────────────────────────────────────────────────┘
 ```
 
-### トレードオフの分析
+### Analyzing Trade-offs
 
-技術的な判断には必ずトレードオフが伴います。以下の観点で分析を行いましょう:
+Technical decisions always involve trade-offs. Analyze from the following perspectives:
 
-**1. 短期 vs 長期のコスト**
-- 短期的に速い方法が長期的には技術的負債になることがある
-- 逆に、過剰な設計は短期的なコストが高く、プロジェクトの遅延を招く
+**1. Short-term vs Long-term Cost**
+- A faster short-term approach can become technical debt in the long run
+- Conversely, over-engineering has high short-term costs and can delay projects
 
-**2. 一貫性 vs 柔軟性**
-- 統一された技術スタックは学習コストが低い
-- 多様な技術の採用は適材適所が可能だが、運用コストが増加
+**2. Consistency vs Flexibility**
+- A unified technology stack has lower learning costs
+- Adopting diverse technologies allows using the right tool for the job, but increases operational costs
 
-**3. 抽象化のレベル**
-- 高い抽象化は再利用性が高いが、デバッグが困難になる場合がある
-- 低い抽象化は直感的だが、コードの重複が発生しやすい
+**3. Level of Abstraction**
+- High abstraction offers high reusability but can make debugging difficult
+- Low abstraction is intuitive but tends to lead to code duplication
 
 ```python
-# 設計判断の記録テンプレート
+# Template for recording design decisions
 class ArchitectureDecisionRecord:
-    """ADR (Architecture Decision Record) の作成"""
+    """Creating an ADR (Architecture Decision Record)"""
 
     def __init__(self, title: str):
         self.title = title
@@ -1212,17 +1208,17 @@ class ArchitectureDecisionRecord:
         self.alternatives = []
 
     def set_context(self, context: str):
-        """背景と課題の記述"""
+        """Describe the background and problem"""
         self.context = context
         return self
 
     def set_decision(self, decision: str):
-        """決定内容の記述"""
+        """Describe the decision made"""
         self.decision = decision
         return self
 
     def add_consequence(self, consequence: str, positive: bool = True):
-        """結果の追加"""
+        """Add a consequence"""
         self.consequences.append({
             'description': consequence,
             'type': 'positive' if positive else 'negative'
@@ -1230,7 +1226,7 @@ class ArchitectureDecisionRecord:
         return self
 
     def add_alternative(self, name: str, reason_rejected: str):
-        """却下した代替案の追加"""
+        """Add a rejected alternative"""
         self.alternatives.append({
             'name': name,
             'reason_rejected': reason_rejected
@@ -1238,15 +1234,15 @@ class ArchitectureDecisionRecord:
         return self
 
     def to_markdown(self) -> str:
-        """Markdown形式で出力"""
+        """Output in Markdown format"""
         md = f"# ADR: {self.title}\n\n"
-        md += f"## 背景\n{self.context}\n\n"
-        md += f"## 決定\n{self.decision}\n\n"
-        md += "## 結果\n"
+        md += f"## Background\n{self.context}\n\n"
+        md += f"## Decision\n{self.decision}\n\n"
+        md += "## Consequences\n"
         for c in self.consequences:
             icon = "✅" if c['type'] == 'positive' else "⚠️"
             md += f"- {icon} {c['description']}\n"
-        md += "\n## 却下した代替案\n"
+        md += "\n## Rejected Alternatives\n"
         for a in self.alternatives:
             md += f"- **{a['name']}**: {a['reason_rejected']}\n"
         return md
@@ -1254,53 +1250,53 @@ class ArchitectureDecisionRecord:
 
 ---
 
-## 実務での適用シナリオ
+## Real-World Application Scenarios
 
-### シナリオ1: スタートアップでのMVP開発
+### Scenario 1: MVP Development at a Startup
 
-**状況:** 限られたリソースで素早くプロダクトをリリースする必要がある
+**Situation:** Need to release a product quickly with limited resources
 
-**アプローチ:**
-- シンプルなアーキテクチャを選択
-- 必要最小限の機能に集中
-- 自動テストはクリティカルパスのみ
-- モニタリングは早期から導入
+**Approach:**
+- Choose a simple architecture
+- Focus on the minimum necessary features
+- Automated tests only for critical paths
+- Introduce monitoring early
 
-**学んだ教訓:**
-- 完璧を求めすぎない（YAGNI原則）
-- ユーザーフィードバックを早期に取得
-- 技術的負債は意識的に管理する
+**Lessons learned:**
+- Don't strive for perfection (YAGNI principle)
+- Gather user feedback early
+- Manage technical debt consciously
 
-### シナリオ2: レガシーシステムのモダナイゼーション
+### Scenario 2: Modernizing a Legacy System
 
-**状況:** 10年以上運用されているシステムを段階的に刷新する
+**Situation:** Gradually renewing a system that has been in operation for more than 10 years
 
-**アプローチ:**
-- Strangler Fig パターンで段階的に移行
-- 既存のテストがない場合はCharacterization Testを先に作成
-- APIゲートウェイで新旧システムを共存
-- データ移行は段階的に実施
+**Approach:**
+- Migrate incrementally using the Strangler Fig pattern
+- Create Characterization Tests first if no existing tests exist
+- Coexist old and new systems via an API gateway
+- Perform data migration in stages
 
-| フェーズ | 作業内容 | 期間目安 | リスク |
+| Phase | Work Content | Estimated Duration | Risk |
 |---------|---------|---------|--------|
-| 1. 調査 | 現状分析、依存関係の把握 | 2-4週間 | 低 |
-| 2. 基盤 | CI/CD構築、テスト環境 | 4-6週間 | 低 |
-| 3. 移行開始 | 周辺機能から順次移行 | 3-6ヶ月 | 中 |
-| 4. コア移行 | 中核機能の移行 | 6-12ヶ月 | 高 |
-| 5. 完了 | 旧システム廃止 | 2-4週間 | 中 |
+| 1. Investigation | Current state analysis, mapping dependencies | 2–4 weeks | Low |
+| 2. Foundation | CI/CD setup, test environment | 4–6 weeks | Low |
+| 3. Migration start | Migrate peripheral features first | 3–6 months | Medium |
+| 4. Core migration | Migrate core features | 6–12 months | High |
+| 5. Completion | Decommission old system | 2–4 weeks | Medium |
 
-### シナリオ3: 大規模チームでの開発
+### Scenario 3: Development with a Large Team
 
-**状況:** 50人以上のエンジニアが同一プロダクトを開発する
+**Situation:** 50+ engineers developing the same product
 
-**アプローチ:**
-- ドメイン駆動設計で境界を明確化
-- チームごとにオーナーシップを設定
-- 共通ライブラリはInner Source方式で管理
-- APIファーストで設計し、チーム間の依存を最小化
+**Approach:**
+- Clarify boundaries with Domain-Driven Design
+- Assign ownership per team
+- Manage shared libraries using Inner Source
+- Design API-first to minimize inter-team dependencies
 
 ```python
-# チーム間のAPI契約定義
+# API contract definition between teams
 from dataclasses import dataclass
 from typing import List, Optional
 from enum import Enum
@@ -1313,20 +1309,20 @@ class Priority(Enum):
 
 @dataclass
 class APIContract:
-    """チーム間のAPI契約"""
+    """API contract between teams"""
     endpoint: str
     method: str
     owner_team: str
     consumers: List[str]
-    sla_ms: int  # レスポンスタイムSLA
+    sla_ms: int  # Response time SLA
     priority: Priority
 
     def validate_sla(self, actual_ms: int) -> bool:
-        """SLA準拠の確認"""
+        """Check SLA compliance"""
         return actual_ms <= self.sla_ms
 
     def to_openapi(self) -> dict:
-        """OpenAPI形式で出力"""
+        """Output in OpenAPI format"""
         return {
             'path': self.endpoint,
             'method': self.method,
@@ -1335,7 +1331,7 @@ class APIContract:
             'x-sla-ms': self.sla_ms
         }
 
-# 使用例
+# Usage example
 contracts = [
     APIContract(
         endpoint="/api/v1/users",
@@ -1356,67 +1352,67 @@ contracts = [
 ]
 ```
 
-### シナリオ4: パフォーマンスクリティカルなシステム
+### Scenario 4: Performance-Critical Systems
 
-**状況:** ミリ秒単位のレスポンスが求められるシステム
+**Situation:** Systems where millisecond-level response times are required
 
-**最適化ポイント:**
-1. キャッシュ戦略（L1: インメモリ、L2: Redis、L3: CDN）
-2. 非同期処理の活用
-3. コネクションプーリング
-4. クエリ最適化とインデックス設計
+**Optimization Points:**
+1. Caching strategy (L1: in-memory, L2: Redis, L3: CDN)
+2. Leveraging asynchronous processing
+3. Connection pooling
+4. Query optimization and index design
 
-| 最適化手法 | 効果 | 実装コスト | 適用場面 |
+| Optimization Technique | Effect | Implementation Cost | Use Case |
 |-----------|------|-----------|---------|
-| インメモリキャッシュ | 高 | 低 | 頻繁にアクセスされるデータ |
-| CDN | 高 | 低 | 静的コンテンツ |
-| 非同期処理 | 中 | 中 | I/O待ちが多い処理 |
-| DB最適化 | 高 | 高 | クエリが遅い場合 |
-| コード最適化 | 低-中 | 高 | CPU律速の場合 |
+| In-memory cache | High | Low | Frequently accessed data |
+| CDN | High | Low | Static content |
+| Asynchronous processing | Medium | Medium | I/O-heavy processing |
+| DB optimization | High | High | Slow queries |
+| Code optimization | Low–Medium | High | CPU-bound cases |
 ---
 
 ## 8. FAQ
 
-### Q1: Strategy と DI は同じですか？
+### Q1: Is Strategy the same as DI?
 
-DI（依存性注入）は依存の注入メカニズム、Strategy はアルゴリズム交換のパターンです。DI は Strategy を実現する手段として使えますが、Strategy は DI なしでも実装可能です。DI コンテナ（InversifyJS, tsyringe 等）を使うと、設定ファイルから Strategy を自動的に注入できて便利ですが、必須ではありません。
+DI (Dependency Injection) is a mechanism for injecting dependencies, while Strategy is a pattern for exchanging algorithms. DI can be used as a means to implement Strategy, but Strategy can be implemented without DI. Using a DI container (InversifyJS, tsyringe, etc.) allows strategies to be automatically injected from a configuration file, which is convenient but not required.
 
-### Q2: JavaScript では関数を渡すだけで Strategy は実現できますか？
+### Q2: In JavaScript, can Strategy be implemented simply by passing a function?
 
-はい。コールバック関数は Strategy パターンの軽量な実装です。`Array.sort(compareFn)` が典型例です。ただし、複雑な状態を持つ戦略やパラメータ設定が必要な戦略にはクラスが適しています。「関数1つで済むならクラスは不要、設定やテストの都合でクラスが必要なら使う」が実用的な判断基準です。
+Yes. Callback functions are a lightweight implementation of the Strategy pattern. `Array.sort(compareFn)` is a typical example. However, classes are more appropriate for strategies that hold complex state or require parameter configuration. A practical rule of thumb: "if a single function is enough, no class is needed; use a class if it is needed for configuration or testing purposes."
 
-### Q3: Strategy と Template Method の違いは？
+### Q3: What is the difference between Strategy and Template Method?
 
-Strategy は委譲（has-a）でアルゴリズム全体を交換します。Template Method は継承（is-a）でアルゴリズムの一部をオーバーライドします。Strategy の方が柔軟性が高く、現代のプログラミングでは推奨されます。GoF 自身も「委譲を継承より優先せよ」と述べています。
+Strategy exchanges the entire algorithm through delegation (has-a). Template Method overrides part of an algorithm through inheritance (is-a). Strategy is more flexible and is preferred in modern programming. The GoF themselves state "favor delegation over inheritance."
 
-### Q4: Strategy をいつ導入すべきですか？
+### Q4: When should I introduce Strategy?
 
-以下の条件を満たす場合に導入を検討してください: (1) 同じ処理に3つ以上のバリエーションがある、(2) 将来新しいバリエーションの追加が見込まれる、(3) 実行時にアルゴリズムを切り替える必要がある、(4) アルゴリズムのテストを個別に行いたい。逆に、バリエーションが2つで将来の追加もないなら if-else で十分です。
+Consider introducing it when the following conditions are met: (1) there are 3 or more variations of the same processing, (2) future additions of new variations are expected, (3) the algorithm needs to be switched at runtime, (4) you want to test algorithms individually. Conversely, if there are only 2 variations with no expected additions, if-else is sufficient.
 
-### Q5: Strategy とポリモーフィズムの関係は？
+### Q5: What is the relationship between Strategy and polymorphism?
 
-Strategy パターンはポリモーフィズムの応用です。共通のインタフェースを通じて異なる実装を統一的に扱うという点で、ポリモーフィズムそのものです。OOP ではインタフェース/抽象クラスで、関数型では関数型（type alias）で実現します。
+The Strategy pattern is an application of polymorphism. Treating different implementations uniformly through a common interface is polymorphism itself. In OOP it is achieved with interfaces/abstract classes; in functional programming with function types (type aliases).
 
-### Q6: Strategy パターンのテストはどう書くべきか？
+### Q6: How should tests for the Strategy pattern be written?
 
-テストは3つの層に分けて書くのが効果的です。
+It is effective to write tests in three layers.
 
-1. **各 Strategy の単体テスト**: Strategy ごとに入力と期待出力を検証する。Strategy は独立したクラス/関数なのでモック不要でテストしやすい。
-2. **Context のテスト**: モック Strategy を注入して、Context が Strategy を正しく呼び出しているかを検証する。ここでは Strategy の実装詳細には踏み込まない。
-3. **統合テスト**: 実際の Strategy と Context を組み合わせて、エンドツーエンドの動作を確認する。
+1. **Unit tests for each Strategy**: Verify input and expected output for each Strategy. Since strategies are independent classes/functions, they are easy to test without mocks.
+2. **Tests for Context**: Inject a mock Strategy and verify that Context is calling Strategy correctly. Do not go into the implementation details of Strategy here.
+3. **Integration tests**: Combine actual strategies with Context and verify end-to-end behavior.
 
 ```typescript
-// 1. Strategy の単体テスト
+// 1. Unit test for Strategy
 describe('ExpressShipping', () => {
-  it('5kg以下の荷物に速達料金を適用する', () => {
+  it('applies express shipping rate for packages under 5kg', () => {
     const strategy = new ExpressShipping();
-    expect(strategy.calculate(1000, 3.0)).toBe(1800); // 基本料 + 速達加算
+    expect(strategy.calculate(1000, 3.0)).toBe(1800); // base rate + express surcharge
   });
 });
 
-// 2. Context のテスト（モック使用）
+// 2. Context test (using mock)
 describe('ShippingCalculator', () => {
-  it('設定された Strategy に計算を委譲する', () => {
+  it('delegates calculation to the configured Strategy', () => {
     const mockStrategy: ShippingStrategy = {
       calculate: jest.fn().mockReturnValue(500),
     };
@@ -1427,73 +1423,73 @@ describe('ShippingCalculator', () => {
   });
 });
 
-// 3. 統合テスト
+// 3. Integration test
 describe('ShippingCalculator + StandardShipping', () => {
-  it('実際の送料計算が正しい', () => {
+  it('calculates actual shipping costs correctly', () => {
     const calculator = new ShippingCalculator(new StandardShipping());
     expect(calculator.calculateShipping(1000, 2.0)).toBe(600);
   });
 });
 ```
 
-### Q7: Strategy パターンとデコレータパターンの使い分けは？
+### Q7: How do you choose between Strategy and the Decorator pattern?
 
-Strategy は「アルゴリズムの交換」、デコレータは「機能の追加・装飾」が目的です。Strategy ではある時点で1つの戦略が選択されて実行されますが、デコレータは複数のラッパーを重ねて機能を拡張します。
+Strategy's purpose is "algorithm exchange," while Decorator's purpose is "adding/decorating functionality." With Strategy, one strategy is selected and executed at a given point in time, whereas Decorator stacks multiple wrappers to extend functionality.
 
-判断基準:
-- 「A **または** B を実行する」→ Strategy（排他的選択）
-- 「A **に加えて** B も実行する」→ Decorator（累積的追加）
+Decision criteria:
+- "Execute A **or** B" -> Strategy (exclusive selection)
+- "Execute A **and also** B" -> Decorator (cumulative addition)
 
-実務では両者を組み合わせることも多く、例えばログ出力 Strategy をキャッシュ Decorator で包むといった設計が有効です。
+In practice, both are often combined; for example, wrapping a logging Strategy with a caching Decorator is an effective design.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just from theory but by actually writing code and confirming its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in professional practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes particularly important during code reviews and architectural design.
 
 ---
 
-## 9. まとめ
+## 9. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| 目的 | アルゴリズムをカプセル化して交換可能にする |
-| OCP | 新しい戦略を追加しても既存コード変更不要 |
-| 実装方式 | クラスベース（状態あり）/ 関数ベース（軽量） |
-| Registry | 動的選択と拡張性を両立する補助パターン |
-| 関数型 | 関数を渡すだけでも実現可能（Array.sort等） |
-| 判断基準 | 3+バリエーション or 将来の拡張が見込まれる場合に導入 |
-| 注意 | Context は Strategy の具象型を知らない設計にする |
-| 粒度 | 1つの Strategy に1つの責務（ISP の遵守） |
+| Purpose | Encapsulate algorithms to make them interchangeable |
+| OCP | Adding new strategies requires no changes to existing code |
+| Implementation style | Class-based (with state) / Function-based (lightweight) |
+| Registry | A supplementary pattern that balances dynamic selection and extensibility |
+| Functional | Can be implemented simply by passing functions (e.g., Array.sort) |
+| Decision criteria | Introduce when there are 3+ variations or future expansion is expected |
+| Caution | Design Context so it does not know the concrete type of Strategy |
+| Granularity | One responsibility per Strategy (adherence to ISP) |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [Command パターン](./02-command.md) -- 操作のカプセル化と Undo/Redo
-- [State パターン](./03-state.md) -- 状態遷移の管理
-- [Observer パターン](./00-observer.md) -- イベント駆動設計
-- [SOLID 原則](../../../clean-code-principles/docs/00-principles/01-solid.md) -- OCP の詳細
-- [関数型パターン](../03-functional/02-fp-patterns.md) -- 関数合成とパイプライン
+- [Command Pattern](./02-command.md) -- Encapsulation of operations and Undo/Redo
+- [State Pattern](./03-state.md) -- Managing state transitions
+- [Observer Pattern](./00-observer.md) -- Event-driven design
+- [SOLID Principles](../../../clean-code-principles/docs/00-principles/01-solid.md) -- Details on OCP
+- [Functional Patterns](../03-functional/02-fp-patterns.md) -- Function composition and pipelines
 
 ---
 
-## 参考文献
+## References
 
-1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- Strategy パターンの原典。
-2. Freeman, E., Robson, E. (2020). *Head First Design Patterns* (2nd Edition). O'Reilly Media. -- Strategy パターンを最初に扱い、設計原則との関連を丁寧に解説。
-3. Refactoring.Guru -- Strategy. https://refactoring.guru/design-patterns/strategy -- 図解と多言語実装例。
-4. Martin, R.C. (2003). *Agile Software Development: Principles, Patterns, and Practices*. Prentice Hall. -- OCP と Strategy の関係。
-5. Fowler, M. (1999). *Refactoring: Improving the Design of Existing Code*. Addison-Wesley. -- 「条件分岐をポリモーフィズムに置き換える」リファクタリング。
+1. Gamma, E., Helm, R., Johnson, R., Vlissides, J. (1994). *Design Patterns: Elements of Reusable Object-Oriented Software*. Addison-Wesley. -- The original source for the Strategy pattern.
+2. Freeman, E., Robson, E. (2020). *Head First Design Patterns* (2nd Edition). O'Reilly Media. -- Covers the Strategy pattern first and carefully explains its relationship with design principles.
+3. Refactoring.Guru -- Strategy. https://refactoring.guru/design-patterns/strategy -- Illustrated guide with multi-language implementation examples.
+4. Martin, R.C. (2003). *Agile Software Development: Principles, Patterns, and Practices*. Prentice Hall. -- The relationship between OCP and Strategy.
+5. Fowler, M. (1999). *Refactoring: Improving the Design of Existing Code*. Addison-Wesley. -- The "Replace Conditional with Polymorphism" refactoring.

--- a/03-software-design/design-patterns-guide/docs/02-behavioral/02-command.md
+++ b/03-software-design/design-patterns-guide/docs/02-behavioral/02-command.md
@@ -1,55 +1,55 @@
-# Command パターン
+# Command Pattern
 
-> 操作をオブジェクトとしてカプセル化し、Undo/Redo、キューイング、マクロ記録、トランザクション制御を実現する行動パターン
-
----
-
-## この章で学ぶこと
-
-1. **Command パターンの基本構造と GoF の意図** -- コマンドオブジェクトによる操作のカプセル化、実行の遅延・記録・再生の仕組み
-2. **Undo/Redo の設計と実装** -- コマンド履歴を管理し、操作の取り消しとやり直しを実現する設計手法とその内部動作原理
-3. **マクロ・キューイング・トランザクション** -- 複数コマンドの合成、非同期実行キュー、ロールバック付きトランザクション実行
-4. **実プロダクトにおける Command** -- テキストエディタ、Redux、CQRS/Event Sourcing、ゲームリプレイなど現実の適用例
-5. **関数型アプローチとの統合** -- クロージャベース Command、TypeScript の型安全な Command バス
+> A behavioral pattern that encapsulates operations as objects, enabling Undo/Redo, queuing, macro recording, and transaction control
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-| トピック | 必要な理解 | 参照リンク |
+1. **Basic structure and GoF intent of the Command pattern** -- encapsulating operations as command objects, mechanisms for deferred execution, recording, and replay
+2. **Designing and implementing Undo/Redo** -- design techniques for managing command history to enable operation reversal and redo, and how they work internally
+3. **Macros, queuing, and transactions** -- composing multiple commands, asynchronous execution queues, and transactional execution with rollback
+4. **Command in real products** -- practical applications such as text editors, Redux, CQRS/Event Sourcing, and game replays
+5. **Integration with functional approaches** -- closure-based Commands, type-safe Command buses in TypeScript
+
+---
+
+## Prerequisites
+
+| Topic | Required Understanding | Reference Link |
 |---------|-----------|-----------|
-| TypeScript の interface と class | インターフェースの定義と実装、ジェネリクスの基本 | 02-programming |
-| SOLID 原則（特に SRP・OCP） | 単一責任と開放閉鎖原則の理解 | clean-code-principles |
-| Observer パターン | イベント駆動の基本概念 | [00-observer.md](./00-observer.md) |
-| Strategy パターン | アルゴリズムの切り替え | [01-strategy.md](./01-strategy.md) |
-| Promise / async-await | 非同期処理の基本 | 02-programming |
+| TypeScript interfaces and classes | Defining and implementing interfaces, basics of generics | 02-programming |
+| SOLID principles (especially SRP and OCP) | Understanding single responsibility and open/closed principles | clean-code-principles |
+| Observer pattern | Basic concepts of event-driven design | [00-observer.md](./00-observer.md) |
+| Strategy pattern | Switching algorithms | [01-strategy.md](./01-strategy.md) |
+| Promise / async-await | Basics of asynchronous processing | 02-programming |
 
 ---
 
-## なぜ Command パターンが必要なのか
+## Why the Command Pattern Is Needed
 
-### 直接呼び出しの問題
+### Problems with Direct Invocation
 
-ボタンのクリックで「保存」を実行するUIを考えてみましょう。
+Consider a UI where clicking a button triggers a "save" operation.
 
 ```
-直接呼び出しの問題:
+Problems with direct invocation:
 
   ┌──────────┐     ┌──────────────┐
   │ Button   │────►│ Document     │
   │ onClick()│     │ save()       │
   └──────────┘     └──────────────┘
 
-  問題1: ボタンが Document を直接知っている（密結合）
-  問題2: キーボードショートカットでも同じ処理をしたい
-  問題3: Undo したいが、どうやって？
-  問題4: 操作を記録・再生したいが、仕組みがない
+  Problem 1: Button directly knows about Document (tight coupling)
+  Problem 2: Want the same operation triggered by keyboard shortcuts too
+  Problem 3: Want to Undo, but how?
+  Problem 4: Want to record and replay operations, but no mechanism exists
 ```
 
-### Command パターンによる解決
+### Solution with the Command Pattern
 
 ```
-Command パターンの解決:
+Command pattern solution:
 
   ┌──────────┐     ┌──────────────┐     ┌──────────────┐
   │ Button   │────►│  SaveCommand │────►│  Document    │
@@ -57,35 +57,35 @@ Command パターンの解決:
   └──────────┘     │  undo()      │     └──────────────┘
                    │  describe()  │
   ┌──────────┐     └──────────────┘
-  │Shortcut  │────►│ (同じCommand) │
+  │Shortcut  │────►│ (same Command) │
   │ Ctrl+S   │
   └──────────┘
 
-  利点:
-  ✓ Invoker は Command のみ知る（疎結合）
-  ✓ 同じ Command を複数の Invoker から使える
-  ✓ undo() で操作を元に戻せる
-  ✓ Command 履歴で操作ログを保持
-  ✓ Command をシリアライズして永続化できる
+  Benefits:
+  ✓ Invoker only knows about Command (loose coupling)
+  ✓ The same Command can be used from multiple Invokers
+  ✓ undo() allows reversing operations
+  ✓ Command history maintains an operation log
+  ✓ Commands can be serialized and persisted
 ```
 
-GoF の定義:
+GoF definition:
 
 > "Encapsulate a request as an object, thereby letting you parameterize clients with different requests, queue or log requests, and support undoable operations."
 >
 > -- Design Patterns: Elements of Reusable Object-Oriented Software (1994)
 
-Command パターンの本質は **「操作を第一級オブジェクト（first-class object）にする」** ことです。操作がオブジェクトになることで、操作を変数に代入し、配列に格納し、引数として渡し、シリアライズして保存し、ネットワーク越しに送信できるようになります。これは関数型プログラミングにおける「関数が第一級市民」の概念と通じるものです。
+The essence of the Command pattern is **"making operations first-class objects"**. When operations become objects, they can be assigned to variables, stored in arrays, passed as arguments, serialized and saved, and sent over a network. This resonates with the concept of "functions as first-class citizens" in functional programming.
 
 ---
 
-## 1. Command パターンの構造
+## 1. Structure of the Command Pattern
 
 ```
-Command パターンの構成要素（GoF）:
+Command pattern components (GoF):
 
   ┌──────────────┐
-  │    Client    │  コマンドを生成し、Receiver を設定
+  │    Client    │  Creates commands and sets the Receiver
   └──────┬───────┘
          │ creates
          ▼
@@ -110,51 +110,51 @@ Command パターンの構成要素（GoF）:
          │                   ▼              ▼
          │              ┌──────────────────────┐
          │              │     Receiver         │
-         │              │ (実際のビジネスロジック)  │
+         │              │ (actual business logic) │
          │              │                      │
          │              │ + action1()          │
          │              │ + action2()          │
          └─────────────►│                      │
-           直接呼ばない    └──────────────────────┘
+           not called directly └──────────────────────┘
 
   ┌──────────────┐
-  │   History    │  コマンド履歴の管理
-  │              │  Undo/Redo スタック
+  │   History    │  Manages command history
+  │              │  Undo/Redo stacks
   │ + push(cmd)  │
   │ + undo()     │
   │ + redo()     │
   └──────────────┘
 
-各役割:
-  Client   : ConcreteCommand を生成し Receiver を注入
-  Invoker  : Command の execute() を呼ぶ（何をするかは知らない）
-  Command  : execute/undo のインターフェースを定義
-  Receiver : 実際のビジネスロジックを持つ
-  History  : 実行済みコマンドの履歴を保持（Undo/Redo 用）
+Roles:
+  Client   : Creates ConcreteCommand and injects Receiver
+  Invoker  : Calls execute() on Command (does not know what it does)
+  Command  : Defines the execute/undo interface
+  Receiver : Holds the actual business logic
+  History  : Maintains history of executed commands (for Undo/Redo)
 ```
 
 ---
 
-## 2. 基本実装 -- テキストエディタ
+## 2. Basic Implementation -- Text Editor
 
-### コード例 1: 完全なテキストエディタ Command
+### Code Example 1: Complete Text Editor Command
 
 ```typescript
-// command.ts -- Command パターンの基本構造
+// command.ts -- Basic structure of the Command pattern
 
 // ============================
-// Command インターフェース
+// Command interface
 // ============================
 interface Command {
   execute(): void;
   undo(): void;
   describe(): string;
-  /** Undo 不可能な操作かどうかを示すフラグ */
+  /** Flag indicating whether this operation can be undone */
   readonly isUndoable: boolean;
 }
 
 // ============================
-// Receiver: テキストエディタ
+// Receiver: Text editor
 // ============================
 class TextEditor {
   private content: string = '';
@@ -216,7 +216,7 @@ class TextEditor {
 }
 
 // ============================
-// Concrete Command: テキスト挿入
+// Concrete Command: Insert text
 // ============================
 class InsertTextCommand implements Command {
   readonly isUndoable = true;
@@ -241,7 +241,7 @@ class InsertTextCommand implements Command {
 }
 
 // ============================
-// Concrete Command: テキスト削除
+// Concrete Command: Delete text
 // ============================
 class DeleteTextCommand implements Command {
   readonly isUndoable = true;
@@ -267,7 +267,7 @@ class DeleteTextCommand implements Command {
 }
 
 // ============================
-// Concrete Command: テキスト置換
+// Concrete Command: Replace text
 // ============================
 class ReplaceTextCommand implements Command {
   readonly isUndoable = true;
@@ -298,7 +298,7 @@ class ReplaceTextCommand implements Command {
 }
 
 // ============================
-// 使用例
+// Usage example
 // ============================
 const editor = new TextEditor();
 
@@ -323,15 +323,15 @@ console.log(editor.getContent()); // "Hello"
 
 ---
 
-## 3. Undo/Redo マネージャー
+## 3. Undo/Redo Manager
 
-### コード例 2: 高機能 Undo/Redo マネージャー
+### Code Example 2: Full-Featured Undo/Redo Manager
 
 ```typescript
-// undo-redo-manager.ts -- Undo/Redo の管理
+// undo-redo-manager.ts -- Managing Undo/Redo
 
 // ============================
-// イベント通知付き UndoRedoManager
+// UndoRedoManager with event notifications
 // ============================
 type HistoryEvent =
   | { type: 'execute'; command: Command }
@@ -353,23 +353,23 @@ class UndoRedoManager {
     this.maxHistory = maxHistory;
   }
 
-  /** コマンドを実行し、Undo スタックに追加 */
+  /** Execute a command and add it to the Undo stack */
   execute(command: Command): void {
     command.execute();
 
     if (this.batchLevel > 0) {
-      // バッチモード中はバッチに蓄積
+      // Accumulate in batch during batch mode
       this.batchCommands.push(command);
       return;
     }
 
     this.undoStack.push(command);
 
-    // 新しいコマンド実行時は Redo スタックをクリア
-    // (分岐した履歴は破棄される)
+    // Clear the Redo stack when a new command is executed
+    // (branched history is discarded)
     this.redoStack = [];
 
-    // 履歴の上限を超えたら古いものを削除
+    // Remove oldest entry if history exceeds the limit
     if (this.undoStack.length > this.maxHistory) {
       this.undoStack.shift();
     }
@@ -377,7 +377,7 @@ class UndoRedoManager {
     this.notify({ type: 'execute', command });
   }
 
-  /** 直前のコマンドを取り消す */
+  /** Undo the most recent command */
   undo(): boolean {
     const command = this.undoStack.pop();
     if (!command) return false;
@@ -388,7 +388,7 @@ class UndoRedoManager {
     return true;
   }
 
-  /** 取り消したコマンドをやり直す */
+  /** Redo an undone command */
   redo(): boolean {
     const command = this.redoStack.pop();
     if (!command) return false;
@@ -399,7 +399,7 @@ class UndoRedoManager {
     return true;
   }
 
-  /** バッチ操作の開始（複数操作を1つの Undo 単位にまとめる） */
+  /** Begin a batch operation (group multiple operations as one Undo unit) */
   beginBatch(): void {
     this.batchLevel++;
     if (this.batchLevel === 1) {
@@ -407,7 +407,7 @@ class UndoRedoManager {
     }
   }
 
-  /** バッチ操作の終了 */
+  /** End a batch operation */
   endBatch(description?: string): void {
     this.batchLevel--;
     if (this.batchLevel === 0 && this.batchCommands.length > 0) {
@@ -442,14 +442,14 @@ class UndoRedoManager {
     return this.redoStack.length;
   }
 
-  /** 全履歴をクリア */
+  /** Clear all history */
   clear(): void {
     this.undoStack = [];
     this.redoStack = [];
     this.notify({ type: 'clear' });
   }
 
-  /** 履歴変更のリスナーを追加 */
+  /** Add a listener for history changes */
   subscribe(listener: HistoryListener): () => void {
     this.listeners.push(listener);
     return () => {
@@ -465,12 +465,12 @@ class UndoRedoManager {
 }
 
 // ============================
-// 使用例
+// Usage example
 // ============================
 const editor2 = new TextEditor();
 const manager = new UndoRedoManager();
 
-// イベント監視
+// Monitor events
 manager.subscribe(event => {
   console.log(`[History] ${event.type}: ${
     event.type !== 'clear' ? event.command.describe() : 'all'
@@ -493,19 +493,19 @@ manager.redo();
 // [History] redo: Insert " World" at position 5
 console.log(editor2.getContent()); // "Hello World"
 
-// バッチ操作: 「検索と置換」を1つの Undo 単位に
+// Batch operation: combine "Find and Replace" into one Undo unit
 manager.beginBatch();
 manager.execute(new DeleteTextCommand(editor2, 0, 5));
 manager.execute(new InsertTextCommand(editor2, 0, 'Hi'));
 manager.endBatch('Replace "Hello" with "Hi"');
 
 console.log(editor2.getContent()); // "Hi World"
-manager.undo(); // バッチ全体が1回の Undo で元に戻る
+manager.undo(); // The entire batch is undone with one Undo
 console.log(editor2.getContent()); // "Hello World"
 ```
 
 ```
-Undo/Redo のスタック操作の詳細:
+Detailed Undo/Redo stack operations:
 
   execute("Hello")  execute(" World")   undo()           redo()
   ┌─────────┐      ┌─────────┐       ┌─────────┐      ┌─────────┐
@@ -517,38 +517,38 @@ Undo/Redo のスタック操作の詳細:
   │         │      │└───────┘│       │         │      │└───────┘│
   ├─────────┤      ├─────────┤       ├─────────┤      ├─────────┤
   │ Redo    │      │ Redo    │       │ Redo    │      │ Redo    │
-  │ (空)    │      │ (空)    │       │┌───────┐│      │ (空)    │
+  │ (empty) │      │ (empty) │       │┌───────┐│      │ (empty) │
   │         │      │         │       ││"World"││      │         │
   │         │      │         │       │└───────┘│      │         │
   └─────────┘      └─────────┘       └─────────┘      └─────────┘
 
-  ★ 重要: undo() 後に新しい execute() を行うと、
-    Redo スタックは全てクリアされる（分岐履歴は失われる）
+  ★ Important: If a new execute() is called after undo(),
+    the Redo stack is completely cleared (branched history is lost)
 
-  分岐が発生する場面:
+  When branching occurs:
   execute(A) → execute(B) → undo() → execute(C)
-                                      ↑ この時点で B は Redo 不可能に
+                                      ↑ At this point B can no longer be redone
 
   ┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐
   │Undo: │    │Undo: │    │Undo: │    │Undo: │
   │  [A] │    │[A,B] │    │  [A] │    │[A,C] │
   │      │    │      │    │      │    │      │
   │Redo: │    │Redo: │    │Redo: │    │Redo: │
-  │  []  │    │  []  │    │  [B] │    │  []  │ ← B は消えた
+  │  []  │    │  []  │    │  [B] │    │  []  │ ← B is gone
   └──────┘    └──────┘    └──────┘    └──────┘
 ```
 
 ---
 
-## 4. マクロコマンド（Composite Command）
+## 4. Macro Command (Composite Command)
 
-### コード例 3: マクロの記録と再生
+### Code Example 3: Recording and Replaying Macros
 
 ```typescript
-// macro-command.ts -- 複数コマンドの合成（Composite パターンとの組合せ）
+// macro-command.ts -- Composing multiple commands (combination with Composite pattern)
 
 // ============================
-// MacroCommand: 複数コマンドを1つにまとめる
+// MacroCommand: Combines multiple commands into one
 // ============================
 class MacroCommand implements Command {
   readonly isUndoable = true;
@@ -572,7 +572,7 @@ class MacroCommand implements Command {
   }
 
   undo(): void {
-    // 逆順で Undo（LIFO: 最後に実行したものから戻す）
+    // Undo in reverse order (LIFO: revert from the last executed)
     for (let i = this.commands.length - 1; i >= 0; i--) {
       this.commands[i].undo();
     }
@@ -585,7 +585,7 @@ class MacroCommand implements Command {
 }
 
 // ============================
-// MacroRecorder: ユーザー操作の記録・再生
+// MacroRecorder: Record and replay user operations
 // ============================
 class MacroRecorder {
   private recording: boolean = false;
@@ -626,16 +626,16 @@ class MacroRecorder {
 }
 
 // ============================
-// 使用例: テキスト整形マクロ
+// Usage example: Text formatting macro
 // ============================
 const editorMacro = new TextEditor();
 const managerMacro = new UndoRedoManager();
 const recorder = new MacroRecorder();
 
-// マクロの記録開始
+// Start recording the macro
 recorder.startRecording();
 
-// 操作を記録しつつ実行
+// Execute operations while recording them
 const m1 = new InsertTextCommand(editorMacro, 0, '# ');
 recorder.recordCommand(m1);
 managerMacro.execute(m1);
@@ -646,40 +646,40 @@ const m2 = new InsertTextCommand(
 recorder.recordCommand(m2);
 managerMacro.execute(m2);
 
-// マクロを名前付きで保存
+// Save macro with a name
 const formatMacro = recorder.stopRecording('heading-format');
 
 console.log(editorMacro.getContent());
 // "# \n---\n"
 
-// マクロを別のテキストに再適用
-// ※ 新しい editor でコマンドを再生成する必要がある点に注意
+// Re-apply the macro to another text
+// Note: commands need to be recreated for a new editor
 ```
 
 ---
 
-## 5. 非同期コマンドキュー
+## 5. Asynchronous Command Queue
 
-### コード例 4: リトライ・ロールバック付き非同期キュー
+### Code Example 4: Async Queue with Retry and Rollback
 
 ```typescript
-// command-queue.ts -- 非同期コマンドの順序実行
+// command-queue.ts -- Sequential execution of async commands
 
 // ============================
-// AsyncCommand インターフェース
+// AsyncCommand interface
 // ============================
 interface AsyncCommand {
   execute(): Promise<void>;
   undo(): Promise<void>;
   describe(): string;
-  /** リトライ可能かどうか */
+  /** Whether the command can be retried */
   canRetry(): boolean;
-  /** 最大リトライ回数 */
+  /** Maximum number of retries */
   maxRetries: number;
 }
 
 // ============================
-// CommandQueue: 順序実行キュー
+// CommandQueue: Sequential execution queue
 // ============================
 type QueueEvent =
   | { type: 'enqueue'; command: AsyncCommand }
@@ -724,7 +724,7 @@ class CommandQueue {
       this.notify({ type: 'fail', command: entry.command, error: err });
 
       if (entry.command.canRetry() && entry.retries < entry.command.maxRetries) {
-        // リトライ: キューの先頭に戻す
+        // Retry: put back at the front of the queue
         entry.retries++;
         this.notify({
           type: 'retry',
@@ -733,7 +733,7 @@ class CommandQueue {
         });
         this.queue.unshift(entry);
       } else {
-        // 失敗時のロールバック
+        // Rollback on failure
         await this.rollback();
       }
     } finally {
@@ -755,11 +755,11 @@ class CommandQueue {
         this.notify({ type: 'rollback', command: cmd });
       } catch (err) {
         console.error(`Rollback failed for: ${cmd.describe()}`, err);
-        // 補償トランザクションのロールバック失敗は
-        // 人間の介入が必要な場面 → アラート
+        // A rollback failure in a compensating transaction
+        // requires human intervention → alert
       }
     }
-    // ロールバック後はキューも全てクリア
+    // Clear the entire queue after rollback
     this.queue = [];
   }
 
@@ -778,7 +778,7 @@ class CommandQueue {
 }
 
 // ============================
-// 使用例: API コール のトランザクション
+// Usage example: API call transaction
 // ============================
 class CreateUserCommand implements AsyncCommand {
   maxRetries = 2;
@@ -787,7 +787,7 @@ class CreateUserCommand implements AsyncCommand {
   constructor(private userData: { name: string; email: string }) {}
 
   async execute(): Promise<void> {
-    // API 呼び出し (シミュレーション)
+    // API call (simulation)
     console.log(`Creating user: ${this.userData.name}`);
     this.userId = `user_${Date.now()}`;
   }
@@ -810,7 +810,7 @@ class SendWelcomeEmailCommand implements AsyncCommand {
 
   async execute(): Promise<void> {
     console.log(`Sending welcome email to: ${this.email}`);
-    // ネットワークエラーのシミュレーション
+    // Simulate network error
     if (Math.random() < 0.3) {
       throw new Error('SMTP connection timeout');
     }
@@ -824,7 +824,7 @@ class SendWelcomeEmailCommand implements AsyncCommand {
   describe(): string { return `SendEmail(${this.email})`; }
 }
 
-// キューの使用
+// Using the queue
 const queue = new CommandQueue();
 
 queue.subscribe(event => {
@@ -849,12 +849,12 @@ queue.enqueueAll([
 
 ---
 
-## 6. Python での Command パターン
+## 6. Command Pattern in Python
 
-### コード例 5: Python Protocol ベースの Command
+### Code Example 5: Protocol-Based Command in Python
 
 ```python
-# command_python.py -- Python での Command パターン実装
+# command_python.py -- Command pattern implementation in Python
 from __future__ import annotations
 from typing import Protocol, runtime_checkable
 from dataclasses import dataclass, field
@@ -862,7 +862,7 @@ from datetime import datetime
 
 
 # ============================
-# Command プロトコル
+# Command protocol
 # ============================
 @runtime_checkable
 class Command(Protocol):
@@ -872,7 +872,7 @@ class Command(Protocol):
 
 
 # ============================
-# Receiver: スプレッドシート
+# Receiver: Spreadsheet
 # ============================
 class Spreadsheet:
     def __init__(self, rows: int = 100, cols: int = 26):
@@ -900,7 +900,7 @@ class Spreadsheet:
 
 
 # ============================
-# Concrete Command: セル値の設定
+# Concrete Command: Set cell value
 # ============================
 @dataclass
 class SetCellCommand:
@@ -926,7 +926,7 @@ class SetCellCommand:
 
 
 # ============================
-# Concrete Command: 範囲の一括クリア
+# Concrete Command: Clear a range in bulk
 # ============================
 @dataclass
 class ClearRangeCommand:
@@ -955,7 +955,7 @@ class ClearRangeCommand:
 
 
 # ============================
-# UndoRedoManager (Python 版)
+# UndoRedoManager (Python version)
 # ============================
 @dataclass
 class UndoRedoManager:
@@ -991,7 +991,7 @@ class UndoRedoManager:
 
 
 # ============================
-# 使用例
+# Usage example
 # ============================
 if __name__ == "__main__":
     sheet = Spreadsheet()
@@ -1007,11 +1007,11 @@ if __name__ == "__main__":
     print(f"A2={sheet.get_cell(1, 0)}, B2={sheet.get_cell(1, 1)}")
     # A2=Alice, B2=30
 
-    mgr.undo()  # B2 = 30 を取り消し
+    mgr.undo()  # Undo B2 = 30
     print(f"B2 after undo: {sheet.get_cell(1, 1)}")
     # B2 after undo: None
 
-    mgr.redo()  # B2 = 30 を復元
+    mgr.redo()  # Restore B2 = 30
     print(f"B2 after redo: {sheet.get_cell(1, 1)}")
     # B2 after redo: 30
 
@@ -1021,15 +1021,15 @@ if __name__ == "__main__":
 
 ---
 
-## 7. 関数型 Command -- クロージャベース
+## 7. Functional Command -- Closure-Based
 
-### コード例 6: クロージャと高階関数による Command
+### Code Example 6: Command Using Closures and Higher-Order Functions
 
 ```typescript
-// functional-command.ts -- 関数型アプローチの Command パターン
+// functional-command.ts -- Functional approach to the Command pattern
 
 // ============================
-// 関数型 Command の型定義
+// Type definition for functional Command
 // ============================
 interface FunctionalCommand {
   execute: () => void;
@@ -1038,7 +1038,7 @@ interface FunctionalCommand {
 }
 
 // ============================
-// Command ファクトリ
+// Command factories
 // ============================
 function createInsertCommand(
   editor: TextEditor,
@@ -1066,7 +1066,7 @@ function createDeleteCommand(
 }
 
 // ============================
-// 汎用 Command ファクトリ（任意の操作をコマンドに）
+// Generic Command factory (converts any operation into a command)
 // ============================
 function makeCommand(
   doFn: () => void,
@@ -1081,7 +1081,7 @@ function makeCommand(
 }
 
 // ============================
-// 関数型 UndoRedoManager
+// Functional UndoRedoManager
 // ============================
 function createUndoRedoManager() {
   const undoStack: FunctionalCommand[] = [];
@@ -1114,7 +1114,7 @@ function createUndoRedoManager() {
 }
 
 // ============================
-// 使用例: クラス不要の軽量 Command
+// Usage example: lightweight Command without classes
 // ============================
 const ed = new TextEditor();
 const mgr = createUndoRedoManager();
@@ -1126,7 +1126,7 @@ console.log(ed.getContent()); // "Hello World"
 mgr.undo();
 console.log(ed.getContent()); // "Hello"
 
-// 任意の操作もコマンドに変換可能
+// Any operation can be converted into a command
 let logBuffer: string[] = [];
 mgr.execute(makeCommand(
   () => logBuffer.push('entry'),
@@ -1137,20 +1137,20 @@ mgr.execute(makeCommand(
 
 ---
 
-## 8. 型安全な Command バス
+## 8. Type-Safe Command Bus
 
-### コード例 7: TypeScript のジェネリクスを活用した Command バス
+### Code Example 7: Command Bus Using TypeScript Generics
 
 ```typescript
-// command-bus.ts -- 型安全な Command ディスパッチ
+// command-bus.ts -- Type-safe Command dispatching
 
 // ============================
-// Command と Handler の型定義
+// Type definitions for Command and Handler
 // ============================
 interface TypedCommand<TName extends string, TPayload, TResult> {
   readonly type: TName;
   readonly payload: TPayload;
-  // TResult は型レベルの情報のみ（実行時に使用しない）
+  // TResult is type-level information only (not used at runtime)
   readonly __result?: TResult;
 }
 
@@ -1158,7 +1158,7 @@ type CommandHandler<C extends TypedCommand<string, unknown, unknown>> =
   (command: C) => C extends TypedCommand<string, unknown, infer R> ? R : never;
 
 // ============================
-// Command バス
+// Command bus
 // ============================
 class CommandBus {
   private handlers = new Map<string, CommandHandler<any>>();
@@ -1167,7 +1167,7 @@ class CommandBus {
     next: () => unknown
   ) => unknown> = [];
 
-  /** ハンドラの登録 */
+  /** Register a handler */
   register<C extends TypedCommand<string, unknown, unknown>>(
     type: C['type'],
     handler: CommandHandler<C>
@@ -1175,7 +1175,7 @@ class CommandBus {
     this.handlers.set(type, handler);
   }
 
-  /** ミドルウェアの追加（ロギング、認証等） */
+  /** Add middleware (logging, authentication, etc.) */
   use(
     middleware: (
       command: TypedCommand<string, unknown, unknown>,
@@ -1185,7 +1185,7 @@ class CommandBus {
     this.middleware.push(middleware);
   }
 
-  /** コマンドのディスパッチ */
+  /** Dispatch a command */
   dispatch<C extends TypedCommand<string, unknown, unknown>>(
     command: C
   ): C extends TypedCommand<string, unknown, infer R> ? R : never {
@@ -1194,7 +1194,7 @@ class CommandBus {
       throw new Error(`No handler registered for command: ${command.type}`);
     }
 
-    // ミドルウェアチェーンの構築
+    // Build the middleware chain
     const chain = this.middleware.reduceRight(
       (next, mw) => () => mw(command, next),
       () => handler(command)
@@ -1205,7 +1205,7 @@ class CommandBus {
 }
 
 // ============================
-// 具体的なコマンド定義
+// Concrete command definitions
 // ============================
 type CreateOrderCommand = TypedCommand<
   'CreateOrder',
@@ -1220,11 +1220,11 @@ type CancelOrderCommand = TypedCommand<
 >;
 
 // ============================
-// 使用例
+// Usage example
 // ============================
 const bus = new CommandBus();
 
-// ロギングミドルウェア
+// Logging middleware
 bus.use((command, next) => {
   console.log(`[CommandBus] Dispatching: ${command.type}`, command.payload);
   const start = performance.now();
@@ -1234,7 +1234,7 @@ bus.use((command, next) => {
   return result;
 });
 
-// ハンドラ登録
+// Register handlers
 bus.register<CreateOrderCommand>('CreateOrder', (cmd) => {
   console.log(`Creating order for user: ${cmd.payload.userId}`);
   return { orderId: `ORD-${Date.now()}` };
@@ -1245,213 +1245,213 @@ bus.register<CancelOrderCommand>('CancelOrder', (cmd) => {
   return { refundAmount: 1500 };
 });
 
-// ディスパッチ（型安全: 戻り値が自動推論される）
+// Dispatch (type-safe: return type is inferred automatically)
 const result = bus.dispatch<CreateOrderCommand>({
   type: 'CreateOrder',
   payload: { userId: 'u1', items: [{ sku: 'SKU-001', qty: 2 }] },
 });
-console.log(result.orderId); // 型安全: string
+console.log(result.orderId); // Type-safe: string
 ```
 
 ---
 
-## 9. 深掘り: Command パターンの内部設計判断
+## 9. Deep Dive: Internal Design Decisions of the Command Pattern
 
-### Undo 実装の3方式比較
+### Comparison of 3 Undo Implementation Approaches
 
 ```
-方式1: Command 履歴 (Command Pattern)
-  各コマンドが undo() を持ち、逆操作を実行
+Approach 1: Command History (Command Pattern)
+  Each command holds an undo() that executes the inverse operation
   ┌─────┐  ┌─────┐  ┌─────┐
-  │ C1  │→│ C2  │→│ C3  │  ← Undo スタック
+  │ C1  │→│ C2  │→│ C3  │  ← Undo stack
   │undo │  │undo │  │undo │
   └─────┘  └─────┘  └─────┘
-  メモリ: 差分のみ保持（省メモリ）
-  速度:   O(1) per undo
+  Memory: Only diffs are stored (memory-efficient)
+  Speed:  O(1) per undo
 
-方式2: Memento (スナップショット)
-  操作前の全状態を保存
+Approach 2: Memento (Snapshot)
+  Saves the entire state before each operation
   ┌───────┐  ┌───────┐  ┌───────┐
-  │State 0│  │State 1│  │State 2│  ← スナップショット
-  │(全体) │  │(全体) │  │(全体) │
+  │State 0│  │State 1│  │State 2│  ← Snapshots
+  │(full) │  │(full) │  │(full) │
   └───────┘  └───────┘  └───────┘
-  メモリ: 状態サイズ × 履歴数（大量消費）
-  速度:   O(1) per undo（スワップのみ）
+  Memory: State size × history count (heavy consumption)
+  Speed:  O(1) per undo (just swap)
 
-方式3: Event Sourcing
-  全イベントを記録し、再生で状態を再構築
+Approach 3: Event Sourcing
+  Records all events and rebuilds state by replaying them
   ┌─────┐  ┌─────┐  ┌─────┐
-  │ E1  │→│ E2  │→│ E3  │  ← イベントログ
-  │(追記)│  │(追記)│  │(追記)│
+  │ E1  │→│ E2  │→│ E3  │  ← Event log
+  │(append)│  │(append)│  │(append)│
   └─────┘  └─────┘  └─────┘
-  メモリ: イベントサイズ × 件数
-  速度:   O(N) per undo（先頭から再生）
-  ※スナップショットで高速化可能
+  Memory: Event size × count
+  Speed:  O(N) per undo (replay from the beginning)
+  ※ Can be optimized with snapshots
 ```
 
-| 比較項目 | Command 履歴 | Memento | Event Sourcing |
+| Comparison | Command History | Memento | Event Sourcing |
 |---------|-------------|---------|----------------|
-| メモリ使用 | 低い（差分のみ） | 高い（全状態 x N） | 中（イベント列） |
-| 実装の複雑さ | 中 | 低い | 高い |
-| 部分的 Undo | 困難 | 不可 | 可能 |
-| 永続化 | 容易 | 容易 | 容易 |
-| 監査証跡 | 操作ログとして利用可 | 不向き | 最適 |
-| デバッグ容易性 | 中 | 高い（状態を直接確認） | 高い（リプレイ可能） |
-| 適用場面 | エディタ、操作記録 | ゲームのセーブ | ドメインイベント記録 |
+| Memory usage | Low (diffs only) | High (full state x N) | Medium (event sequence) |
+| Implementation complexity | Medium | Low | High |
+| Partial Undo | Difficult | Not possible | Possible |
+| Persistence | Easy | Easy | Easy |
+| Audit trail | Usable as operation log | Not suitable | Optimal |
+| Debuggability | Medium | High (direct state inspection) | High (replayable) |
+| Use cases | Editors, operation recording | Game saves | Domain event recording |
 
-### Command の粒度設計
+### Designing Command Granularity
 
-Command の粒度（1つのコマンドがカバーする操作の範囲）は、ユーザー体験に直結する重要な設計判断です。
+Command granularity (the scope of operations a single command covers) is an important design decision that directly affects user experience.
 
 ```
-粒度が細かすぎる場合:
-  1文字ずつ Command → Undo が1文字ずつ戻る（UX が悪い）
-  "Hello" = 5 Commands → 5回 Undo して初めて消える
+When granularity is too fine:
+  One command per character → Undo reverts one character at a time (poor UX)
+  "Hello" = 5 Commands → requires 5 Undos to erase
 
-粒度が粗すぎる場合:
-  1ページ全体で1 Command → 小さな変更の Undo で大量の変更が消える
+When granularity is too coarse:
+  One command per entire page → Undoing a small change erases a large amount
 
-理想的な粒度:
+Ideal granularity:
   ┌────────────────────────────────────────────┐
-  │ ユーザーの「意図」に対応する単位             │
+  │ Units corresponding to the user's "intent" │
   │                                            │
-  │ 例: テキストエディタ                         │
-  │   - 単語の入力 → 1 Command                  │
-  │   - Backspace で単語削除 → 1 Command        │
-  │   - 検索と置換 → 1 Command（MacroCommand）  │
-  │   - 書式変更 → 1 Command                    │
+  │ Example: Text editor                       │
+  │   - Typing a word → 1 Command              │
+  │   - Deleting a word with Backspace → 1 Command │
+  │   - Find and replace → 1 Command (MacroCommand) │
+  │   - Formatting change → 1 Command          │
   │                                            │
-  │ 例: グラフィックエディタ                      │
-  │   - 図形の移動 → 1 Command                  │
-  │   - 複数選択して移動 → 1 Command             │
-  │   - 色変更 → 1 Command                      │
+  │ Example: Graphics editor                   │
+  │   - Moving a shape → 1 Command             │
+  │   - Multi-select and move → 1 Command      │
+  │   - Color change → 1 Command               │
   └────────────────────────────────────────────┘
 
-バッファリングによる粒度制御:
-  入力開始 → タイマー開始
-  入力中   → バッファに蓄積
-  500ms 無入力 or Enter → Command 確定
+Granularity control through buffering:
+  Start typing → start timer
+  While typing → accumulate in buffer
+  500ms of no input or Enter → finalize Command
 
   "H" "e" "l" "l" "o" [500ms] → InsertCommand("Hello")
 ```
 
 ---
 
-## 10. 実世界での Command パターン
+## 10. Command Pattern in the Real World
 
-### Redux / Flux アーキテクチャ
+### Redux / Flux Architecture
 
 ```
-Redux は Command パターンの変形:
+Redux is a variation of the Command pattern:
 
-  Action     = Command（type + payload で操作を記述）
-  Reducer    = execute()（状態を更新）
+  Action     = Command (describes an operation with type + payload)
+  Reducer    = execute() (updates state)
   Store      = Invoker + History
-  Middleware = Command の前後にフック
+  Middleware = hooks before/after Command
 
   dispatch({ type: 'ADD_TODO', payload: { text: '...' } })
   ↓
   [Middleware] → [Reducer] → [New State]
 
-  Redux DevTools = Undo/Redo マネージャー
-    - 全 Action の履歴を保持
-    - タイムトラベルデバッグ（任意の時点に戻る）
-    - Action のリプレイ
+  Redux DevTools = Undo/Redo manager
+    - Maintains history of all Actions
+    - Time-travel debugging (go back to any point)
+    - Action replay
 ```
 
-### Git の操作モデル
+### Git's Operation Model
 
 ```
-Git は Command パターンの具体例:
+Git is a concrete example of the Command pattern:
 
-  git commit   = execute()    新しいスナップショットを記録
-  git revert   = undo()       補償コミットで変更を打ち消す
-  git cherry-pick = コマンドの再適用
-  git reflog   = Command 履歴
+  git commit      = execute()     Records a new snapshot
+  git revert      = undo()        Negates changes with a compensating commit
+  git cherry-pick = re-applying a command
+  git reflog      = Command history
 
-  ※ git reset --hard は「Memento 方式」（状態を直接復元）
-  ※ git revert は「Command 方式」（逆操作を追加）
+  ※ git reset --hard uses the "Memento approach" (directly restores state)
+  ※ git revert uses the "Command approach" (adds the inverse operation)
 ```
 
-### ゲームのリプレイシステム
+### Game Replay Systems
 
 ```
-ゲームリプレイ = Command のシリアライズと再生:
+Game replay = Serializing and replaying Commands:
 
-  記録フェーズ:
+  Recording phase:
   Frame 1: [MoveCommand(player, {x:1, y:0})]
   Frame 2: [AttackCommand(player, target)]
   Frame 3: [MoveCommand(player, {x:0, y:1}), UseItemCommand(player, potion)]
   ...
 
-  再生フェーズ:
-  同じ初期状態 + 同じ Command 列 → 同じ結果（決定的実行）
+  Replay phase:
+  Same initial state + same Command sequence → same result (deterministic execution)
 
-  圧縮: 同種の連続コマンドをマージ
-  Frame 1-10: MoveCommand(player, {x:10, y:0})  ← 10フレーム分をまとめ
+  Compression: merge consecutive commands of the same type
+  Frame 1-10: MoveCommand(player, {x:10, y:0})  ← 10 frames combined
 ```
 
 ---
 
-## 11. 比較表
+## 11. Comparison Tables
 
-### Command vs 他のパターン
+### Command vs Other Patterns
 
-| 特性 | Command | Strategy | Observer | Memento |
+| Characteristic | Command | Strategy | Observer | Memento |
 |------|---------|----------|----------|---------|
-| 目的 | 操作のカプセル化 | アルゴリズムの切替 | 状態変化の通知 | 状態の保存・復元 |
-| Undo/Redo | 対応（逆操作） | 非対応 | 非対応 | 対応（スナップショット） |
-| 履歴管理 | 可能 | 不要 | 不要 | 可能 |
-| 遅延実行 | 可能 | 即座に実行 | イベント駆動 | 即座に保存 |
-| キューイング | 可能 | 不要 | 不要 | 不要 |
-| シリアライズ | 容易 | 困難 | 不要 | 容易 |
-| メモリ効率 | 高い（差分） | -- | -- | 低い（全状態） |
+| Purpose | Encapsulate operations | Switch algorithms | Notify state changes | Save/restore state |
+| Undo/Redo | Supported (inverse operation) | Not supported | Not supported | Supported (snapshot) |
+| History management | Possible | Not needed | Not needed | Possible |
+| Deferred execution | Possible | Executes immediately | Event-driven | Saves immediately |
+| Queuing | Possible | Not needed | Not needed | Not needed |
+| Serialization | Easy | Difficult | Not needed | Easy |
+| Memory efficiency | High (diffs) | -- | -- | Low (full state) |
 
-### Command の実装アプローチ比較
+### Comparison of Command Implementation Approaches
 
-| アプローチ | クラスベース | 関数型（クロージャ） | オブジェクトリテラル |
+| Approach | Class-based | Functional (closure) | Object literal |
 |-----------|-------------|-------------------|-------------------|
-| Undo | execute/undo メソッド | do/undo クロージャ | execute/undo プロパティ |
-| 型安全性 | インターフェースで強い | 型定義が必要 | 型定義が必要 |
-| シリアライズ | 容易（クラス名 + パラメータ） | 困難（クロージャは直列化不可） | 困難 |
-| テスタビリティ | モック容易 | 関数の差し替え容易 | 同左 |
-| ボイラープレート | 多い | 少ない | 少ない |
-| 適用場面 | 大規模、シリアライズ要 | 軽量、一時的 | 中規模 |
+| Undo | execute/undo methods | do/undo closures | execute/undo properties |
+| Type safety | Strong with interface | Requires type definitions | Requires type definitions |
+| Serialization | Easy (class name + params) | Difficult (closures cannot be serialized) | Difficult |
+| Testability | Easy to mock | Easy to swap functions | Same as left |
+| Boilerplate | More | Less | Less |
+| Use cases | Large-scale, requires serialization | Lightweight, temporary | Medium-scale |
 
-### Command パターンの導入判断
+### Decision Criteria for Introducing the Command Pattern
 
-| 判断基準 | Command パターンが有効 | 直接関数呼び出しで十分 |
+| Criterion | Command pattern is effective | Direct function call is sufficient |
 |---------|---------------------|---------------------|
-| Undo/Redo | 必要 | 不要 |
-| 操作のログ記録 | 必要（監査、デバッグ） | 不要 |
-| 遅延実行 / キューイング | 必要 | 不要 |
-| マクロ記録 | 必要 | 不要 |
-| シリアライズ / ネットワーク送信 | 必要 | 不要 |
-| 操作の種類 | 多い・増える予定 | 少ない・固定 |
+| Undo/Redo | Required | Not needed |
+| Operation logging | Required (audit, debugging) | Not needed |
+| Deferred execution / Queuing | Required | Not needed |
+| Macro recording | Required | Not needed |
+| Serialization / Network transmission | Required | Not needed |
+| Number of operation types | Many or expected to grow | Few and fixed |
 
 ---
 
-## 12. アンチパターン
+## 12. Anti-Patterns
 
-### アンチパターン 1: コマンドの粒度が不適切
+### Anti-Pattern 1: Inappropriate Command Granularity
 
 ```typescript
 // ============================
-// [NG] 1文字ごとにコマンドを生成
+// [NG] Creating a command for each character
 // ============================
-// Undo が1文字ずつ戻る、メモリも浪費
+// Undo reverts one character at a time, also wastes memory
 manager.execute(new InsertTextCommand(editor, 0, 'H'));
 manager.execute(new InsertTextCommand(editor, 1, 'e'));
 manager.execute(new InsertTextCommand(editor, 2, 'l'));
 manager.execute(new InsertTextCommand(editor, 3, 'l'));
 manager.execute(new InsertTextCommand(editor, 4, 'o'));
-// Undo 5回で "Hello" → "Hell" → "Hel" → "He" → "H" → ""
-// ユーザーの期待: Undo 1回で "Hello" が消える
+// Undo 5 times: "Hello" → "Hell" → "Hel" → "He" → "H" → ""
+// User expectation: 1 Undo removes "Hello"
 
 // ============================
-// [OK] 意味のある単位でコマンドを生成
+// [OK] Create commands at meaningful units
 // ============================
-// 入力をバッファリングし、一定時間の無入力でコマンドを確定
+// Buffer input and finalize the command after a period of inactivity
 class BufferedTextInput {
   private buffer: string = '';
   private bufferStart: number = 0;
@@ -1463,34 +1463,34 @@ class BufferedTextInput {
     private debounceMs: number = 500
   ) {}
 
-  /** 1文字入力のたびに呼ばれる */
+  /** Called on each character input */
   type(char: string): void {
     if (this.buffer === '') {
       this.bufferStart = this.editor.getCursorPosition();
     }
-    // エディタに直接挿入（Command 経由ではない）
+    // Insert directly into editor (not through a Command)
     this.editor.insertAt(this.editor.getCursorPosition(), char);
     this.buffer += char;
 
-    // デバウンス: 一定時間入力がなければ Command を確定
+    // Debounce: finalize Command after a period of no input
     if (this.timer) clearTimeout(this.timer);
     this.timer = setTimeout(() => this.flush(), this.debounceMs);
   }
 
-  /** Enter キーや操作切り替え時にも呼ぶ */
+  /** Also called on Enter key or when switching operations */
   flush(): void {
     if (this.buffer) {
-      // ★ すでに editor には反映済みなので、
-      //    undo 用に逆操作を記録するだけの Command を作る
+      // ★ Already applied to editor,
+      //    so just create a Command to record the inverse for undo
       const text = this.buffer;
       const start = this.bufferStart;
       const cmd: Command = {
         isUndoable: true,
-        execute: () => { /* 既に反映済み */ },
+        execute: () => { /* already applied */ },
         undo: () => this.editor.deleteRange(start, start + text.length),
         describe: () => `Type "${text}"`,
       };
-      // execute() は呼ばず、履歴にだけ追加
+      // Do not call execute(); only add to history
       this.manager['undoStack'].push(cmd);
       this.buffer = '';
     }
@@ -1498,29 +1498,29 @@ class BufferedTextInput {
 }
 ```
 
-### アンチパターン 2: Undo 不可能なコマンドの放置
+### Anti-Pattern 2: Leaving Non-Undoable Commands Without Proper Declaration
 
 ```typescript
 // ============================
-// [NG] undo() が実装されていない（空のメソッド）
+// [NG] undo() is not implemented (empty method)
 // ============================
 class SendEmailCommand implements Command {
-  readonly isUndoable = true; // 嘘の宣言!
+  readonly isUndoable = true; // False declaration!
 
   execute(): void {
     emailService.send(this.email);
   }
 
   undo(): void {
-    // 何もしない...?? 送信済みメールは取り消せないのに
-    // isUndoable = true なので、ユーザーは Undo できると期待する
+    // Does nothing...?? A sent email cannot be unsent,
+    // but isUndoable = true makes the user expect undo to work
   }
 
   describe(): string { return `Send email to ${this.email}`; }
 }
 
 // ============================
-// [OK 方法1] 補償アクション (Compensating Action) を定義
+// [OK Option 1] Define a compensating action
 // ============================
 class SendEmailCommandV2 implements Command {
   readonly isUndoable = true;
@@ -1529,16 +1529,16 @@ class SendEmailCommandV2 implements Command {
   constructor(private email: string) {}
 
   execute(): void {
-    // 即座に送信せず、「送信予約」にする（5分後に実送信）
+    // Do not send immediately; schedule for sending (actual send after 5 minutes)
     this.sentId = emailService.schedule(this.email, { delayMinutes: 5 });
   }
 
   undo(): void {
     if (this.sentId) {
-      // 5分以内なら予約をキャンセル
+      // Cancel the scheduled send if within 5 minutes
       const cancelled = emailService.cancelScheduled(this.sentId);
       if (!cancelled) {
-        // 既に送信済みの場合は取り消しメールを送信
+        // If already sent, send a cancellation email
         emailService.sendCancellation(this.sentId);
       }
     }
@@ -1548,10 +1548,10 @@ class SendEmailCommandV2 implements Command {
 }
 
 // ============================
-// [OK 方法2] Undo 不可であることを明示的に宣言
+// [OK Option 2] Explicitly declare that Undo is not possible
 // ============================
 class IrreversibleSendEmailCommand implements Command {
-  readonly isUndoable = false; // 正直に宣言
+  readonly isUndoable = false; // Honest declaration
 
   constructor(private email: string) {}
 
@@ -1566,7 +1566,7 @@ class IrreversibleSendEmailCommand implements Command {
   describe(): string { return `Send email to ${this.email} (irreversible)`; }
 }
 
-// UndoRedoManager 側でも対応
+// Handle on the UndoRedoManager side as well
 class SafeUndoRedoManager extends UndoRedoManager {
   override undo(): boolean {
     const lastCmd = this['undoStack'][this['undoStack'].length - 1];
@@ -1579,17 +1579,17 @@ class SafeUndoRedoManager extends UndoRedoManager {
 }
 ```
 
-### アンチパターン 3: God Command（巨大コマンド）
+### Anti-Pattern 3: God Command (Oversized Command)
 
 ```typescript
 // ============================
-// [NG] 1つのコマンドに複数の責任を詰め込む
+// [NG] Cramming multiple responsibilities into one command
 // ============================
 class ProcessOrderCommand implements Command {
   readonly isUndoable = true;
 
   execute(): void {
-    // 1つの Command に全ビジネスロジックが...
+    // All business logic crammed into one Command...
     this.validateOrder();
     this.calculateTax();
     this.applyDiscount();
@@ -1600,14 +1600,14 @@ class ProcessOrderCommand implements Command {
   }
 
   undo(): void {
-    // 7つの逆操作を正しい順序で...
-    // テスト不可能、バグの温床
+    // 7 inverse operations in the correct order...
+    // Untestable, a breeding ground for bugs
   }
   // ...
 }
 
 // ============================
-// [OK] 単一責任の小さな Command に分割し、MacroCommand で合成
+// [OK] Split into small single-responsibility Commands and compose with MacroCommand
 // ============================
 const processOrder = new MacroCommand([
   new ValidateOrderCommand(order),
@@ -1619,29 +1619,29 @@ const processOrder = new MacroCommand([
   new NotifyWarehouseCommand(order),
 ], 'Process Order');
 
-// 利点:
-// - 各 Command が独立してテスト可能
-// - 途中で失敗した場合、実行済みの Command だけ undo
-// - 新しいステップの追加・削除が容易
-// - 各 Command の再利用が可能
+// Benefits:
+// - Each Command can be tested independently
+// - If a step fails, only the executed Commands are undone
+// - Adding or removing steps is easy
+// - Each Command can be reused
 ```
 
 ---
 
-## 13. 演習問題
+## 13. Exercises
 
-### 演習 1（基礎）: DrawingCanvas のコマンド実装
+### Exercise 1 (Basic): Implementing Commands for a DrawingCanvas
 
-以下の仕様を満たす描画キャンバスの Command を実装してください。
+Implement Commands for a drawing canvas that satisfy the following specification.
 
-**仕様:**
-- `DrawCircleCommand`: 円を描画（x, y, radius, color）
-- `DrawRectCommand`: 四角を描画（x, y, width, height, color）
-- `ClearCanvasCommand`: キャンバス全体をクリア
-- `UndoRedoManager` と組み合わせて Undo/Redo を実現
+**Specification:**
+- `DrawCircleCommand`: Draw a circle (x, y, radius, color)
+- `DrawRectCommand`: Draw a rectangle (x, y, width, height, color)
+- `ClearCanvasCommand`: Clear the entire canvas
+- Combine with `UndoRedoManager` to enable Undo/Redo
 
 ```typescript
-// ヒント: Canvas（Receiver）の定義
+// Hint: Definition of Canvas (Receiver)
 interface Shape {
   type: 'circle' | 'rect';
   id: string;
@@ -1658,7 +1658,7 @@ class DrawingCanvas {
 }
 ```
 
-**期待される出力:**
+**Expected output:**
 ```
 canvas.getShapes() → []
 execute(DrawCircleCommand(50, 50, 20, 'red'))
@@ -1675,18 +1675,18 @@ canvas.getShapes().length → 1
 
 ---
 
-### 演習 2（応用）: トランザクション付き API コマンドキュー
+### Exercise 2 (Applied): API Command Queue with Transactions
 
-以下の仕様を満たすトランザクション実行エンジンを実装してください。
+Implement a transaction execution engine that satisfies the following specification.
 
-**仕様:**
-- 複数の非同期 Command を順序実行
-- 途中で失敗した場合、実行済み Command を逆順で全て undo（ロールバック）
-- リトライ機能（最大3回）
-- 進捗イベントの通知（onProgress コールバック）
+**Specification:**
+- Execute multiple async Commands sequentially
+- If a failure occurs midway, undo all executed Commands in reverse order (rollback)
+- Retry functionality (up to 3 times)
+- Progress event notifications (onProgress callback)
 
 ```typescript
-// ヒント: インターフェース
+// Hint: Interface
 interface TransactionEngine {
   execute(commands: AsyncCommand[]): Promise<TransactionResult>;
 }
@@ -1699,13 +1699,13 @@ interface TransactionResult {
 }
 ```
 
-**期待される出力:**
+**Expected output:**
 ```
-正常系:
+Happy path:
   execute([CmdA, CmdB, CmdC])
   → { success: true, executedCount: 3 }
 
-異常系（CmdC で失敗、リトライも失敗）:
+Error case (CmdC fails, retries also fail):
   execute([CmdA, CmdB, CmdC])
   → Retrying CmdC (attempt 1/3)
   → Retrying CmdC (attempt 2/3)
@@ -1717,18 +1717,18 @@ interface TransactionResult {
 
 ---
 
-### 演習 3（発展）: シリアライズ可能な Command でリプレイシステムを構築
+### Exercise 3 (Advanced): Build a Replay System with Serializable Commands
 
-以下の仕様を満たすリプレイ（操作の記録・再生）システムを実装してください。
+Implement a replay (record and replay operations) system that satisfies the following specification.
 
-**仕様:**
-- Command を JSON にシリアライズ/デシリアライズ
-- タイムスタンプ付きで操作を記録
-- 記録した操作を別の Receiver に対して再生
-- 再生速度の制御（1x, 2x, 0.5x）
+**Specification:**
+- Serialize/deserialize Commands to/from JSON
+- Record operations with timestamps
+- Replay recorded operations against a different Receiver
+- Control replay speed (1x, 2x, 0.5x)
 
 ```typescript
-// ヒント: シリアライズ形式
+// Hint: Serialization format
 interface SerializedCommand {
   type: string;
   params: Record<string, unknown>;
@@ -1743,15 +1743,15 @@ interface ReplayEngine {
 }
 ```
 
-**期待される出力:**
+**Expected output:**
 ```
-記録:
+Recording:
   record(InsertCommand(0, "Hello"))     // t=0ms
   record(InsertCommand(5, " World"))    // t=500ms
   record(DeleteCommand(5, 11))          // t=1200ms
   serialize() → '[{"type":"insert","params":{"pos":0,"text":"Hello"},"timestamp":0},...]'
 
-再生 (speed=2x):
+Replay (speed=2x):
   t=0ms:   Insert "Hello"     → "Hello"
   t=250ms: Insert " World"    → "Hello World"
   t=600ms: Delete [5:11]      → "Hello"
@@ -1761,55 +1761,55 @@ interface ReplayEngine {
 
 ## 14. FAQ
 
-### Q1: Command パターンはどのような場面で使うべきですか？
+### Q1: In what situations should the Command pattern be used?
 
-主に次の5つの場面で有効です。
+It is effective primarily in the following five situations.
 
-1. **Undo/Redo**: テキストエディタ、グラフィックツール、スプレッドシート。ユーザーが操作を取り消せる必要がある場面。
-2. **操作のキューイング**: ジョブキュー、バッチ処理、ネットワーク不安定時のオフラインキュー。
-3. **操作のログ記録**: 監査証跡（誰がいつ何をしたか）、デバッグログ、コンプライアンス要件。
-4. **マクロ記録**: ユーザー操作の記録と再生、テスト自動化。
-5. **トランザクション**: 複数操作のアトミック実行（全て成功 or 全てロールバック）。
+1. **Undo/Redo**: Text editors, graphic tools, spreadsheets. Any situation where users need to reverse operations.
+2. **Operation queuing**: Job queues, batch processing, offline queues for unstable network conditions.
+3. **Operation logging**: Audit trails (who did what and when), debug logs, compliance requirements.
+4. **Macro recording**: Recording and replaying user operations, test automation.
+5. **Transactions**: Atomic execution of multiple operations (all succeed or all rollback).
 
-単純な関数呼び出し1回で済む場面ではオーバーエンジニアリングになります。「この操作を後から取り消す必要があるか？」「操作の履歴を残す必要があるか？」を判断基準にしてください。
+In situations where a single simple function call suffices, it becomes over-engineering. Use the criteria "Do I need to be able to cancel this operation later?" and "Do I need to keep a history of operations?" as your guide.
 
-### Q2: Command パターンと関数型プログラミングのクロージャは何が違いますか？
+### Q2: What is the difference between the Command pattern and closures in functional programming?
 
-クロージャも「操作をカプセル化」しますが、以下の点で Command パターンとは異なります。
+Closures also "encapsulate operations," but they differ from the Command pattern in the following ways.
 
-| 比較項目 | Command パターン | クロージャ |
+| Comparison | Command pattern | Closure |
 |---------|----------------|-----------|
-| undo | 明示的な undo() メソッド | 逆操作を別途用意する必要あり |
-| シリアライズ | 可能（クラス名 + パラメータ） | 不可能（クロージャは直列化できない） |
-| 検査可能性 | describe() で内容を確認可能 | 内部を外から見れない |
-| テスト | 独立してテスト可能 | テストしにくい |
+| Undo | Explicit undo() method | Inverse operation must be provided separately |
+| Serialization | Possible (class name + parameters) | Not possible (closures cannot be serialized) |
+| Inspectability | Content can be checked with describe() | Cannot see the internals from outside |
+| Testing | Can be tested independently | Harder to test |
 
-TypeScript では、クラスベースと関数型（クロージャ）のハイブリッドが実用的です。シリアライズが不要な軽量な場面ではクロージャで、永続化やネットワーク送信が必要な場面ではクラスベースを使います。
+In TypeScript, a hybrid of class-based and functional (closure) approaches is practical. Use closures for lightweight scenarios where serialization is not needed, and use class-based approaches when persistence or network transmission is required.
 
-### Q3: 大量のコマンド履歴によるメモリ消費をどう管理しますか？
+### Q3: How do you manage memory consumption from a large command history?
 
-4つの戦略があります。
+There are four strategies.
 
-1. **履歴の上限設定**: 最大100〜1000件に制限し、古いものから破棄。ほとんどのエディタはこの方式。
-2. **コマンドの圧縮（Coalescing）**: 連続する同種のコマンドをマージ。例: 連続入力の文字を1つの InsertCommand にまとめる。
-3. **チェックポイント**: 定期的に全状態をスナップショットし、それ以前の Command 履歴を破棄。undo はチェックポイントまでしか遡れないが、メモリは一定。
-4. **遅延読込（Lazy Loading）**: 古い履歴をディスクに退避し、必要時のみ読み込む。IndexedDB や SQLite に保存。
+1. **History limit**: Cap at 100–1000 entries and discard the oldest. Most editors use this approach.
+2. **Command coalescing**: Merge consecutive commands of the same type. For example, combine consecutive character inputs into a single InsertCommand.
+3. **Checkpoints**: Periodically take a snapshot of the full state and discard Command history before that point. Undo can only go back to the checkpoint, but memory stays constant.
+4. **Lazy loading**: Archive old history to disk and load only when needed. Store in IndexedDB or SQLite.
 
-### Q4: Command パターンと Event Sourcing の関係は？
+### Q4: What is the relationship between the Command pattern and Event Sourcing?
 
-Command パターンと Event Sourcing は密接に関連しますが、目的が異なります。
+The Command pattern and Event Sourcing are closely related but have different purposes.
 
-- **Command**: 「操作の意図」を表す。実行前のもので、拒否される可能性がある。
-- **Event**: 「起きた事実」を表す。実行後のもので、不変（immutable）。
+- **Command**: Represents the "intent of an operation." It exists before execution and can be rejected.
+- **Event**: Represents "what happened." It exists after execution and is immutable.
 
-Event Sourcing では、Command を受け取り、バリデーション後に Event を生成します。Event を再生すれば任意の時点の状態を復元できます。Command パターンの `execute()` が Event を発行し、`undo()` は補償 Event を発行するという設計が一般的です。
+In Event Sourcing, a Command is received, validated, and then an Event is generated. By replaying Events, the state at any point in time can be restored. A common design is for `execute()` in the Command pattern to emit an Event, and `undo()` to emit a compensating Event.
 
-### Q5: React / フロントエンドフレームワークで Command パターンをどう使いますか？
+### Q5: How do you use the Command pattern in React / frontend frameworks?
 
-React では以下のパターンが一般的です。
+In React, the following pattern is common.
 
 ```typescript
-// useUndoRedo カスタムフック
+// useUndoRedo custom hook
 function useUndoRedo<T>(initialState: T) {
   const [state, setState] = useState(initialState);
   const undoStack = useRef<T[]>([]);
@@ -1844,57 +1844,57 @@ function useUndoRedo<T>(initialState: T) {
 }
 ```
 
-Redux の `dispatch(action)` も Command パターンそのものです。Action が Command、Reducer が execute、Redux DevTools が UndoRedoManager に対応します。
+Redux's `dispatch(action)` is itself the Command pattern. Actions are Commands, Reducers are execute, and Redux DevTools corresponds to UndoRedoManager.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point to understand about this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not only through theory but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in professional development?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architectural design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Item | Key Points |
 |------|------|
-| Command パターンの本質 | 操作をオブジェクトとしてカプセル化し、第一級市民にする |
-| 4つの構成要素 | Client, Invoker, Command (interface), Receiver |
-| Undo/Redo | Undo スタックと Redo スタックで双方向の操作履歴を管理 |
-| MacroCommand | Composite パターンとの組合せ。複数コマンドを1つの Undo 単位に |
-| 非同期キュー | コマンドの順序実行、リトライ、ロールバック |
-| 粒度設計 | ユーザーの「意図」に対応する単位でコマンドを区切る |
-| 関数型アプローチ | クロージャによる軽量 Command。シリアライズ不要な場面で有効 |
-| Command バス | CQRS における Command の型安全なディスパッチ |
-| 導入判断 | Undo/ログ/キュー/マクロのいずれかが必要なら検討 |
+| Essence of the Command pattern | Encapsulate operations as objects and make them first-class citizens |
+| Four components | Client, Invoker, Command (interface), Receiver |
+| Undo/Redo | Manage bidirectional operation history with Undo and Redo stacks |
+| MacroCommand | Combination with Composite pattern. Groups multiple commands as one Undo unit |
+| Async queue | Sequential command execution, retry, and rollback |
+| Granularity design | Divide commands into units that correspond to the user's "intent" |
+| Functional approach | Lightweight Command using closures. Effective when serialization is not needed |
+| Command bus | Type-safe dispatching of Commands in CQRS |
+| Decision criteria | Consider adopting when Undo / logging / queuing / macro recording is needed |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [03-state.md](./03-state.md) -- State パターンと状態遷移（Command + State で状態付き操作管理）
-- [04-iterator.md](./04-iterator.md) -- Iterator パターンとジェネレータ（Command 履歴の走査に応用）
-- [00-observer.md](./00-observer.md) -- Observer パターン（Command 実行をイベントとして通知）
-- [../03-functional/00-monad.md](../03-functional/00-monad.md) -- モナドパターン（Either で Command の成功/失敗を型安全に）
-- Event Sourcing / CQRS -- Command パターンの大規模アーキテクチャへの発展
+- [03-state.md](./03-state.md) -- State pattern and state transitions (Command + State for stateful operation management)
+- [04-iterator.md](./04-iterator.md) -- Iterator pattern and generators (applied to traversing Command history)
+- [00-observer.md](./00-observer.md) -- Observer pattern (notifying Command execution as events)
+- [../03-functional/00-monad.md](../03-functional/00-monad.md) -- Monad pattern (type-safe success/failure of Commands with Either)
+- Event Sourcing / CQRS -- Evolving the Command pattern into large-scale architecture
 
 ---
 
-## 参考文献
+## References
 
-1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- Command パターンの原典。Chapter 5, pp.233-242
-2. **Head First Design Patterns** -- Eric Freeman, Elisabeth Robson (O'Reilly, 2nd Edition, 2020) -- Command パターンの平易な解説と実践例
-3. **Refactoring.Guru - Command** -- https://refactoring.guru/design-patterns/command -- 図解と多言語実装例
-4. **Martin Fowler - Command Query Responsibility Segregation (CQRS)** -- https://martinfowler.com/bliki/CQRS.html -- Command パターンのアーキテクチャレベルへの発展
-5. **Redux Documentation** -- https://redux.js.org/ -- Command パターンの実践的な大規模適用例（Action = Command）
+1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- The original source for the Command pattern. Chapter 5, pp.233-242
+2. **Head First Design Patterns** -- Eric Freeman, Elisabeth Robson (O'Reilly, 2nd Edition, 2020) -- Accessible explanation and practical examples of the Command pattern
+3. **Refactoring.Guru - Command** -- https://refactoring.guru/design-patterns/command -- Diagrams and multi-language implementation examples
+4. **Martin Fowler - Command Query Responsibility Segregation (CQRS)** -- https://martinfowler.com/bliki/CQRS.html -- Evolution of the Command pattern to the architectural level
+5. **Redux Documentation** -- https://redux.js.org/ -- Practical large-scale application of the Command pattern (Action = Command)

--- a/03-software-design/design-patterns-guide/docs/02-behavioral/03-state.md
+++ b/03-software-design/design-patterns-guide/docs/02-behavioral/03-state.md
@@ -1,46 +1,46 @@
-# State パターン
+# State Pattern
 
-> オブジェクトの内部状態に応じて振る舞いを動的に切り替え、有限状態マシン (FSM) を型安全に実装する行動パターン
-
----
-
-## この章で学ぶこと
-
-1. **State パターンの基本構造と GoF の意図** -- 状態ごとにクラスを分離し、条件分岐の爆発を防ぐ設計手法の原理
-2. **有限状態マシン (FSM) の型安全な実装** -- 状態遷移図をコードに落とし込み、不正な遷移をコンパイル時に防止する
-3. **宣言的 FSM と階層状態マシン** -- XState 風の設定ベース FSM、親子状態による複雑さの管理
-4. **実プロダクトへの適用** -- EC注文管理、UIコンポーネント、フォームバリデーション、ゲーム AI での実践例
-5. **State パターンと他パターンの連携** -- Strategy、Command、Observer との組合せと使い分け
+> A behavioral pattern that dynamically switches behavior based on an object's internal state, enabling type-safe implementation of finite state machines (FSM)
 
 ---
 
-## 前提知識
+## What You Will Learn in This Chapter
 
-| トピック | 必要な理解 | 参照リンク |
+1. **Basic structure of the State pattern and GoF's intent** -- The principles of separating behavior into per-state classes to prevent conditional branch explosion
+2. **Type-safe implementation of finite state machines (FSM)** -- Translating state transition diagrams into code and preventing invalid transitions at compile time
+3. **Declarative FSM and hierarchical state machines** -- XState-style configuration-based FSM, managing complexity with parent-child states
+4. **Applying to real products** -- Practical examples in e-commerce order management, UI components, form validation, and game AI
+5. **Combining the State pattern with other patterns** -- Integration with Strategy, Command, and Observer, and when to use each
+
+---
+
+## Prerequisites
+
+| Topic | Required Understanding | Reference Link |
 |---------|-----------|-----------|
-| TypeScript の interface と class | インターフェース実装、ジェネリクス、型ガード | 02-programming |
-| SOLID 原則（特に OCP・SRP） | 開放閉鎖原則、単一責任原則の理解 | clean-code-principles |
-| Strategy パターン | アルゴリズムの切り替えの基本概念 | [01-strategy.md](./01-strategy.md) |
-| Observer パターン | 状態変化の通知 | [00-observer.md](./00-observer.md) |
-| Command パターン | 操作のカプセル化、Undo/Redo | [02-command.md](./02-command.md) |
+| TypeScript interface and class | Interface implementation, generics, type guards | 02-programming |
+| SOLID principles (especially OCP & SRP) | Open-Closed Principle, Single Responsibility Principle | clean-code-principles |
+| Strategy pattern | Basic concept of switching algorithms | [01-strategy.md](./01-strategy.md) |
+| Observer pattern | Notification of state changes | [00-observer.md](./00-observer.md) |
+| Command pattern | Encapsulating operations, Undo/Redo | [02-command.md](./02-command.md) |
 
 ---
 
-## なぜ State パターンが必要なのか
+## Why the State Pattern Is Needed
 
-### if/else の爆発問題
+### The if/else Explosion Problem
 
-注文管理システムで「注文のステータスに応じて異なる処理を行う」要件を考えてみましょう。
+Consider the requirement to "perform different processing based on order status" in an order management system.
 
 ```
-if/else アプローチの問題:
+Problems with the if/else approach:
 
 class Order {
   status: string = 'pending';
 
   pay(): void {
     if (this.status === 'pending') {
-      // 決済処理...
+      // Payment processing...
       this.status = 'paid';
     } else if (this.status === 'paid') {
       throw new Error('Already paid');
@@ -57,35 +57,35 @@ class Order {
     if (this.status === 'pending') {
       throw new Error('Must pay first');
     } else if (this.status === 'paid') {
-      // 発送処理...
+      // Shipping processing...
       this.status = 'shipped';
     } else if (...) { ... }
-    // 同じパターンの繰り返し...
+    // The same pattern repeats...
   }
 
-  deliver(): void { /* 同じパターン */ }
-  cancel(): void { /* 同じパターン */ }
-  refund(): void { /* 同じパターン */ }
+  deliver(): void { /* Same pattern */ }
+  cancel(): void { /* Same pattern */ }
+  refund(): void { /* Same pattern */ }
 }
 
-問題:
+Problems:
   ┌──────────────────────────────────────────────────┐
-  │ 状態 5 × メソッド 5 = 25 個の分岐               │
+  │ 5 states × 5 methods = 25 branches               │
   │                                                  │
-  │ 新しい状態 "returned" を追加すると:               │
-  │   → 全 5 メソッドを修正（OCP 違反）              │
-  │   → 修正漏れ → ランタイムエラー                  │
-  │   → テストケースが指数的に増加                    │
+  │ Adding a new state "returned":                    │
+  │   → All 5 methods must be modified (OCP violation)│
+  │   → Missed modifications → runtime errors        │
+  │   → Test cases grow exponentially                 │
   └──────────────────────────────────────────────────┘
 ```
 
-### State パターンによる解決
+### Solution with the State Pattern
 
 ```
-State パターンの解決:
+State pattern solution:
 
   ┌──────────────┐         ┌──────────────────┐
-  │   Context    │────────►│   State (抽象)    │
+  │   Context    │────────►│   State (abstract)│
   │ OrderContext │         │                  │
   │              │         │ + pay()          │
   │ - state ─────┤         │ + ship()         │
@@ -104,32 +104,32 @@ State パターンの解決:
                      │ cancel()→ │  │ cancel() →    │
                      │  Cancelled│  │  Cancelled     │
                      └───────────┘  └───────────────┘
-                     ...他の状態も同様
+                     ...same for other states
 
-  利点:
-  ✓ 各状態の振る舞いが1つのクラスにまとまる（SRP）
-  ✓ 新しい状態の追加は新クラスの追加のみ（OCP）
-  ✓ 不正な遷移はその状態クラス内で例外を投げるだけ
-  ✓ 各状態クラスを独立してテスト可能
+  Benefits:
+  ✓ Each state's behavior is consolidated in one class (SRP)
+  ✓ Adding a new state only requires adding a new class (OCP)
+  ✓ Invalid transitions simply throw exceptions within their state class
+  ✓ Each state class can be tested independently
 ```
 
-GoF の定義:
+GoF definition:
 
 > "Allow an object to alter its behavior when its internal state changes. The object will appear to change its class."
 >
 > -- Design Patterns: Elements of Reusable Object-Oriented Software (1994)
 
-State パターンの本質は **「条件分岐をポリモーフィズムに変換する」** ことです。`if (status === 'pending')` という条件分岐を、`PendingState` クラスの存在そのもので表現します。これにより、各状態の振る舞いが凝集し、状態の追加が既存コードに影響を与えなくなります。
+The essence of the State pattern is **"converting conditional branches into polymorphism"**. The conditional branch `if (status === 'pending')` is expressed by the very existence of the `PendingState` class. This consolidates each state's behavior and allows adding new states without affecting existing code.
 
 ---
 
-## 1. State パターンの構造
+## 1. Structure of the State Pattern
 
 ```
-State パターンの構成要素（GoF）:
+State pattern components (GoF):
 
   ┌──────────────────┐         ┌──────────────────┐
-  │    Context        │────────►│   State (抽象)    │
+  │    Context        │────────►│   State (abstract)│
   │                   │         │                  │
   │ - currentState    │         │ + handle(ctx)    │
   │ + request()       │         │                  │
@@ -140,36 +140,36 @@ State パターンの構成要素（GoF）:
                                │State A │  │ State B    │
                                │        │  │            │
                                │handle()│  │ handle()   │
-                               │→ Aの   │  │ → Bの      │
-                               │ 振る舞い│  │  振る舞い   │
-                               │→ Bに   │  │ → Cに      │
-                               │ 遷移   │  │  遷移      │
+                               │→ A's   │  │ → B's      │
+                               │behavior│  │  behavior  │
+                               │→ trans.│  │ → trans.   │
+                               │  to B  │  │  to C      │
                                └────────┘  └────────────┘
 
-  Context.request() は currentState.handle(this) に委譲
-  handle() の中で context.setState(new NextState()) を呼ぶ
+  Context.request() delegates to currentState.handle(this)
+  Inside handle(), context.setState(new NextState()) is called
 
-  ★ Strategy パターンとの違い:
-    Strategy: クライアントが外部から戦略を切り替える
-    State:    状態オブジェクト自身が次の状態に遷移する
+  ★ Difference from Strategy pattern:
+    Strategy: The client switches the strategy from outside
+    State:    The state object itself transitions to the next state
 
-  遷移の方向:
+  Direction of transitions:
     Strategy: Client → Context.setStrategy(new X())
     State:    StateA.handle() → context.setState(new StateB())
-              （状態が自分で次の状態を決める）
+              (the state decides its own next state)
 ```
 
 ---
 
-## 2. 基本実装 -- 注文ステータス管理
+## 2. Basic Implementation -- Order Status Management
 
-### コード例 1: GoF スタイルの State パターン
+### Code Example 1: GoF-style State Pattern
 
 ```typescript
-// order-state.ts -- 注文の状態管理
+// order-state.ts -- Order state management
 
 // ============================
-// State インターフェース
+// State interface
 // ============================
 interface OrderState {
   readonly name: string;
@@ -180,7 +180,7 @@ interface OrderState {
 }
 
 // ============================
-// Context: 注文
+// Context: Order
 // ============================
 class OrderContext {
   private state: OrderState;
@@ -217,7 +217,7 @@ class OrderContext {
     });
   }
 
-  // 操作を状態に委譲
+  // Delegate operations to the state
   pay(): void { this.state.pay(this); }
   ship(): void { this.state.ship(this); }
   deliver(): void { this.state.deliver(this); }
@@ -225,125 +225,125 @@ class OrderContext {
 }
 
 // ============================
-// Concrete State: Pending（未決済）
+// Concrete State: Pending (unpaid)
 // ============================
 class PendingState implements OrderState {
   readonly name = 'pending';
 
   pay(context: OrderContext): void {
-    console.log('決済処理を実行...');
+    console.log('Processing payment...');
     context.setState(new PaidState(), 'pay');
   }
 
   ship(_context: OrderContext): void {
-    throw new Error('未決済の注文は発送できません');
+    throw new Error('Cannot ship an unpaid order');
   }
 
   deliver(_context: OrderContext): void {
-    throw new Error('未決済の注文は配達完了にできません');
+    throw new Error('Cannot mark an unpaid order as delivered');
   }
 
   cancel(context: OrderContext): void {
-    console.log('注文をキャンセルしました');
+    console.log('Order has been cancelled');
     context.setState(new CancelledState(), 'cancel');
   }
 }
 
 // ============================
-// Concrete State: Paid（決済済み）
+// Concrete State: Paid
 // ============================
 class PaidState implements OrderState {
   readonly name = 'paid';
 
   pay(_context: OrderContext): void {
-    throw new Error('すでに決済済みです');
+    throw new Error('Already paid');
   }
 
   ship(context: OrderContext): void {
-    console.log('発送処理を実行...');
+    console.log('Processing shipment...');
     context.setState(new ShippedState(), 'ship');
   }
 
   deliver(_context: OrderContext): void {
-    throw new Error('発送前に配達完了にはできません');
+    throw new Error('Cannot mark as delivered before shipping');
   }
 
   cancel(context: OrderContext): void {
-    console.log('返金処理を実行...');
+    console.log('Processing refund...');
     context.setState(new CancelledState(), 'cancel');
   }
 }
 
 // ============================
-// Concrete State: Shipped（発送済み）
+// Concrete State: Shipped
 // ============================
 class ShippedState implements OrderState {
   readonly name = 'shipped';
 
   pay(_context: OrderContext): void {
-    throw new Error('発送済みの注文に決済はできません');
+    throw new Error('Cannot process payment for a shipped order');
   }
 
   ship(_context: OrderContext): void {
-    throw new Error('すでに発送済みです');
+    throw new Error('Already shipped');
   }
 
   deliver(context: OrderContext): void {
-    console.log('配達完了を記録...');
+    console.log('Recording delivery completion...');
     context.setState(new DeliveredState(), 'deliver');
   }
 
   cancel(_context: OrderContext): void {
-    throw new Error('発送済みの注文はキャンセルできません（返品手続きをご利用ください）');
+    throw new Error('Cannot cancel a shipped order (please use the return process)');
   }
 }
 
 // ============================
-// Concrete State: Delivered（配達完了） -- 終端状態
+// Concrete State: Delivered (terminal state)
 // ============================
 class DeliveredState implements OrderState {
   readonly name = 'delivered';
 
-  pay(): void { throw new Error('配達済みの注文に決済はできません'); }
-  ship(): void { throw new Error('配達済みの注文は発送できません'); }
-  deliver(): void { throw new Error('すでに配達済みです'); }
-  cancel(): void { throw new Error('配達済みの注文はキャンセルできません'); }
+  pay(): void { throw new Error('Cannot process payment for a delivered order'); }
+  ship(): void { throw new Error('Cannot ship a delivered order'); }
+  deliver(): void { throw new Error('Already delivered'); }
+  cancel(): void { throw new Error('Cannot cancel a delivered order'); }
 }
 
 // ============================
-// Concrete State: Cancelled（キャンセル済み） -- 終端状態
+// Concrete State: Cancelled (terminal state)
 // ============================
 class CancelledState implements OrderState {
   readonly name = 'cancelled';
 
-  pay(): void { throw new Error('キャンセル済みの注文に決済はできません'); }
-  ship(): void { throw new Error('キャンセル済みの注文は発送できません'); }
-  deliver(): void { throw new Error('キャンセル済みの注文は配達完了にできません'); }
-  cancel(): void { throw new Error('すでにキャンセル済みです'); }
+  pay(): void { throw new Error('Cannot process payment for a cancelled order'); }
+  ship(): void { throw new Error('Cannot ship a cancelled order'); }
+  deliver(): void { throw new Error('Cannot mark a cancelled order as delivered'); }
+  cancel(): void { throw new Error('Already cancelled'); }
 }
 
 // ============================
-// 使用例
+// Usage example
 // ============================
 const order = new OrderContext('ORD-001');
 console.log(order.getStateName()); // "pending"
 
 order.pay();
-// 決済処理を実行...
+// Processing payment...
 // [ORD-001] pending → paid (pay)
 
 order.ship();
-// 発送処理を実行...
+// Processing shipment...
 // [ORD-001] paid → shipped (ship)
 
 order.deliver();
-// 配達完了を記録...
+// Recording delivery completion...
 // [ORD-001] shipped → delivered (deliver)
 
 try {
-  order.cancel(); // 配達済みなのでエラー
+  order.cancel(); // Error because already delivered
 } catch (e) {
-  console.log(e.message); // "配達済みの注文はキャンセルできません"
+  console.log(e.message); // "Cannot cancel a delivered order"
 }
 
 console.log(order.getHistory());
@@ -356,7 +356,7 @@ console.log(order.getHistory());
 ```
 
 ```
-注文状態の遷移図:
+Order state transition diagram:
 
   ┌─────────┐   PAY    ┌─────────┐   SHIP   ┌──────────┐
   │ pending │────────►│  paid   │────────►│ shipped  │
@@ -369,46 +369,46 @@ console.log(order.getHistory());
   │cancelled │       │cancelled │        │ delivered │
   └──────────┘       └──────────┘        └───────────┘
 
-  ※ delivered, cancelled は終端状態（遷移先なし）
-  ※ shipped → cancel は不可（返品手続きが別途必要）
+  * delivered and cancelled are terminal states (no further transitions)
+  * shipped → cancel is not allowed (a separate return process is required)
 ```
 
 ---
 
-## 3. 型安全な FSM（有限状態マシン）
+## 3. Type-Safe FSM (Finite State Machine)
 
-### コード例 2: TypeScript の型システムで遷移を制約する
+### Code Example 2: Constraining Transitions with TypeScript's Type System
 
 ```typescript
-// typed-fsm.ts -- 型で遷移を制約する FSM
+// typed-fsm.ts -- FSM that constrains transitions with types
 
 // ============================
-// 状態とイベントの型定義
+// Type definitions for states and events
 // ============================
 type OrderStatus = 'pending' | 'paid' | 'shipped' | 'delivered' | 'cancelled';
 type OrderEvent = 'PAY' | 'SHIP' | 'DELIVER' | 'CANCEL';
 
 // ============================
-// 許可される遷移を型レベルで定義
+// Define allowed transitions at the type level
 // ============================
 type TransitionMap = {
   pending:   { PAY: 'paid'; CANCEL: 'cancelled' };
   paid:      { SHIP: 'shipped'; CANCEL: 'cancelled' };
   shipped:   { DELIVER: 'delivered' };
-  delivered: {};  // 終端状態: 遷移先なし
-  cancelled: {};  // 終端状態: 遷移先なし
+  delivered: {};  // Terminal state: no transitions
+  cancelled: {};  // Terminal state: no transitions
 };
 
 // ============================
-// 型安全な遷移関数の型
+// Type of the type-safe transition function
 // ============================
-// これにより、存在しない遷移はコンパイル時にエラーになる
+// This causes non-existent transitions to produce compile-time errors
 type ValidEvent<S extends OrderStatus> = keyof TransitionMap[S];
 type NextState<S extends OrderStatus, E extends ValidEvent<S>> =
   TransitionMap[S][E];
 
 // ============================
-// FSM クラス（型安全版）
+// FSM class (type-safe version)
 // ============================
 const STATE_TRANSITIONS: Record<
   OrderStatus,
@@ -429,9 +429,9 @@ class TypedStateMachine<S extends OrderStatus> {
   }
 
   /**
-   * 型安全な遷移
-   * - 許可されたイベントのみ引数に取れる
-   * - 戻り値の型が次の状態に正しく推論される
+   * Type-safe transition
+   * - Only accepts allowed events as arguments
+   * - Return type is correctly inferred as the next state
    */
   transition<E extends ValidEvent<S>>(
     event: E
@@ -452,7 +452,7 @@ class TypedStateMachine<S extends OrderStatus> {
 }
 
 // ============================
-// 使用例: コンパイル時に不正な遷移を検出
+// Usage example: detecting invalid transitions at compile time
 // ============================
 const machine = new TypedStateMachine('pending' as const);
 
@@ -460,30 +460,30 @@ const paid = machine.transition('PAY');       // OK: pending → paid
 const shipped = paid.transition('SHIP');      // OK: paid → shipped
 const delivered = shipped.transition('DELIVER'); // OK: shipped → delivered
 
-// 以下はコンパイルエラー!
-// machine.transition('SHIP');    // Error: 'SHIP' は pending で許可されていない
-// machine.transition('DELIVER'); // Error: 'DELIVER' は pending で許可されていない
-// paid.transition('DELIVER');    // Error: 'DELIVER' は paid で許可されていない
-// delivered.transition('PAY');   // Error: delivered は終端状態（遷移先なし）
+// The following are compile errors!
+// machine.transition('SHIP');    // Error: 'SHIP' is not allowed in pending
+// machine.transition('DELIVER'); // Error: 'DELIVER' is not allowed in pending
+// paid.transition('DELIVER');    // Error: 'DELIVER' is not allowed in paid
+// delivered.transition('PAY');   // Error: delivered is a terminal state (no transitions)
 
-// 型推論の確認
+// Type inference verification
 type PaidMachine = typeof paid;    // TypedStateMachine<'paid'>
 type ShippedMachine = typeof shipped; // TypedStateMachine<'shipped'>
 ```
 
-この実装のポイントは、**遷移テーブルを型レベルで定義する**ことです。`TransitionMap` 型により、各状態から発行できるイベントとその遷移先が型として宣言されます。存在しない遷移（例: `pending` から `DELIVER`）は型エラーとしてコンパイル時に検出されます。
+The key to this implementation is **defining the transition table at the type level**. The `TransitionMap` type declares, for each state, the events that can be fired and their target states as types. Non-existent transitions (e.g., `DELIVER` from `pending`) are caught as type errors at compile time.
 
 ---
 
-## 4. 宣言的 FSM（XState 風）
+## 4. Declarative FSM (XState-style)
 
-### コード例 3: 設定オブジェクトで定義する FSM
+### Code Example 3: FSM Defined with a Configuration Object
 
 ```typescript
-// declarative-fsm.ts -- 設定ベースの FSM
+// declarative-fsm.ts -- Configuration-based FSM
 
 // ============================
-// FSM の設定型
+// FSM configuration types
 // ============================
 interface TransitionConfig<TContext> {
   target: string;
@@ -505,7 +505,7 @@ interface MachineConfig<TContext> {
 }
 
 // ============================
-// FSM エンジン
+// FSM engine
 // ============================
 type FSMEvent =
   | { type: 'transition'; from: string; to: string; event: string }
@@ -522,11 +522,11 @@ class FSM<TContext> {
     this.currentState = config.initial;
     this.context = { ...config.context };
 
-    // 初期状態の entry アクションを実行
+    // Execute the entry action for the initial state
     this.config.states[this.currentState]?.entry?.(this.context);
   }
 
-  /** イベントを送信して遷移を試みる */
+  /** Send an event to attempt a transition */
   send(event: string): boolean {
     const stateConfig = this.config.states[this.currentState];
     const transition = stateConfig?.on?.[event];
@@ -538,7 +538,7 @@ class FSM<TContext> {
       return false;
     }
 
-    // ガード条件のチェック
+    // Check guard conditions
     if (transition.guard && !transition.guard(this.context)) {
       this.notify({
         type: 'guard-blocked',
@@ -550,7 +550,7 @@ class FSM<TContext> {
 
     const from = this.currentState;
 
-    // exit → action → entry の順序で実行
+    // Execute in order: exit → action → entry
     stateConfig?.exit?.(this.context);
     transition.action?.(this.context);
 
@@ -569,7 +569,7 @@ class FSM<TContext> {
     return { ...this.context };
   }
 
-  /** 現在の状態で許可されるイベントの一覧 */
+  /** List of events allowed in the current state */
   allowedEvents(): string[] {
     const stateConfig = this.config.states[this.currentState];
     return stateConfig?.on ? Object.keys(stateConfig.on) : [];
@@ -590,7 +590,7 @@ class FSM<TContext> {
 }
 
 // ============================
-// 使用例: 信号機
+// Usage example: traffic light
 // ============================
 const trafficLight = new FSM({
   id: 'traffic-light',
@@ -598,7 +598,7 @@ const trafficLight = new FSM({
   context: { cycleCount: 0 },
   states: {
     red: {
-      entry: (ctx) => console.log(`赤信号 (サイクル: ${ctx.cycleCount})`),
+      entry: (ctx) => console.log(`Red light (cycle: ${ctx.cycleCount})`),
       on: {
         TIMER: {
           target: 'green',
@@ -607,13 +607,13 @@ const trafficLight = new FSM({
       },
     },
     green: {
-      entry: () => console.log('青信号'),
+      entry: () => console.log('Green light'),
       on: {
         TIMER: { target: 'yellow' },
       },
     },
     yellow: {
-      entry: () => console.log('黄信号'),
+      entry: () => console.log('Yellow light'),
       on: {
         TIMER: { target: 'red' },
       },
@@ -621,23 +621,23 @@ const trafficLight = new FSM({
   },
 });
 
-trafficLight.send('TIMER'); // 赤信号 (サイクル: 0) → 青信号
-trafficLight.send('TIMER'); // 青信号 → 黄信号
-trafficLight.send('TIMER'); // 黄信号 → 赤信号 (サイクル: 1)
+trafficLight.send('TIMER'); // Red light (cycle: 0) → Green light
+trafficLight.send('TIMER'); // Green light → Yellow light
+trafficLight.send('TIMER'); // Yellow light → Red light (cycle: 1)
 console.log(trafficLight.getContext()); // { cycleCount: 1 }
 ```
 
 ---
 
-## 5. 実用例: フォームバリデーション状態
+## 5. Practical Example: Form Validation State
 
-### コード例 4: 複雑なフォームの状態管理
+### Code Example 4: State Management for a Complex Form
 
 ```typescript
-// form-state.ts -- フォームの状態管理
+// form-state.ts -- Form state management
 
 // ============================
-// フォームコンテキスト
+// Form context
 // ============================
 interface FormContext {
   data: Record<string, string>;
@@ -647,7 +647,7 @@ interface FormContext {
 }
 
 // ============================
-// フォーム FSM
+// Form FSM
 // ============================
 const formMachine = new FSM<FormContext>({
   id: 'form',
@@ -660,11 +660,11 @@ const formMachine = new FSM<FormContext>({
   },
   states: {
     idle: {
-      entry: () => console.log('[Form] Idle - 入力待ち'),
+      entry: () => console.log('[Form] Idle - waiting for input'),
       on: {
         CHANGE: {
           target: 'editing',
-          action: () => console.log('[Form] 入力開始'),
+          action: () => console.log('[Form] Input started'),
         },
       },
     },
@@ -688,14 +688,14 @@ const formMachine = new FSM<FormContext>({
     },
     validating: {
       entry: (ctx) => {
-        console.log('[Form] バリデーション実行中...');
+        console.log('[Form] Running validation...');
         ctx.errors = {};
-        // バリデーションルールの適用
+        // Apply validation rules
         if (!ctx.data.email?.includes('@')) {
-          ctx.errors.email = 'メールアドレスの形式が不正です';
+          ctx.errors.email = 'Invalid email address format';
         }
         if (!ctx.data.name || ctx.data.name.length < 2) {
-          ctx.errors.name = '名前は2文字以上で入力してください';
+          ctx.errors.name = 'Name must be at least 2 characters';
         }
       },
       on: {
@@ -709,7 +709,7 @@ const formMachine = new FSM<FormContext>({
       },
     },
     submitting: {
-      entry: () => console.log('[Form] 送信中...'),
+      entry: () => console.log('[Form] Submitting...'),
       on: {
         SUCCESS: {
           target: 'success',
@@ -721,7 +721,7 @@ const formMachine = new FSM<FormContext>({
       },
     },
     success: {
-      entry: () => console.log('[Form] 送信成功!'),
+      entry: () => console.log('[Form] Submission successful!'),
       on: {
         RESET: {
           target: 'idle',
@@ -733,7 +733,7 @@ const formMachine = new FSM<FormContext>({
       },
     },
     error: {
-      entry: () => console.log('[Form] 送信エラー'),
+      entry: () => console.log('[Form] Submission error'),
       on: {
         RETRY: {
           target: 'submitting',
@@ -751,15 +751,15 @@ const formMachine = new FSM<FormContext>({
   },
 });
 
-// 使用例
+// Usage example
 formMachine.send('CHANGE');      // idle → editing
 formMachine.send('SUBMIT');      // editing → validating
-// バリデーションエラーがある場合:
+// If there are validation errors:
 formMachine.send('INVALID');     // validating → editing
 ```
 
 ```
-フォーム状態の遷移図:
+Form state transition diagram:
 
   ┌──────┐  CHANGE  ┌─────────┐  SUBMIT  ┌────────────┐
   │ idle │────────►│ editing │────────►│ validating │
@@ -783,12 +783,12 @@ formMachine.send('INVALID');     // validating → editing
 
 ---
 
-## 6. Python での State パターン
+## 6. State Pattern in Python
 
-### コード例 5: Python の ABC とデコレータによる State
+### Code Example 5: State Pattern with Python ABC and Decorators
 
 ```python
-# state_python.py -- Python での State パターン実装
+# state_python.py -- State pattern implementation in Python
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -797,11 +797,11 @@ from typing import Callable
 
 
 # ============================
-# 自動販売機の State パターン
+# State pattern for a vending machine
 # ============================
 
 class VendingState(ABC):
-    """自動販売機の状態インターフェース"""
+    """Vending machine state interface"""
 
     @abstractmethod
     def insert_coin(self, machine: VendingMachine, amount: int) -> None: ...
@@ -821,7 +821,7 @@ class VendingState(ABC):
 
 
 class IdleState(VendingState):
-    """待機状態: コイン投入待ち"""
+    """Idle state: waiting for coin insertion"""
 
     @property
     def name(self) -> str:
@@ -829,21 +829,21 @@ class IdleState(VendingState):
 
     def insert_coin(self, machine: VendingMachine, amount: int) -> None:
         machine.balance += amount
-        print(f"投入: {amount}円 (残高: {machine.balance}円)")
+        print(f"Inserted: {amount} yen (balance: {machine.balance} yen)")
         machine.set_state(HasMoneyState())
 
     def select_product(self, machine: VendingMachine, product: str) -> None:
-        print("先にコインを投入してください")
+        print("Please insert a coin first")
 
     def dispense(self, machine: VendingMachine) -> None:
-        print("先にコインを投入し、商品を選択してください")
+        print("Please insert a coin and select a product first")
 
     def cancel(self, machine: VendingMachine) -> None:
-        print("キャンセルする操作がありません")
+        print("There is nothing to cancel")
 
 
 class HasMoneyState(VendingState):
-    """コイン投入済み: 商品選択待ち"""
+    """Coin inserted: waiting for product selection"""
 
     @property
     def name(self) -> str:
@@ -851,51 +851,51 @@ class HasMoneyState(VendingState):
 
     def insert_coin(self, machine: VendingMachine, amount: int) -> None:
         machine.balance += amount
-        print(f"追加投入: {amount}円 (残高: {machine.balance}円)")
+        print(f"Additional coin: {amount} yen (balance: {machine.balance} yen)")
 
     def select_product(self, machine: VendingMachine, product: str) -> None:
         price = machine.get_price(product)
         if price is None:
-            print(f"商品 '{product}' は存在しません")
+            print(f"Product '{product}' does not exist")
             return
         if machine.balance < price:
-            print(f"残高不足: {machine.balance}円 < {price}円")
+            print(f"Insufficient balance: {machine.balance} yen < {price} yen")
             return
         if not machine.has_stock(product):
-            print(f"'{product}' は在庫切れです")
+            print(f"'{product}' is out of stock")
             return
 
         machine.selected_product = product
         machine.balance -= price
-        print(f"'{product}' を選択 (価格: {price}円, 残高: {machine.balance}円)")
+        print(f"Selected '{product}' (price: {price} yen, balance: {machine.balance} yen)")
         machine.set_state(DispensingState())
 
     def dispense(self, machine: VendingMachine) -> None:
-        print("先に商品を選択してください")
+        print("Please select a product first")
 
     def cancel(self, machine: VendingMachine) -> None:
-        print(f"返金: {machine.balance}円")
+        print(f"Refund: {machine.balance} yen")
         machine.balance = 0
         machine.set_state(IdleState())
 
 
 class DispensingState(VendingState):
-    """商品排出中"""
+    """Dispensing product"""
 
     @property
     def name(self) -> str:
         return "dispensing"
 
     def insert_coin(self, machine: VendingMachine, amount: int) -> None:
-        print("商品排出中です。しばらくお待ちください")
+        print("Dispensing product. Please wait")
 
     def select_product(self, machine: VendingMachine, product: str) -> None:
-        print("商品排出中です。しばらくお待ちください")
+        print("Dispensing product. Please wait")
 
     def dispense(self, machine: VendingMachine) -> None:
         product = machine.selected_product
         machine.reduce_stock(product)
-        print(f"'{product}' を排出しました")
+        print(f"Dispensed '{product}'")
         machine.selected_product = None
 
         if machine.balance > 0:
@@ -904,18 +904,18 @@ class DispensingState(VendingState):
             machine.set_state(IdleState())
 
     def cancel(self, machine: VendingMachine) -> None:
-        print("商品排出中はキャンセルできません")
+        print("Cannot cancel while dispensing")
 
 
 # ============================
-# Context: 自動販売機
+# Context: Vending machine
 # ============================
 @dataclass
 class VendingMachine:
     products: dict[str, dict] = field(default_factory=lambda: {
-        "コーラ": {"price": 120, "stock": 5},
-        "お茶": {"price": 100, "stock": 3},
-        "コーヒー": {"price": 150, "stock": 0},  # 在庫切れ
+        "Cola": {"price": 120, "stock": 5},
+        "Tea": {"price": 100, "stock": 3},
+        "Coffee": {"price": 150, "stock": 0},  # Out of stock
     })
     balance: int = 0
     selected_product: str | None = None
@@ -939,7 +939,7 @@ class VendingMachine:
         if product in self.products:
             self.products[product]["stock"] -= 1
 
-    # 操作を状態に委譲
+    # Delegate operations to the state
     def insert_coin(self, amount: int) -> None:
         self._state.insert_coin(self, amount)
 
@@ -954,39 +954,39 @@ class VendingMachine:
 
 
 # ============================
-# 使用例
+# Usage example
 # ============================
 if __name__ == "__main__":
     vm = VendingMachine()
 
-    vm.insert_coin(100)    # 投入: 100円
-    vm.insert_coin(50)     # 追加投入: 50円 (残高: 150円)
-    vm.select_product("コーラ")  # 'コーラ' を選択 (価格: 120円, 残高: 30円)
-    vm.dispense()          # 'コーラ' を排出しました
+    vm.insert_coin(100)    # Inserted: 100 yen
+    vm.insert_coin(50)     # Additional coin: 50 yen (balance: 150 yen)
+    vm.select_product("Cola")  # Selected 'Cola' (price: 120 yen, balance: 30 yen)
+    vm.dispense()          # Dispensed 'Cola'
 
-    print(f"State: {vm._state.name}")  # idle (残高0) or has_money (残高あり)
-    print(f"残高: {vm.balance}円")     # 30円
+    print(f"State: {vm._state.name}")  # idle (balance 0) or has_money (balance remaining)
+    print(f"Balance: {vm.balance} yen")  # 30 yen
 
-    vm.select_product("お茶")  # 先にコインを投入してください... wait
-    # 実は has_money 状態のはず (残高30円)
+    vm.select_product("Tea")  # Please insert a coin first... wait
+    # Actually should be has_money state (30 yen remaining)
 
-    print(f"遷移履歴: {vm._history}")
+    print(f"Transition history: {vm._history}")
 ```
 
 ---
 
-## 7. 階層状態マシン（HSM: Hierarchical State Machine）
+## 7. Hierarchical State Machine (HSM)
 
-### コード例 6: 親子状態による複雑さの管理
+### Code Example 6: Managing Complexity with Parent-Child States
 
 ```typescript
-// hierarchical-state.ts -- 階層状態マシン
+// hierarchical-state.ts -- Hierarchical state machine
 
 // ============================
-// HSM の構造
+// HSM structure
 // ============================
-// 階層状態マシンでは、状態を親子関係で整理できる
-// 子状態で処理できないイベントは親状態に委譲される
+// In a hierarchical state machine, states can be organized in parent-child relationships
+// Events that cannot be handled by a child state are delegated to the parent state
 
 interface HierarchicalState {
   readonly name: string;
@@ -1010,7 +1010,7 @@ class HSMEngine {
   send(event: string): void {
     let state: HierarchicalState | undefined = this.currentState;
 
-    // 現在の状態から親に向かって、ハンドラを探す
+    // Search for a handler from the current state up to parents
     while (state) {
       const nextState = state.handle(event, this.context);
       if (nextState !== null) {
@@ -1024,20 +1024,20 @@ class HSMEngine {
   }
 
   private transitionTo(target: HierarchicalState): void {
-    // 共通祖先を見つけて、exit/entry を正しい順序で実行
+    // Find common ancestor and execute exit/entry in the correct order
     const exitStates = this.getAncestors(this.currentState);
     const enterStates = this.getAncestors(target);
 
-    // 共通祖先より上はスキップ
+    // Skip states above the common ancestor
     const common = this.findCommonAncestor(exitStates, enterStates);
 
-    // exit: 現在の状態から共通祖先まで
+    // exit: from current state up to the common ancestor
     for (const s of exitStates) {
       if (s === common) break;
       s.exit?.(this.context);
     }
 
-    // entry: 共通祖先からターゲットまで
+    // entry: from the common ancestor down to the target
     const toEnter = [];
     for (const s of enterStates) {
       if (s === common) break;
@@ -1078,12 +1078,12 @@ class HSMEngine {
 }
 
 // ============================
-// 使用例: メディアプレーヤー
+// Usage example: media player
 // ============================
-// 階層構造:
+// Hierarchy:
 //   Root
 //   ├── Stopped
-//   └── Playing (親状態)
+//   └── Playing (parent state)
 //       ├── NormalSpeed
 //       └── FastForward
 
@@ -1093,18 +1093,18 @@ const stoppedState: HierarchicalState = {
     if (event === 'PLAY') return normalSpeedState;
     return null;
   },
-  entry() { console.log('[Stopped] 停止中'); },
+  entry() { console.log('[Stopped] Stopped'); },
 };
 
 const playingState: HierarchicalState = {
   name: 'playing',
   handle(event) {
-    // 子状態で処理されないイベントをここで処理
+    // Handle events not processed by child states here
     if (event === 'STOP') return stoppedState;
     return null;
   },
-  entry() { console.log('[Playing] 再生開始'); },
-  exit() { console.log('[Playing] 再生終了'); },
+  entry() { console.log('[Playing] Playback started'); },
+  exit() { console.log('[Playing] Playback ended'); },
 };
 
 const normalSpeedState: HierarchicalState = {
@@ -1112,9 +1112,9 @@ const normalSpeedState: HierarchicalState = {
   parent: playingState,
   handle(event) {
     if (event === 'FAST_FORWARD') return fastForwardState;
-    return null; // 親 (playing) に委譲
+    return null; // Delegate to parent (playing)
   },
-  entry() { console.log('[Normal] 通常速度'); },
+  entry() { console.log('[Normal] Normal speed'); },
 };
 
 const fastForwardState: HierarchicalState = {
@@ -1122,31 +1122,31 @@ const fastForwardState: HierarchicalState = {
   parent: playingState,
   handle(event) {
     if (event === 'NORMAL') return normalSpeedState;
-    return null; // 親 (playing) に委譲
+    return null; // Delegate to parent (playing)
   },
-  entry() { console.log('[FastForward] 早送り'); },
+  entry() { console.log('[FastForward] Fast forward'); },
 };
 
-// 使用例
+// Usage example
 const player = new HSMEngine(stoppedState, {});
-// [Stopped] 停止中
+// [Stopped] Stopped
 
 player.send('PLAY');
-// [Playing] 再生開始
-// [Normal] 通常速度
+// [Playing] Playback started
+// [Normal] Normal speed
 
 player.send('FAST_FORWARD');
-// [FastForward] 早送り
+// [FastForward] Fast forward
 
 player.send('STOP');
-// ★ fastForward 自体は STOP を処理できないので、
-//    親の playing に委譲 → stoppedState に遷移
-// [Playing] 再生終了
-// [Stopped] 停止中
+// ★ fastForward itself cannot handle STOP, so
+//    it delegates to the parent playing → transitions to stoppedState
+// [Playing] Playback ended
+// [Stopped] Stopped
 ```
 
 ```
-階層状態マシンの構造:
+Hierarchical state machine structure:
 
   ┌─────────────────────────────────────────┐
   │                Root                      │
@@ -1163,23 +1163,23 @@ player.send('STOP');
   │                                          │
   └──────────────────────────────────────────┘
 
-  イベント委譲の流れ:
-    FastForward で STOP を受け取った場合:
-    1. FastForward.handle('STOP') → null（処理できない）
-    2. Playing.handle('STOP') → stoppedState（親が処理）
+  Event delegation flow:
+    When STOP is received in FastForward:
+    1. FastForward.handle('STOP') → null (cannot handle)
+    2. Playing.handle('STOP') → stoppedState (parent handles it)
 ```
 
 ---
 
-## 8. React での State パターン
+## 8. State Pattern in React
 
-### コード例 7: useReducer + State パターンでUIの状態管理
+### Code Example 7: UI State Management with useReducer + State Pattern
 
 ```typescript
-// react-state-pattern.tsx -- React での State パターン活用
+// react-state-pattern.tsx -- Using the State pattern in React
 
 // ============================
-// UI の状態定義
+// UI state definitions
 // ============================
 type ModalState =
   | { status: 'closed' }
@@ -1199,7 +1199,7 @@ type ModalAction =
   | { type: 'RETRY' };
 
 // ============================
-// State パターンを Reducer で表現
+// Expressing the State pattern as a Reducer
 // ============================
 function modalReducer(state: ModalState, action: ModalAction): ModalState {
   switch (state.status) {
@@ -1231,7 +1231,7 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
     case 'error':
       switch (action.type) {
         case 'RETRY':
-          if (state.retryCount >= 3) return state; // ガード条件
+          if (state.retryCount >= 3) return state; // Guard condition
           return { status: 'loading' };
         case 'CLOSE': return { status: 'closed' };
         default: return state;
@@ -1239,7 +1239,7 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
 
     case 'confirming':
       switch (action.type) {
-        case 'CONFIRM_YES': return { status: 'closed' }; // 確認後に閉じる
+        case 'CONFIRM_YES': return { status: 'closed' }; // Close after confirmation
         case 'CONFIRM_NO': return { status: 'open', data: state.data };
         default: return state;
       }
@@ -1250,30 +1250,30 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
 }
 
 // ============================
-// React コンポーネントでの使用
+// Usage in a React component
 // ============================
 /*
 function ModalComponent() {
   const [state, dispatch] = useReducer(modalReducer, { status: 'closed' });
 
-  // 状態に応じた UI レンダリング
+  // Render UI based on state
   switch (state.status) {
     case 'closed':
-      return <button onClick={() => dispatch({ type: 'OPEN' })}>開く</button>;
+      return <button onClick={() => dispatch({ type: 'OPEN' })}>Open</button>;
 
     case 'loading':
-      return <div>読み込み中...</div>;
+      return <div>Loading...</div>;
 
     case 'open':
       return (
         <div>
           <pre>{JSON.stringify(state.data)}</pre>
-          <button onClick={() => dispatch({ type: 'CLOSE' })}>閉じる</button>
+          <button onClick={() => dispatch({ type: 'CLOSE' })}>Close</button>
           <button onClick={() => dispatch({
             type: 'CONFIRM',
-            message: '本当に削除しますか？',
+            message: 'Are you sure you want to delete?',
           })}>
-            削除
+            Delete
           </button>
         </div>
       );
@@ -1281,13 +1281,13 @@ function ModalComponent() {
     case 'error':
       return (
         <div>
-          <p>エラー: {state.message}</p>
+          <p>Error: {state.message}</p>
           {state.retryCount < 3 && (
             <button onClick={() => dispatch({ type: 'RETRY' })}>
-              リトライ ({state.retryCount}/3)
+              Retry ({state.retryCount}/3)
             </button>
           )}
-          <button onClick={() => dispatch({ type: 'CLOSE' })}>閉じる</button>
+          <button onClick={() => dispatch({ type: 'CLOSE' })}>Close</button>
         </div>
       );
 
@@ -1295,8 +1295,8 @@ function ModalComponent() {
       return (
         <div>
           <p>{state.message}</p>
-          <button onClick={() => dispatch({ type: 'CONFIRM_YES' })}>はい</button>
-          <button onClick={() => dispatch({ type: 'CONFIRM_NO' })}>いいえ</button>
+          <button onClick={() => dispatch({ type: 'CONFIRM_YES' })}>Yes</button>
+          <button onClick={() => dispatch({ type: 'CONFIRM_NO' })}>No</button>
         </div>
       );
   }
@@ -1304,103 +1304,103 @@ function ModalComponent() {
 */
 ```
 
-React の `useReducer` は State パターンそのものです。state の `status` フィールドが「どの State クラスか」に対応し、`switch (state.status)` が「状態ごとの振る舞い分岐」に対応します。discriminated union（判別可能共用型）により、各状態で利用可能なプロパティが型安全に制限されます。
+React's `useReducer` is the State pattern itself. The `status` field of the state corresponds to "which State class", and `switch (state.status)` corresponds to "behavior branching per state". Discriminated unions ensure that the properties available in each state are type-safely restricted.
 
 ---
 
-## 9. 深掘り: State パターンの設計判断
+## 9. Deep Dive: Design Decisions for the State Pattern
 
-### 遷移の責任をどこに持たせるか
+### Where to Place Transition Responsibility
 
 ```
-方式1: State 内部で遷移（GoF の推奨）
-  各 State クラスが次の状態を直接知っている
+Approach 1: Transitions inside State (GoF recommendation)
+  Each State class directly knows the next state
   PaidState.ship() → context.setState(new ShippedState())
 
-  利点: 各状態が自律的、分散した制御
-  欠点: 状態間の結合、遷移の全体像が見づらい
+  Pros: Each state is autonomous, decentralized control
+  Cons: Coupling between states, the overall transition picture is hard to see
 
-方式2: Context / 遷移テーブルで一元管理
-  外部テーブルで全遷移を定義
+Approach 2: Centralized management via Context / transition table
+  All transitions are defined in an external table
   transitions['paid']['SHIP'] = 'shipped'
 
-  利点: 遷移の全体像が明確、変更しやすい
-  欠点: テーブルが大きくなる、ガード条件の表現が冗長
+  Pros: Overall transitions are clear, easy to change
+  Cons: Table grows large, guard conditions are verbose to express
 
-方式3: ハイブリッド
-  単純な遷移はテーブル、複雑な遷移はメソッド内で
-  guard 条件付き遷移はメソッドで、単純遷移はテーブルで
+Approach 3: Hybrid
+  Simple transitions use the table, complex transitions use methods
+  Transitions with guard conditions use methods, simple ones use the table
 ```
 
-### State オブジェクトの生成戦略
+### State Object Creation Strategy
 
 ```
-方式1: 毎回 new で生成
+Approach 1: Create a new instance each time
   context.setState(new PaidState());
-  利点: 状態固有のデータを保持可能
-  欠点: GC 負荷
+  Pros: Can hold state-specific data
+  Cons: GC pressure
 
-方式2: Singleton / 共有インスタンス
+Approach 2: Singleton / shared instance
   context.setState(PaidState.INSTANCE);
-  利点: メモリ効率が良い
-  欠点: 状態にデータを持てない
+  Pros: Memory efficient
+  Cons: Cannot hold data in the state
 
-方式3: Flyweight + 外部データ
-  状態は共有、データは Context に保持
-  利点: メモリ効率 + データ保持
-  欠点: 実装がやや複雑
+Approach 3: Flyweight + external data
+  State is shared, data is held in Context
+  Pros: Memory efficient + data holding
+  Cons: Implementation is slightly more complex
 
-  判断基準: 状態固有データがあるか？
-  ある → 方式1
-  ない → 方式2（推奨）
+  Decision criteria: Is there state-specific data?
+  Yes → Approach 1
+  No  → Approach 2 (recommended)
 ```
 
 ---
 
-## 10. 比較表
+## 10. Comparison Table
 
-### State vs 他のパターン
+### State vs Other Patterns
 
-| 特性 | State パターン | Strategy パターン | if/else 分岐 |
+| Characteristic | State Pattern | Strategy Pattern | if/else Branching |
 |------|--------------|-----------------|-------------|
-| 振る舞いの切替 | 内部状態に応じて自動 | 外部から明示的に注入 | 条件分岐で決定 |
-| 遷移の管理 | 状態クラスが遷移先を知る | 遷移の概念なし | コード内に散在 |
-| 遷移の主体 | State 自身が遷移を決定 | Client が切り替え | なし |
-| OCP (新しい状態の追加) | 新クラスを追加するだけ | 新戦略を追加するだけ | 全条件を修正 |
-| テスタビリティ | 状態ごとに独立テスト | 戦略ごとに独立テスト | 全パス網羅が困難 |
-| 複雑さ | 中（状態数に比例） | 低い | 状態数の二乗に比例 |
+| Behavior switching | Automatic based on internal state | Explicitly injected from outside | Determined by conditional branches |
+| Transition management | State class knows the next state | No concept of transitions | Scattered throughout code |
+| Who drives transitions | State itself decides the transition | Client switches | None |
+| OCP (adding new states) | Just add a new class | Just add a new strategy | Modify all conditions |
+| Testability | Independent test per state | Independent test per strategy | Hard to cover all paths |
+| Complexity | Medium (proportional to number of states) | Low | Proportional to the square of number of states |
 
-### FSM ライブラリの比較
+### FSM Library Comparison
 
-| 特性 | XState | Robot | Zustand + 自前FSM | 自前実装 |
+| Characteristic | XState | Robot | Zustand + custom FSM | Custom implementation |
 |------|--------|-------|--------------------|---------|
-| 型安全性 | 高い（v5で大幅改善） | 高い | 中 | 実装次第 |
-| 可視化 | Inspector / Visualizer | なし | なし | なし |
-| 階層状態 | 対応 | 非対応 | 非対応 | 要実装 |
-| 並行状態 | 対応 | 非対応 | 非対応 | 要実装 |
-| バンドルサイズ | ~40KB | ~1KB | ~3KB + 自前 | 0 |
-| 学習コスト | 高い | 低い | 中 | 低い |
-| 実績 | 大規模プロダクト多数 | 中規模 | 多数 | -- |
+| Type safety | High (greatly improved in v5) | High | Medium | Depends on implementation |
+| Visualization | Inspector / Visualizer | None | None | None |
+| Hierarchical states | Supported | Not supported | Not supported | Requires implementation |
+| Parallel states | Supported | Not supported | Not supported | Requires implementation |
+| Bundle size | ~40KB | ~1KB | ~3KB + custom | 0 |
+| Learning cost | High | Low | Medium | Low |
+| Track record | Many large-scale products | Medium scale | Many | -- |
 
-### State パターンの導入判断
+### Deciding When to Introduce the State Pattern
 
-| 判断基準 | State パターンが有効 | if/else で十分 |
+| Decision Criteria | State Pattern Is Effective | if/else Is Sufficient |
 |---------|---------------------|---------------|
-| 状態数 | 3つ以上 | 2つ以下 |
-| 状態依存メソッド数 | 2つ以上 | 1つ |
-| 新しい状態の追加 | 頻繁にありえる | ほぼ固定 |
-| 遷移ルール | 複雑（ガード条件あり） | 単純 |
-| テスト要件 | 状態ごとの独立テストが必要 | 網羅テストで十分 |
+| Number of states | 3 or more | 2 or fewer |
+| State-dependent methods | 2 or more | 1 |
+| Adding new states | Likely to happen frequently | Nearly fixed |
+| Transition rules | Complex (with guard conditions) | Simple |
+| Testing requirements | Independent tests per state needed | Coverage testing is enough |
 
 ---
 
-## 11. アンチパターン
+## 11. Anti-patterns
 
-### アンチパターン 1: 巨大な switch/if-else チェーン
+### Anti-pattern 1: Giant switch/if-else chains
 
 ```typescript
 // ============================
-// [NG] 状態ごとの分岐が全メソッドに散在
+// [BAD] Per-state branching scattered across all methods
 // ============================
 class Order {
   status: string = 'pending';
@@ -1417,55 +1417,55 @@ class Order {
     } else if (this.status === 'cancelled') {
       throw new Error('Order is cancelled');
     }
-    // 新しい状態 "returned" を追加 → ここに分岐を追加
+    // Adding new state "returned" → add branch here
   }
 
   ship(): void {
     if (this.status === 'paid') { /* ... */ }
     else if (this.status === 'pending') { throw new Error('Must pay first'); }
     else if (this.status === 'shipped') { throw new Error('Already shipped'); }
-    // ... 同じパターンの繰り返し
-    // 新しい状態 "returned" を追加 → ここにも分岐を追加
+    // ... same pattern repeats
+    // Adding new state "returned" → add branch here too
   }
 
-  // deliver(), cancel() も同様...
-  // 5状態 x 4メソッド = 20箇所の条件分岐!!
+  // deliver(), cancel() follow the same pattern...
+  // 5 states x 4 methods = 20 conditional branches!!
 }
 
 // ============================
-// [OK] State パターンで状態ごとのクラスに分離
+// [GOOD] Separate into per-state classes using the State pattern
 // ============================
-// → 各状態の振る舞いが1クラスにまとまり、保守性が向上
-// → 新しい状態の追加は新クラスの追加のみ
-// → 既存コードの修正不要（OCP 準拠）
-// (実装は上記コード例 1 を参照)
+// → Each state's behavior is consolidated in one class, improving maintainability
+// → Adding a new state only requires adding a new class
+// → No modification to existing code required (OCP compliant)
+// (See Code Example 1 above for the implementation)
 ```
 
-### アンチパターン 2: 遷移の暗黙的な副作用
+### Anti-pattern 2: Implicit side effects in transitions
 
 ```typescript
 // ============================
-// [NG] 遷移の副作用が State 内に隠れている
+// [BAD] Side effects of transitions hidden inside the State
 // ============================
 class PaidStateNG implements OrderState {
   readonly name = 'paid';
 
   ship(context: OrderContext): void {
-    // ★ 遷移のたびに大量の副作用が暗黙的に実行される
+    // ★ A large number of side effects are executed implicitly on every transition
     sendEmail(context.orderId, 'Your order has been shipped!');
     updateInventory(context.orderId);
     notifyWarehouse(context.orderId);
     logToAnalytics('order_shipped', context.orderId);
     context.setState(new ShippedState(), 'ship');
-    // どの副作用が実行されるか、外から全く見えない
+    // What side effects run is completely invisible from the outside
   }
   // ...
 }
 
 // ============================
-// [OK] 副作用を遷移アクション/ミドルウェアとして明示
+// [GOOD] Explicitly define side effects as transition actions/middleware
 // ============================
-// 方法1: FSM の action として宣言的に定義
+// Method 1: Declare declaratively as FSM actions
 const orderFSM = new FSM<OrderContext>({
   id: 'order',
   initial: 'pending',
@@ -1476,7 +1476,7 @@ const orderFSM = new FSM<OrderContext>({
         SHIP: {
           target: 'shipped',
           action: (ctx) => {
-            // 副作用が明示的に定義されている
+            // Side effects are explicitly defined
             emailService.send(ctx.orderId, 'shipped');
             inventoryService.update(ctx.orderId);
             warehouseService.notify(ctx.orderId);
@@ -1488,16 +1488,16 @@ const orderFSM = new FSM<OrderContext>({
   },
 });
 
-// 方法2: Observer パターンと組合せ
-// State の遷移をイベントとして通知し、
-// 副作用はリスナー側で処理する
+// Method 2: Combine with Observer pattern
+// Notify state transitions as events,
+// and handle side effects on the listener side
 class OrderContextWithEvents extends OrderContext {
   private listeners: Array<(event: { from: string; to: string }) => void> = [];
 
   override setState(state: OrderState, action: string): void {
     const from = this.getStateName();
     super.setState(state, action);
-    // 遷移後にイベント通知
+    // Notify event after transition
     for (const listener of this.listeners) {
       listener({ from, to: state.name });
     }
@@ -1508,7 +1508,7 @@ class OrderContextWithEvents extends OrderContext {
   }
 }
 
-// 副作用をリスナーとして登録（テスト時はモックに差し替え可能）
+// Register side effects as listeners (can be replaced with mocks during testing)
 const order2 = new OrderContextWithEvents('ORD-002');
 order2.onTransition(({ from, to }) => {
   if (from === 'paid' && to === 'shipped') {
@@ -1518,11 +1518,11 @@ order2.onTransition(({ from, to }) => {
 });
 ```
 
-### アンチパターン 3: 状態とデータの混同
+### Anti-pattern 3: Confusing state with data
 
 ```typescript
 // ============================
-// [NG] フラグの組み合わせで「状態」を表現
+// [BAD] Representing "state" with a combination of flags
 // ============================
 class FormNG {
   isSubmitting: boolean = false;
@@ -1533,14 +1533,14 @@ class FormNG {
   submit(): void {
     if (this.isSubmitting) return;
     if (this.isValidating) return;
-    // isSubmitting && hasError はどういう状態？
-    // フラグの組み合わせ: 2^4 = 16 通り
-    // 実際に有効な状態はその一部だが、不正な組み合わせを防げない
+    // What does isSubmitting && hasError mean?
+    // Flag combinations: 2^4 = 16 possibilities
+    // Only some are valid states, but invalid combinations cannot be prevented
   }
 }
 
 // ============================
-// [OK] Discriminated Union で有効な状態のみを表現
+// [GOOD] Use Discriminated Union to represent only valid states
 // ============================
 type FormState =
   | { status: 'idle' }
@@ -1550,16 +1550,16 @@ type FormState =
   | { status: 'success'; submittedAt: Date }
   | { status: 'error'; message: string; retryCount: number };
 
-// 不正な状態の組み合わせが型レベルで存在しない
-// status === 'idle' のときに data にアクセス → 型エラー
+// Invalid state combinations do not exist at the type level
+// Accessing data when status === 'idle' → type error
 function handleForm(state: FormState): void {
   switch (state.status) {
     case 'error':
-      console.log(state.message);      // OK: error 状態にのみ message がある
+      console.log(state.message);      // OK: message only exists in error state
       console.log(state.retryCount);   // OK
       break;
     case 'idle':
-      // console.log(state.message);   // 型エラー! idle に message はない
+      // console.log(state.message);   // Type error! idle has no message
       break;
   }
 }
@@ -1567,24 +1567,24 @@ function handleForm(state: FormState): void {
 
 ---
 
-## 12. 演習問題
+## 12. Exercises
 
-### 演習 1（基礎）: ATM の状態管理
+### Exercise 1 (Basic): ATM State Management
 
-以下の仕様を満たす ATM の State パターンを実装してください。
+Implement an ATM State pattern that satisfies the following specification.
 
-**仕様:**
-- 状態: `idle`（待機） → `cardInserted`（カード挿入済み） → `pinVerified`（暗証番号確認済み） → `transacting`（取引中） → `idle`
-- 操作: `insertCard()`, `enterPin(pin)`, `selectTransaction(type)`, `ejectCard()`
-- 暗証番号は3回間違えるとカードをロック（`locked` 状態）
+**Specification:**
+- States: `idle` (waiting) → `cardInserted` (card inserted) → `pinVerified` (PIN verified) → `transacting` (in transaction) → `idle`
+- Operations: `insertCard()`, `enterPin(pin)`, `selectTransaction(type)`, `ejectCard()`
+- If the PIN is entered incorrectly 3 times, the card is locked (`locked` state)
 
-**期待される出力:**
+**Expected output:**
 ```
 atm.insertCard('1234-5678')
 → [ATM] idle → cardInserted
-atm.enterPin('0000')  // 間違い
-→ "暗証番号が違います (残り2回)"
-atm.enterPin('1234')  // 正解
+atm.enterPin('0000')  // Wrong
+→ "Incorrect PIN (2 attempts remaining)"
+atm.enterPin('1234')  // Correct
 → [ATM] cardInserted → pinVerified
 atm.selectTransaction('withdraw')
 → [ATM] pinVerified → transacting
@@ -1594,160 +1594,158 @@ atm.ejectCard()
 
 ---
 
-### 演習 2（応用）: WebSocket 接続の FSM
+### Exercise 2 (Intermediate): WebSocket Connection FSM
 
-以下の仕様を満たす WebSocket 接続状態の FSM を実装してください。
+Implement a WebSocket connection state FSM that satisfies the following specification.
 
-**仕様:**
-- 状態: `disconnected`, `connecting`, `connected`, `reconnecting`, `error`
-- イベント: `CONNECT`, `CONNECTED`, `DISCONNECT`, `ERROR`, `RETRY`
-- ガード条件: `reconnecting` → `connecting` はリトライ回数が5回以下の場合のみ
-- 自動リコネクト: `error` 状態で3秒後に自動 RETRY
+**Specification:**
+- States: `disconnected`, `connecting`, `connected`, `reconnecting`, `error`
+- Events: `CONNECT`, `CONNECTED`, `DISCONNECT`, `ERROR`, `RETRY`
+- Guard condition: `reconnecting` → `connecting` only allowed when retry count is 5 or fewer
+- Auto-reconnect: automatic RETRY after 3 seconds in `error` state
 
-**期待される出力:**
+**Expected output:**
 ```
 ws.send('CONNECT')    → disconnected → connecting
 ws.send('CONNECTED')  → connecting → connected
-ws.send('ERROR')      → connected → error → (3秒後) → reconnecting → connecting
+ws.send('ERROR')      → connected → error → (after 3s) → reconnecting → connecting
 ws.send('CONNECTED')  → connecting → connected
-// 5回以上リトライ失敗:
-ws.send('ERROR')      → "最大リトライ回数に達しました"
+// After 5 or more failed retries:
+ws.send('ERROR')      → "Maximum retry count reached"
 ```
 
 ---
 
-### 演習 3（発展）: ゲーム AI の行動状態マシン
+### Exercise 3 (Advanced): Game AI Behavior State Machine
 
-以下の仕様を満たす敵キャラクター AI の階層状態マシンを実装してください。
+Implement a hierarchical state machine for an enemy character AI that satisfies the following specification.
 
-**仕様:**
-- 親状態: `alive`, `dead`
-- `alive` の子状態: `idle`, `patrol`, `chase`, `attack`
-- 遷移条件:
-  - `idle` → `patrol`: 一定時間経過
-  - `patrol` → `chase`: プレイヤーを検知（距離 < 100）
-  - `chase` → `attack`: 攻撃範囲内（距離 < 20）
-  - `chase` → `patrol`: プレイヤーを見失う（距離 > 150）
-  - `attack` → `chase`: プレイヤーが攻撃範囲外に逃げる
+**Specification:**
+- Parent states: `alive`, `dead`
+- Child states of `alive`: `idle`, `patrol`, `chase`, `attack`
+- Transition conditions:
+  - `idle` → `patrol`: after a certain amount of time has passed
+  - `patrol` → `chase`: player detected (distance < 100)
+  - `chase` → `attack`: within attack range (distance < 20)
+  - `chase` → `patrol`: player lost (distance > 150)
+  - `attack` → `chase`: player escapes outside attack range
   - `alive.*` → `dead`: HP <= 0
 
-**期待される出力:**
+**Expected output:**
 ```
 enemy.update({ playerDistance: 200, hp: 100 })
-→ [idle] 待機中...
+→ [idle] Idling...
 enemy.update({ playerDistance: 80, hp: 100 })
-→ [idle → chase] プレイヤー検知! 追跡開始
+→ [idle → chase] Player detected! Starting pursuit
 enemy.update({ playerDistance: 15, hp: 100 })
-→ [chase → attack] 攻撃範囲内! 攻撃開始
+→ [chase → attack] Within attack range! Starting attack
 enemy.update({ playerDistance: 15, hp: 0 })
-→ [attack → dead] HP が 0 になりました（alive の子状態で共通ハンドリング）
+→ [attack → dead] HP reached 0 (common handling in alive child state)
 ```
 
 ---
 
 ## 13. FAQ
 
-### Q1: State パターンと Strategy パターンの違いは何ですか？
+### Q1: What is the difference between the State pattern and the Strategy pattern?
 
-構造（UML 図）はほぼ同じですが、**意図と遷移の有無**が本質的に異なります。
+The structure (UML diagram) is nearly identical, but they differ fundamentally in **intent and whether transitions exist**.
 
-| 比較項目 | State | Strategy |
+| Comparison | State | Strategy |
 |---------|-------|----------|
-| 意図 | 内部状態に応じて振る舞いが変わる | アルゴリズムを外部から注入 |
-| 遷移 | State 自身が次の状態に遷移する | 遷移の概念なし |
-| 切替の主体 | State オブジェクト自身 | Client（外部） |
-| 典型例 | 注文のライフサイクル管理 | ソートアルゴリズムの選択 |
+| Intent | Behavior changes based on internal state | Algorithm is injected from outside |
+| Transitions | State itself transitions to the next state | No concept of transitions |
+| Who switches | The State object itself | The Client (external) |
+| Typical example | Order lifecycle management | Choosing a sorting algorithm |
 
-判断基準: 「振る舞いの切り替えが自動か手動か」。ユーザーの操作とは無関係に、内部の条件によって振る舞いが変わるなら State、外部から明示的にアルゴリズムを選択するなら Strategy です。
+Decision criteria: "Is the behavior switching automatic or manual?" If behavior changes automatically based on internal conditions regardless of user action, use State. If an algorithm is explicitly selected from the outside, use Strategy.
 
-### Q2: 状態の数が多い場合はどうすべきですか？
+### Q2: What should I do when there are many states?
 
-状態が 10 以上になる場合は以下を検討してください。
+If there are 10 or more states, consider the following.
 
-1. **階層状態マシン（HSM）**: 共通の振る舞いを親状態にまとめる。XState はネイティブサポートあり。
-2. **並行状態マシン**: 独立した関心事を別の FSM に分離し並行で動かす。例: 「接続状態」と「認証状態」は別 FSM。
-3. **状態の分解**: 1つの「状態」が実は2つの独立した概念の組み合わせではないか検討する。例: `loadingAuthenticated` は `loading` x `authenticated` に分解。
+1. **Hierarchical State Machine (HSM)**: Consolidate common behavior in parent states. XState has native support.
+2. **Parallel state machines**: Separate independent concerns into separate FSMs running in parallel. For example: "connection state" and "authentication state" as separate FSMs.
+3. **State decomposition**: Check whether one "state" is actually a combination of two independent concepts. For example: `loadingAuthenticated` can be decomposed into `loading` x `authenticated`.
 
-### Q3: State パターンをどの程度の規模から導入すべきですか？
+### Q3: From what scale should I introduce the State pattern?
 
-**状態が3つ以上**かつ、**状態によって振る舞いが異なるメソッドが2つ以上**ある場合に検討する価値があります。状態が2つで分岐も1〜2箇所なら、シンプルな if 文の方が可読性が高いです。
+It is worth considering when there are **3 or more states** and **2 or more methods whose behavior differs by state**. If there are only 2 states and only 1-2 branching points, a simple if statement will be more readable.
 
-判断の公式:
+Decision formula:
 ```
-修正コスト = 新しい状態の追加時に修正するファイル/メソッドの数
-  if/else 方式: 修正コスト = メソッド数 × 1
-  State 方式:   修正コスト = 1（新クラスの追加のみ）
+Modification cost = number of files/methods to modify when adding a new state
+  if/else approach: modification cost = number of methods × 1
+  State approach:   modification cost = 1 (only adding a new class)
 
-修正コスト > 3 なら State パターンの導入効果あり
+If modification cost > 3, introducing the State pattern is worthwhile
 ```
 
-### Q4: XState を使うべきか、自前実装すべきか？
+### Q4: Should I use XState or a custom implementation?
 
-判断基準:
+Decision criteria:
 
-| 要件 | XState | 自前実装 |
+| Requirement | XState | Custom implementation |
 |------|--------|---------|
-| 階層状態が必要 | XState | 実装が大変 |
-| 可視化が必要 | XState（Inspector） | 別途開発が必要 |
-| バンドルサイズ制限 | 自前（~0KB） | -- |
-| 並行状態が必要 | XState | 実装が非常に大変 |
-| 単純な FSM（状態5個以下） | 自前 | -- |
-| チーム全員が XState を知っている | XState | -- |
+| Hierarchical states needed | XState | Hard to implement |
+| Visualization needed | XState (Inspector) | Requires separate development |
+| Bundle size constraints | Custom (~0KB) | -- |
+| Parallel states needed | XState | Very hard to implement |
+| Simple FSM (5 or fewer states) | Custom | -- |
+| Everyone on the team knows XState | XState | -- |
 
-### Q5: State パターンと状態管理ライブラリ（Redux, Zustand）の関係は？
+### Q5: What is the relationship between the State pattern and state management libraries (Redux, Zustand)?
 
-Redux や Zustand は「アプリケーション全体の状態」を管理するライブラリであり、State パターンは「特定のオブジェクトの振る舞いの切り替え」を管理するパターンです。
-
-両者は排他ではなく、**併用**するのが一般的です。例: Redux の store に注文のステータス（`pending`, `paid`, ...）を保持しつつ、各ステータスの振る舞い（許可される操作、UI の表示内容）は State パターンの reducer で管理する。React の `useReducer` は State パターンの典型的な実装例です。
+Redux and Zustand are libraries that manage "the entire application's state", while the State pattern manages "switching an object's behavior". The two are not mutually exclusive and are commonly **used together**. For example: hold the order status (`pending`, `paid`, ...) in the Redux store, while managing the behavior for each status (allowed operations, UI display content) in a State pattern reducer. React's `useReducer` is a typical implementation of the State pattern.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not just through theory, but by actually writing code and verifying its behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. It is recommended to thoroughly understand the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes particularly important during code reviews and architectural design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Item | Key Points |
 |------|------|
-| State パターンの本質 | 条件分岐をポリモーフィズムに変換。if/else の爆発を防止 |
-| Context | 現在の状態を保持し、操作を状態オブジェクトに委譲 |
-| 遷移の責任 | State 自身が次の状態を決定する（Strategy との決定的な違い） |
-| 型安全 FSM | TypeScript の型システムで遷移を制約。不正な遷移をコンパイル時に検出 |
-| 宣言的 FSM | 設定オブジェクトで状態遷移を定義。可視化・テストが容易 |
-| 階層状態マシン (HSM) | 親子関係で状態を整理。イベント委譲による共通処理の集約 |
-| React との連携 | useReducer + Discriminated Union が State パターンの実装 |
-| 導入判断 | 状態3以上 & 状態依存メソッド2以上で検討 |
+| Essence of the State pattern | Convert conditional branching into polymorphism. Prevent if/else explosion |
+| Context | Holds the current state and delegates operations to state objects |
+| Transition responsibility | The State itself decides the next state (the decisive difference from Strategy) |
+| Type-safe FSM | Constrain transitions with TypeScript's type system. Detect invalid transitions at compile time |
+| Declarative FSM | Define state transitions in a configuration object. Easy to visualize and test |
+| Hierarchical State Machine (HSM) | Organize states in parent-child relationships. Aggregate common processing via event delegation |
+| Integration with React | useReducer + Discriminated Union is an implementation of the State pattern |
+| Adoption decision | Consider when there are 3+ states & 2+ state-dependent methods |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [02-command.md](./02-command.md) -- Command パターンと Undo/Redo（Command + State で状態付き操作管理）
-- [01-strategy.md](./01-strategy.md) -- Strategy パターン（State との構造的類似点と意図の違い）
-- [04-iterator.md](./04-iterator.md) -- Iterator パターンとジェネレータ
-- [00-observer.md](./00-observer.md) -- Observer パターン（State 遷移の通知に活用）
-- Event Sourcing / CQRS -- State の変化をイベントとして記録
+- [02-command.md](./02-command.md) -- Command pattern and Undo/Redo (stateful operation management with Command + State)
+- [01-strategy.md](./01-strategy.md) -- Strategy pattern (structural similarities with State and differences in intent)
+- [04-iterator.md](./04-iterator.md) -- Iterator pattern and generators
+- [00-observer.md](./00-observer.md) -- Observer pattern (used for notifying State transitions)
+- Event Sourcing / CQRS -- Recording state changes as events
 
 ---
 
-## 参考文献
+## References
 
-1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- State パターンの原典。Chapter 5, pp.305-313
-2. **XState Documentation** -- https://xstate.js.org/docs/ -- 宣言的状態マシンライブラリの公式ドキュメント
-3. **Statecharts: A Visual Formalism for Complex Systems** -- David Harel (1987) -- 階層状態マシンの理論的基盤。State パターンの学術的ルーツ
-4. **Refactoring.Guru - State** -- https://refactoring.guru/design-patterns/state -- 図解と多言語実装例
-5. **Ian Horrocks - Constructing the User Interface with Statecharts** -- Addison-Wesley (1999) -- UI 設計における状態マシンの実践的ガイド
+1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- The original source for the State pattern. Chapter 5, pp.305-313
+2. **XState Documentation** -- https://xstate.js.org/docs/ -- Official documentation for the declarative state machine library
+3. **Statecharts: A Visual Formalism for Complex Systems** -- David Harel (1987) -- Theoretical foundation of hierarchical state machines. Academic roots of the State pattern
+4. **Refactoring.Guru - State** -- https://refactoring.guru/design-patterns/state -- Illustrated examples and multi-language implementations
+5. **Ian Horrocks - Constructing the User Interface with Statecharts** -- Addison-Wesley (1999) -- Practical guide for state machines in UI design

--- a/03-software-design/design-patterns-guide/docs/02-behavioral/04-iterator.md
+++ b/03-software-design/design-patterns-guide/docs/02-behavioral/04-iterator.md
@@ -1,109 +1,111 @@
-# Iterator パターン
+# Iterator Pattern
 
-> コレクションの内部構造を隠蔽しつつ要素に順次アクセスする手法と、ジェネレータによる遅延評価を習得する
-
----
-
-## この章で学ぶこと
-
-1. **Iterator プロトコルの仕組み** -- Symbol.iterator と for...of の内部動作、カスタムイテレータの設計と実装
-2. **ジェネレータ関数 (function*)** -- yield による遅延評価、無限シーケンス、コルーチンとしてのジェネレータ
-3. **非同期イテレータ (AsyncGenerator)** -- API ページネーション、ストリーム処理、for await...of の活用
-4. **実用的なイテレータパターン** -- 遅延評価パイプライン、ツリー走査、外部イテレータと内部イテレータ
-5. **GoF の Iterator と JavaScript の Iterator プロトコル** -- 古典的パターンと言語組込みプロトコルの対応関係
+> Master techniques for sequentially accessing elements while hiding a collection's internal structure, and learn lazy evaluation using generators
 
 ---
 
-## 前提知識
+## What You Will Learn
 
-| トピック | 必要な理解 | 参照リンク |
+1. **How the Iterator protocol works** -- Internal workings of Symbol.iterator and for...of, designing and implementing custom iterators
+2. **Generator functions (function*)** -- Lazy evaluation with yield, infinite sequences, generators as coroutines
+3. **Async iterators (AsyncGenerator)** -- API pagination, stream processing, using for await...of
+4. **Practical iterator patterns** -- Lazy evaluation pipelines, tree traversal, external vs internal iterators
+5. **GoF Iterator and the JavaScript Iterator protocol** -- Relationship between the classic pattern and the language-built-in protocol
+
+---
+
+## Prerequisites
+
+| Topic | Required Understanding | Reference |
 |---------|-----------|-----------|
-| TypeScript のジェネリクス | `Iterable<T>`, `Iterator<T>`, `Generator<T>` の型パラメータ | 02-programming |
-| Promise / async-await | 非同期処理の基本、`for await...of` の構文 | 02-programming |
-| データ構造の基本 | 配列、連結リスト、ツリーの概念 | 01-cs-fundamentals |
-| Composite パターン | ツリー構造のパターン（走査に Iterator を利用） | [../01-structural/04-composite.md](../01-structural/04-composite.md) |
+| TypeScript generics | Type parameters of `Iterable<T>`, `Iterator<T>`, `Generator<T>` | 02-programming |
+| Promise / async-await | Basics of async processing, `for await...of` syntax | 02-programming |
+| Basic data structures | Concepts of arrays, linked lists, and trees | 01-cs-fundamentals |
+| Composite pattern | Tree structure pattern (uses Iterator for traversal) | [../01-structural/04-composite.md](../01-structural/04-composite.md) |
 
 ---
 
-## なぜ Iterator パターンが必要なのか
+## Why the Iterator Pattern Is Needed
 
-### コレクションの内部構造への依存問題
+### The Problem of Depending on a Collection's Internal Structure
 
 ```
-配列、連結リスト、ツリー、ハッシュマップ...
-コレクションの種類ごとに走査方法が異なる:
+Arrays, linked lists, trees, hash maps...
+Each collection type has a different traversal method:
 
-  配列:
+  Array:
     for (let i = 0; i < arr.length; i++) { arr[i] }
 
-  連結リスト:
+  Linked List:
     let node = head;
     while (node) { node = node.next; }
 
-  ツリー (深さ優先):
+  Tree (depth-first):
     function traverse(node) {
       visit(node);
       for (const child of node.children) traverse(child);
     }
 
-  ハッシュマップ:
+  Hash Map:
     for (const key of Object.keys(map)) { map[key] }
 
-  問題:
+  Problem:
   ┌────────────────────────────────────────────────┐
-  │ 利用者がコレクションの内部構造を知る必要がある    │
-  │ コレクションの種類を変えると、走査コードも変更     │
-  │ 走査ロジック (DFS/BFS 等) が利用者側に散在       │
+  │ Consumers need to know the internal structure  │
+  │ Changing the collection type requires changing │
+  │ the traversal code as well                     │
+  │ Traversal logic (DFS/BFS etc.) is scattered    │
+  │ across consumer code                           │
   └────────────────────────────────────────────────┘
 ```
 
-### Iterator パターンによる解決
+### Solution via the Iterator Pattern
 
 ```
-Iterator パターンの解決:
+Iterator pattern solution:
 
   ┌──────────────────┐     ┌──────────────────┐
   │   Collection     │────►│   Iterator       │
-  │ (内部構造を隠蔽)  │     │ (統一アクセス)    │
-  │                  │     │                  │
+  │ (hides internal  │     │ (unified access) │
+  │  structure)      │     │                  │
   │ [Symbol.iterator]│     │ + next()         │
   │   → Iterator     │     │   { value, done }│
   └──────────────────┘     └──────────────────┘
 
-  利用者側は常に同じコード:
+  Consumer always uses the same code:
     for (const item of collection) {
-      // 配列でも、リストでも、ツリーでも同じ
+      // Same for arrays, lists, trees, etc.
     }
 
-  利点:
-  ✓ コレクションの内部構造を知らなくてよい
-  ✓ 走査アルゴリズムを複数持てる（DFS, BFS, フィルタ付き等）
-  ✓ 遅延評価で無限シーケンスも表現可能
-  ✓ スプレッド演算子、分割代入、Array.from が自動的に使える
+  Benefits:
+  ✓ No need to know the collection's internal structure
+  ✓ Multiple traversal algorithms are supported (DFS, BFS, filtered, etc.)
+  ✓ Lazy evaluation can express infinite sequences
+  ✓ Spread operator, destructuring, Array.from work automatically
 ```
 
-GoF の定義:
+GoF definition:
 
 > "Provide a way to access the elements of an aggregate object sequentially without exposing its underlying representation."
 >
 > -- Design Patterns: Elements of Reusable Object-Oriented Software (1994)
 
-JavaScript/TypeScript では、Iterator パターンが **言語仕様に組み込まれている** 点が特徴的です。`Symbol.iterator` プロトコルを実装するだけで、`for...of`、スプレッド演算子、分割代入、`Array.from` などの言語機能が自動的に利用可能になります。
+In JavaScript/TypeScript, a notable feature is that the Iterator pattern is **built into the language specification**. Simply implementing the `Symbol.iterator` protocol automatically enables language features such as `for...of`, the spread operator, destructuring, and `Array.from`.
 
 ---
 
-## 1. Iterator プロトコルの構造
+## 1. Structure of the Iterator Protocol
 
 ```
-JavaScript/TypeScript の Iterator プロトコル:
+JavaScript/TypeScript Iterator protocol:
 
   ┌─────────────────────────────┐
   │        Iterable             │
   │                             │
   │  [Symbol.iterator]()        │
-  │    → Iterator を返す        │
+  │    → returns an Iterator    │
   │                             │
-  │  使える構文:                 │
+  │  Usable syntax:             │
   │    for...of                 │
   │    [...iterable]            │
   │    const [a, b] = iterable  │
@@ -118,37 +120,37 @@ JavaScript/TypeScript の Iterator プロトコル:
   │        Iterator             │
   │                             │
   │  next(): IteratorResult     │
-  │    { value: T, done: false }│  ← 値がある
+  │    { value: T, done: false }│  ← has a value
   │    { value: undefined,      │
-  │      done: true }           │  ← 終了
+  │      done: true }           │  ← finished
   │                             │
-  │  return?(): IteratorResult  │  ← 早期終了
-  │  throw?(e): IteratorResult  │  ← エラー注入
+  │  return?(): IteratorResult  │  ← early exit
+  │  throw?(e): IteratorResult  │  ← error injection
   └─────────────────────────────┘
 
-  呼び出しシーケンス:
+  Call sequence:
   ┌──────┐    ┌──────┐    ┌──────┐    ┌──────────┐
   │next()│───►│next()│───►│next()│───►│next()    │
   │{v:1, │    │{v:2, │    │{v:3, │    │{done:    │
   │ d:F} │    │ d:F} │    │ d:F} │    │ true}    │
   └──────┘    └──────┘    └──────┘    └──────────┘
 
-  ★ 重要: Iterable ≠ Iterator
-    Iterable: [Symbol.iterator]() メソッドを持つ → 何度でも Iterator を生成
-    Iterator: next() メソッドを持つ → 1回使い切り
+  ★ Important: Iterable ≠ Iterator
+    Iterable: has a [Symbol.iterator]() method → generates a new Iterator each time
+    Iterator: has a next() method → single-use
 ```
 
 ---
 
-## 2. カスタムイテレータの実装
+## 2. Implementing Custom Iterators
 
-### コード例 1: 範囲イテレータ（Range）
+### Code Example 1: Range Iterator
 
 ```typescript
-// range-iterator.ts -- 範囲イテレータ
+// range-iterator.ts -- Range iterator
 
 // ============================
-// Iterable を実装するクラス
+// Class implementing Iterable
 // ============================
 class Range implements Iterable<number> {
   constructor(
@@ -161,7 +163,7 @@ class Range implements Iterable<number> {
     if (step < 0 && start < end) throw new Error('start must be >= end for negative step');
   }
 
-  /** Iterable プロトコル: Iterator を生成して返す */
+  /** Iterable protocol: generates and returns an Iterator */
   [Symbol.iterator](): Iterator<number> {
     let current = this.start;
     const end = this.end;
@@ -179,12 +181,12 @@ class Range implements Iterable<number> {
     };
   }
 
-  /** 要素数を事前計算（遅延評価を維持しつつサイズ取得） */
+  /** Pre-calculate element count (get size while maintaining lazy evaluation) */
   get length(): number {
     return Math.max(0, Math.ceil((this.end - this.start) / this.step));
   }
 
-  /** 要素が含まれるか判定（O(1)） */
+  /** Check if a value is included (O(1)) */
   includes(value: number): boolean {
     if (this.step > 0) {
       if (value < this.start || value >= this.end) return false;
@@ -196,36 +198,36 @@ class Range implements Iterable<number> {
 }
 
 // ============================
-// 使用例
+// Usage examples
 // ============================
 
-// for...of で走査
+// Traverse with for...of
 for (const n of new Range(1, 5)) {
   console.log(n); // 1, 2, 3, 4
 }
 
-// スプレッド演算子
+// Spread operator
 const numbers = [...new Range(0, 10, 2)]; // [0, 2, 4, 6, 8]
 
-// 分割代入
+// Destructuring
 const [first, second] = new Range(10, 0, -3); // first=10, second=7
 
 // Array.from
 const arr = Array.from(new Range(1, 6)); // [1, 2, 3, 4, 5]
 
-// ★ Iterable なので何度でも走査可能
+// ★ Since it is Iterable, it can be traversed multiple times
 const range = new Range(1, 4);
 console.log([...range]); // [1, 2, 3]
-console.log([...range]); // [1, 2, 3] ← 2回目も同じ結果
+console.log([...range]); // [1, 2, 3] ← same result on second pass
 ```
 
-### コード例 2: 連結リストのイテレータ
+### Code Example 2: Linked List Iterator
 
 ```typescript
-// linked-list-iterator.ts -- 連結リストのイテレータ
+// linked-list-iterator.ts -- Linked list iterator
 
 // ============================
-// Node と LinkedList の定義
+// Node and LinkedList definitions
 // ============================
 class ListNode<T> {
   constructor(
@@ -249,7 +251,7 @@ class LinkedList<T> implements Iterable<T> {
     return this._size;
   }
 
-  /** 順方向のイテレータ */
+  /** Forward iterator */
   [Symbol.iterator](): Iterator<T> {
     let current = this.head;
 
@@ -265,9 +267,9 @@ class LinkedList<T> implements Iterable<T> {
     };
   }
 
-  /** 逆順イテレータ（複数の走査方法を提供） */
+  /** Reverse iterator (providing multiple traversal methods) */
   reversed(): Iterable<T> {
-    const items = [...this]; // 一度配列に
+    const items = [...this]; // convert to array first
     let index = items.length - 1;
 
     return {
@@ -284,7 +286,7 @@ class LinkedList<T> implements Iterable<T> {
     };
   }
 
-  /** 条件付きフィルタイテレータ */
+  /** Conditional filter iterator */
   filter(predicate: (value: T) => boolean): Iterable<T> {
     const source = this;
     return {
@@ -298,24 +300,24 @@ class LinkedList<T> implements Iterable<T> {
 }
 
 // ============================
-// 使用例
+// Usage examples
 // ============================
 const list = new LinkedList<number>();
 list.push(3);
 list.push(2);
 list.push(1);
 
-// 順方向
+// Forward
 for (const value of list) {
   console.log(value); // 1, 2, 3
 }
 
-// 逆順
+// Reverse
 for (const value of list.reversed()) {
   console.log(value); // 3, 2, 1
 }
 
-// フィルタ付き
+// With filter
 for (const value of list.filter(v => v % 2 !== 0)) {
   console.log(value); // 1, 3
 }
@@ -323,15 +325,15 @@ for (const value of list.filter(v => v % 2 !== 0)) {
 
 ---
 
-## 3. ジェネレータ関数
+## 3. Generator Functions
 
-### コード例 3: ジェネレータの基本と応用
+### Code Example 3: Generator Basics and Applications
 
 ```typescript
-// generators.ts -- ジェネレータの基本と応用
+// generators.ts -- Generator basics and applications
 
 // ============================
-// 基本的なジェネレータ
+// Basic generator
 // ============================
 function* fibonacci(): Generator<number> {
   let a = 0;
@@ -342,7 +344,7 @@ function* fibonacci(): Generator<number> {
   }
 }
 
-// 先頭 N 個を取得するヘルパー
+// Helper to get the first N elements
 function take<T>(n: number, iterable: Iterable<T>): T[] {
   const result: T[] = [];
   for (const item of iterable) {
@@ -356,22 +358,22 @@ console.log(take(8, fibonacci()));
 // [0, 1, 1, 2, 3, 5, 8, 13]
 
 // ============================
-// ジェネレータによるツリーの走査
+// Tree traversal using generators
 // ============================
 interface TreeNode<T> {
   value: T;
   children: TreeNode<T>[];
 }
 
-/** 深さ優先走査（前順: pre-order） */
+/** Depth-first traversal (pre-order) */
 function* depthFirst<T>(root: TreeNode<T>): Generator<T> {
   yield root.value;
   for (const child of root.children) {
-    yield* depthFirst(child); // yield* で再帰的にデリゲート
+    yield* depthFirst(child); // recursively delegate with yield*
   }
 }
 
-/** 深さ優先走査（後順: post-order） */
+/** Depth-first traversal (post-order) */
 function* depthFirstPostOrder<T>(root: TreeNode<T>): Generator<T> {
   for (const child of root.children) {
     yield* depthFirstPostOrder(child);
@@ -379,7 +381,7 @@ function* depthFirstPostOrder<T>(root: TreeNode<T>): Generator<T> {
   yield root.value;
 }
 
-/** 幅優先走査 (BFS) */
+/** Breadth-first traversal (BFS) */
 function* breadthFirst<T>(root: TreeNode<T>): Generator<T> {
   const queue: TreeNode<T>[] = [root];
   while (queue.length > 0) {
@@ -389,7 +391,7 @@ function* breadthFirst<T>(root: TreeNode<T>): Generator<T> {
   }
 }
 
-/** レベルごとのグループ化走査 */
+/** Level-grouped traversal */
 function* levelOrder<T>(root: TreeNode<T>): Generator<T[]> {
   let currentLevel: TreeNode<T>[] = [root];
   while (currentLevel.length > 0) {
@@ -404,7 +406,7 @@ function* levelOrder<T>(root: TreeNode<T>): Generator<T[]> {
 }
 
 // ============================
-// 使用例
+// Usage examples
 // ============================
 const tree: TreeNode<string> = {
   value: 'A',
@@ -433,9 +435,9 @@ console.log([...levelOrder(tree)]);
 ```
 
 ```
-ジェネレータの実行フロー:
+Generator execution flow:
 
-  function* gen() {        呼び出し側
+  function* gen() {        Caller side
     yield 1;               const g = gen();
     yield 2;               g.next() → { value: 1, done: false }
     yield 3;               g.next() → { value: 2, done: false }
@@ -446,26 +448,26 @@ console.log([...levelOrder(tree)]);
   │ Generator       │     │ Caller          │
   │                 │     │                 │
   │  ──── yield 1 ──┼────►│ value: 1        │
-  │  (一時停止)      │     │                 │
+  │  (suspended)    │     │                 │
   │                 │◄────┼── next() ───    │
   │  ──── yield 2 ──┼────►│ value: 2        │
-  │  (一時停止)      │     │                 │
+  │  (suspended)    │     │                 │
   │                 │◄────┼── next() ───    │
   │  ──── yield 3 ──┼────►│ value: 3        │
-  │  (一時停止)      │     │                 │
+  │  (suspended)    │     │                 │
   │                 │◄────┼── next() ───    │
   │  ──── return 4 ─┼────►│ done: true      │
   └─────────────────┘     └─────────────────┘
 
-  ★ yield は「一時停止 + 値の送出」
-  ★ next() は「再開 + 値の受信」
-  ★ return の値は for...of では取得されない
-    （done: true の value は無視される）
+  ★ yield means "suspend + emit a value"
+  ★ next() means "resume + receive a value"
+  ★ The value of return is not captured by for...of
+    (the value when done: true is ignored)
 
-  yield* によるデリゲート:
+  Delegation with yield*:
   function* outer() {
     yield 'a';
-    yield* inner();   // inner のすべての yield を外に転送
+    yield* inner();   // forwards all yields from inner to the outside
     yield 'c';
   }
   function* inner() { yield 'b1'; yield 'b2'; }
@@ -475,15 +477,15 @@ console.log([...levelOrder(tree)]);
 
 ---
 
-## 4. 非同期イテレータ
+## 4. Async Iterators
 
-### コード例 4: API ページネーションの自動走査
+### Code Example 4: Automatic Traversal of API Pagination
 
 ```typescript
-// async-iterators.ts -- 非同期イテレータの活用
+// async-iterators.ts -- Using async iterators
 
 // ============================
-// API ページネーション
+// API pagination
 // ============================
 interface PageResponse<T> {
   items: T[];
@@ -511,7 +513,7 @@ async function* fetchAllPages<T>(
     const data: PageResponse<T> = await response.json();
 
     for (const item of data.items) {
-      yield item; // 1件ずつ yield（メモリ効率が良い）
+      yield item; // yield one item at a time (memory-efficient)
     }
 
     hasMore = page * pageSize < data.total;
@@ -519,7 +521,7 @@ async function* fetchAllPages<T>(
   }
 }
 
-// 使用例: 全ユーザーを1件ずつ処理（メモリ効率が良い）
+// Usage: process all users one at a time (memory-efficient)
 interface User { id: string; name: string; active: boolean; }
 
 async function processAllUsers(): Promise<void> {
@@ -534,7 +536,7 @@ async function processAllUsers(): Promise<void> {
 }
 
 // ============================
-// ReadableStream のラインリーダー
+// ReadableStream line reader
 // ============================
 async function* readLines(
   stream: ReadableStream<Uint8Array>
@@ -557,7 +559,7 @@ async function* readLines(
       }
     }
 
-    // 最後のバッファ（改行なし）
+    // Last buffer (no trailing newline)
     if (buffer) {
       yield buffer;
     }
@@ -567,7 +569,7 @@ async function* readLines(
 }
 
 // ============================
-// Server-Sent Events (SSE) のストリーム
+// Server-Sent Events (SSE) stream
 // ============================
 async function* streamSSE(url: string): AsyncGenerator<{
   event: string;
@@ -579,8 +581,8 @@ async function* streamSSE(url: string): AsyncGenerator<{
   for await (const line of readLines(response.body)) {
     if (line.startsWith('event: ')) {
       const event = line.slice(7);
-      // 次の行が data:
-      // (簡略化: 実際の SSE パーサーはもっと複雑)
+      // Next line is data:
+      // (simplified: a real SSE parser is more complex)
       continue;
     }
     if (line.startsWith('data: ')) {
@@ -589,19 +591,19 @@ async function* streamSSE(url: string): AsyncGenerator<{
   }
 }
 
-// 使用例: SSE ストリームの購読
+// Usage: subscribing to an SSE stream
 async function watchUpdates(): Promise<void> {
   for await (const { event, data } of streamSSE('/api/events')) {
     console.log(`[${event}] ${data}`);
-    // 必要に応じて break で中断可能
+    // Can break to interrupt if needed
   }
 }
 ```
 
 ```
-同期 vs 非同期イテレータの対応関係:
+Correspondence between sync and async iterators:
 
-  同期                         非同期
+  Sync                         Async
   ─────────────────────────    ─────────────────────────
   Iterable                     AsyncIterable
   [Symbol.iterator]()          [Symbol.asyncIterator]()
@@ -609,29 +611,29 @@ async function watchUpdates(): Promise<void> {
   next(): IteratorResult       next(): Promise<IteratorResult>
   for...of                     for await...of
   function*                    async function*
-  yield                        yield (async コンテキスト内)
+  yield                        yield (inside async context)
   yield*                       yield*
 
-  ★ for await...of は以下と等価:
+  ★ for await...of is equivalent to:
   const iter = asyncIterable[Symbol.asyncIterator]();
   while (true) {
     const { value, done } = await iter.next();
     if (done) break;
-    // value を処理
+    // process value
   }
 ```
 
 ---
 
-## 5. イテレータパイプライン（遅延評価）
+## 5. Iterator Pipeline (Lazy Evaluation)
 
-### コード例 5: 関数型イテレータ操作ライブラリ
+### Code Example 5: Functional Iterator Operations Library
 
 ```typescript
-// iterator-pipeline.ts -- 関数型イテレータ操作
+// iterator-pipeline.ts -- Functional iterator operations
 
 // ============================
-// 遅延評価パイプラインクラス
+// Lazy evaluation pipeline class
 // ============================
 class Iter<T> implements Iterable<T> {
   constructor(private source: Iterable<T>) {}
@@ -640,14 +642,14 @@ class Iter<T> implements Iterable<T> {
     return new Iter(source);
   }
 
-  /** 無限の繰り返しイテレータ */
+  /** Infinite repetition iterator */
   static repeat<T>(value: T): Iter<T> {
     return new Iter((function* () {
       while (true) yield value;
     })());
   }
 
-  /** 自然数列 (0, 1, 2, ...) */
+  /** Natural number sequence (0, 1, 2, ...) */
   static naturals(): Iter<number> {
     return new Iter((function* () {
       let n = 0;
@@ -659,7 +661,7 @@ class Iter<T> implements Iterable<T> {
     yield* this.source;
   }
 
-  /** 値の変換 */
+  /** Transform values */
   map<U>(fn: (item: T, index: number) => U): Iter<U> {
     const source = this.source;
     return new Iter((function* () {
@@ -670,7 +672,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** フィルタリング */
+  /** Filtering */
   filter(predicate: (item: T) => boolean): Iter<T> {
     const source = this.source;
     return new Iter((function* () {
@@ -680,7 +682,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 先頭 N 個を取得 */
+  /** Take first N elements */
   take(n: number): Iter<T> {
     const source = this.source;
     return new Iter((function* () {
@@ -693,7 +695,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 先頭 N 個をスキップ */
+  /** Skip first N elements */
   skip(n: number): Iter<T> {
     const source = this.source;
     return new Iter((function* () {
@@ -705,7 +707,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 条件を満たす間だけ取得 */
+  /** Take elements while condition is true */
   takeWhile(predicate: (item: T) => boolean): Iter<T> {
     const source = this.source;
     return new Iter((function* () {
@@ -716,7 +718,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** フラットマップ */
+  /** Flat map */
   flatMap<U>(fn: (item: T) => Iterable<U>): Iter<U> {
     const source = this.source;
     return new Iter((function* () {
@@ -726,7 +728,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 隣接要素のペア */
+  /** Pairs of adjacent elements */
   pairwise(): Iter<[T, T]> {
     const source = this.source;
     return new Iter((function* () {
@@ -742,7 +744,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** チャンク分割 */
+  /** Chunk splitting */
   chunk(size: number): Iter<T[]> {
     const source = this.source;
     return new Iter((function* () {
@@ -758,7 +760,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 重複除去 */
+  /** Deduplication */
   distinct(): Iter<T> {
     const source = this.source;
     return new Iter((function* () {
@@ -772,7 +774,7 @@ class Iter<T> implements Iterable<T> {
     })());
   }
 
-  /** 畳み込み（即座に評価） */
+  /** Fold/reduce (evaluates eagerly) */
   reduce<U>(fn: (acc: U, item: T) => U, initial: U): U {
     let result = initial;
     for (const item of this.source) {
@@ -781,12 +783,12 @@ class Iter<T> implements Iterable<T> {
     return result;
   }
 
-  /** 配列に変換（即座に評価） */
+  /** Convert to array (evaluates eagerly) */
   toArray(): T[] {
     return [...this.source];
   }
 
-  /** 最初の要素を取得 */
+  /** Get the first element */
   first(): T | undefined {
     for (const item of this.source) {
       return item;
@@ -794,14 +796,14 @@ class Iter<T> implements Iterable<T> {
     return undefined;
   }
 
-  /** 要素数をカウント */
+  /** Count elements */
   count(): number {
     let n = 0;
     for (const _ of this.source) n++;
     return n;
   }
 
-  /** 全要素が条件を満たすか */
+  /** Check if all elements satisfy the condition */
   every(predicate: (item: T) => boolean): boolean {
     for (const item of this.source) {
       if (!predicate(item)) return false;
@@ -809,7 +811,7 @@ class Iter<T> implements Iterable<T> {
     return true;
   }
 
-  /** いずれかの要素が条件を満たすか */
+  /** Check if any element satisfies the condition */
   some(predicate: (item: T) => boolean): boolean {
     for (const item of this.source) {
       if (predicate(item)) return true;
@@ -819,20 +821,20 @@ class Iter<T> implements Iterable<T> {
 }
 
 // ============================
-// 使用例: パイプラインで遅延評価
+// Usage: lazy evaluation via pipeline
 // ============================
 
-// フィボナッチ数列から偶数の二乗を5個取得
+// Get the first 5 squares of even Fibonacci numbers
 const result = Iter.from(fibonacci())
-  .filter(n => n % 2 === 0)       // 偶数のみ
-  .map(n => n * n)                 // 二乗
-  .take(5)                         // 先頭5個
+  .filter(n => n % 2 === 0)       // even numbers only
+  .map(n => n * n)                 // square them
+  .take(5)                         // first 5
   .toArray();
 
 console.log(result); // [0, 4, 64, 17956, ...]
-// → fibonacci は必要な分だけ生成される（遅延評価）
+// → fibonacci only generates as much as needed (lazy evaluation)
 
-// 自然数から素数を生成
+// Generate prime numbers from natural numbers
 function isPrime(n: number): boolean {
   if (n < 2) return false;
   for (let i = 2; i <= Math.sqrt(n); i++) {
@@ -849,7 +851,7 @@ const primes = Iter.naturals()
 
 console.log(primes); // [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
-// チャンク分割 + マップ
+// Chunk splitting + map
 const chunks = Iter.from(new Range(1, 11))
   .chunk(3)
   .map(chunk => chunk.reduce((a, b) => a + b, 0))
@@ -860,12 +862,12 @@ console.log(chunks); // [6, 15, 24, 10]
 ```
 
 ```
-遅延評価の動作イメージ:
+How lazy evaluation works:
 
   fibonacci() → filter(even) → map(square) → take(3) → toArray()
 
-  評価は「右から左」に要求が伝搬し、
-  「左から右」に値が1つずつ流れる:
+  Evaluation: demand propagates "right to left",
+  values flow one at a time "left to right":
 
   fib     filter    map      take    result
   ─────   ─────     ─────    ─────   ─────
@@ -875,20 +877,20 @@ console.log(chunks); // [6, 15, 24, 10]
   2    →  2      →  4     →  [0,4]
   3    →  (skip)
   5    →  (skip)
-  8    →  8      →  64    →  [0,4,64]  ← take(3) 完了!
+  8    →  8      →  64    →  [0,4,64]  ← take(3) done!
 
-  ★ fibonacci は 8 までしか計算されない（遅延評価のメリット）
-  ★ 中間配列は一切生成されない
+  ★ fibonacci is only computed up to 8 (benefit of lazy evaluation)
+  ★ No intermediate arrays are created at all
 ```
 
 ---
 
-## 6. Python のイテレータとジェネレータ
+## 6. Iterators and Generators in Python
 
-### コード例 6: Python の Iterator プロトコル
+### Code Example 6: Python's Iterator Protocol
 
 ```python
-# python_iterators.py -- Python のイテレータパターン
+# python_iterators.py -- Iterator pattern in Python
 
 from __future__ import annotations
 from typing import Iterator, Iterable, TypeVar, Callable, Generator
@@ -899,10 +901,10 @@ U = TypeVar("U")
 
 
 # ============================
-# カスタム Range (Python 組込みの range と同等)
+# Custom Range (equivalent to Python's built-in range)
 # ============================
 class MyRange:
-    """Python の range() を再実装"""
+    """Re-implementation of Python's range()"""
 
     def __init__(self, start: int, stop: int, step: int = 1):
         self.start = start
@@ -910,11 +912,11 @@ class MyRange:
         self.step = step
 
     def __iter__(self) -> Iterator[int]:
-        """__iter__ = [Symbol.iterator] に相当"""
+        """__iter__ is equivalent to [Symbol.iterator]"""
         current = self.start
         while (self.step > 0 and current < self.stop) or \
               (self.step < 0 and current > self.stop):
-            yield current  # Python ではジェネレータで簡潔に書ける
+            yield current  # In Python, generators allow concise writing
             current += self.step
 
     def __len__(self) -> int:
@@ -928,10 +930,10 @@ class MyRange:
 
 
 # ============================
-# ジェネレータの応用: パイプライン
+# Generator application: pipeline
 # ============================
 def take(n: int, iterable: Iterable[T]) -> Generator[T, None, None]:
-    """先頭 N 個を取得"""
+    """Get the first N elements"""
     count = 0
     for item in iterable:
         if count >= n:
@@ -941,7 +943,7 @@ def take(n: int, iterable: Iterable[T]) -> Generator[T, None, None]:
 
 
 def chunk(iterable: Iterable[T], size: int) -> Generator[list[T], None, None]:
-    """チャンク分割"""
+    """Chunk splitting"""
     buf: list[T] = []
     for item in iterable:
         buf.append(item)
@@ -953,26 +955,26 @@ def chunk(iterable: Iterable[T], size: int) -> Generator[list[T], None, None]:
 
 
 def flatten(iterable: Iterable[Iterable[T]]) -> Generator[T, None, None]:
-    """ネストしたイテラブルをフラット化"""
+    """Flatten nested iterables"""
     for inner in iterable:
-        yield from inner  # yield from = yield* に相当
+        yield from inner  # yield from is equivalent to yield*
 
 
 # ============================
-# Python のイテレータ式 (Generator Expression)
+# Python generator expressions
 # ============================
 def demonstrate_generators():
-    # リスト内包表記（即座に全要素を生成）
+    # List comprehension (generates all elements immediately)
     squares_list = [x**2 for x in range(10)]  # list
 
-    # ジェネレータ式（遅延評価）
+    # Generator expression (lazy evaluation)
     squares_gen = (x**2 for x in range(10))   # generator
 
-    # メモリ効率の違い:
-    # squares_list: 10個のint を全てメモリに保持
-    # squares_gen:  1個ずつ生成、メモリはO(1)
+    # Memory efficiency difference:
+    # squares_list: holds all 10 ints in memory
+    # squares_gen:  generates one at a time, O(1) memory
 
-    # パイプライン（関数の合成）
+    # Pipeline (function composition)
     import itertools
     result = list(
         itertools.islice(                    # take(5)
@@ -986,15 +988,15 @@ def demonstrate_generators():
 
 
 # ============================
-# 使用例
+# Usage examples
 # ============================
 if __name__ == "__main__":
-    # カスタム Range
+    # Custom Range
     for n in MyRange(1, 5):
         print(n, end=" ")  # 1 2 3 4
     print()
 
-    # チャンク分割
+    # Chunk splitting
     for c in chunk(range(1, 11), 3):
         print(c)
     # [1, 2, 3]
@@ -1002,23 +1004,23 @@ if __name__ == "__main__":
     # [7, 8, 9]
     # [10]
 
-    # itertools の活用
+    # Using itertools
     demonstrate_generators()
 ```
 
 ---
 
-## 7. 外部イテレータ vs 内部イテレータ
+## 7. External Iterator vs Internal Iterator
 
-### コード例 7: 両方のスタイルの比較と使い分け
+### Code Example 7: Comparison and Usage of Both Styles
 
 ```typescript
-// external-vs-internal.ts -- 外部イテレータと内部イテレータ
+// external-vs-internal.ts -- External and internal iterators
 
 // ============================
-// 外部イテレータ (External Iterator)
+// External Iterator
 // ============================
-// 利用者が明示的に next() を呼んで制御する
+// The consumer explicitly calls next() to control traversal
 class ExternalIterator<T> {
   private iterator: Iterator<T>;
 
@@ -1026,16 +1028,16 @@ class ExternalIterator<T> {
     this.iterator = iterable[Symbol.iterator]();
   }
 
-  /** 次の要素があるか */
+  /** Check if there is a next element */
   hasNext(): boolean {
     const result = this.iterator.next();
     if (result.done) return false;
-    // peek のために値を戻す必要があるが、Iterator は巻き戻せない
-    // → 実用的には1要素先読みバッファが必要
+    // We need to put the value back for peek, but Iterators cannot rewind
+    // → In practice, a 1-element lookahead buffer is needed
     return true;
   }
 
-  /** 次の要素を取得 */
+  /** Get the next element */
   next(): T {
     const result = this.iterator.next();
     if (result.done) throw new Error('No more elements');
@@ -1043,7 +1045,7 @@ class ExternalIterator<T> {
   }
 }
 
-// 先読み付き外部イテレータ
+// External iterator with lookahead
 class PeekableIterator<T> implements Iterable<T> {
   private iterator: Iterator<T>;
   private buffer: T[] = [];
@@ -1052,7 +1054,7 @@ class PeekableIterator<T> implements Iterable<T> {
     this.iterator = source[Symbol.iterator]();
   }
 
-  /** 次の要素を消費せずに確認 */
+  /** Inspect the next element without consuming it */
   peek(): T | undefined {
     if (this.buffer.length === 0) {
       const result = this.iterator.next();
@@ -1062,7 +1064,7 @@ class PeekableIterator<T> implements Iterable<T> {
     return this.buffer[0];
   }
 
-  /** 次の要素を取得して消費 */
+  /** Get and consume the next element */
   next(): T | undefined {
     if (this.buffer.length > 0) {
       return this.buffer.shift();
@@ -1089,9 +1091,9 @@ class PeekableIterator<T> implements Iterable<T> {
 }
 
 // ============================
-// 内部イテレータ (Internal Iterator)
+// Internal Iterator
 // ============================
-// コレクション側が走査を制御し、コールバックを呼ぶ
+// The collection controls traversal and calls the callback
 class InternalIterator<T> {
   constructor(private items: T[]) {}
 
@@ -1116,7 +1118,7 @@ class InternalIterator<T> {
 }
 
 // ============================
-// 外部イテレータの活用例: トークナイザー
+// External iterator use case: tokenizer
 // ============================
 function* tokenize(input: string): Generator<{ type: string; value: string }> {
   const patterns = [
@@ -1146,7 +1148,7 @@ function* tokenize(input: string): Generator<{ type: string; value: string }> {
   }
 }
 
-// PeekableIterator でパーサーを実装
+// Implement a parser using PeekableIterator
 function parseExpression(tokens: PeekableIterator<{ type: string; value: string }>): number {
   let result = parseTerm(tokens);
 
@@ -1172,136 +1174,137 @@ function parseTerm(tokens: PeekableIterator<{ type: string; value: string }>): n
   throw new Error(`Unexpected token: ${token.value}`);
 }
 
-// 使用例
+// Usage
 const tokens = new PeekableIterator(tokenize('3 + 5 - 2'));
 console.log(parseExpression(tokens)); // 6
 ```
 
 ```
-外部 vs 内部イテレータの比較:
+Comparison of external vs internal iterators:
 
-  外部イテレータ (for...of, next())
+  External Iterator (for...of, next())
   ┌──────────┐                    ┌──────────┐
-  │ 利用者   │── next() ─────────►│ Iterator │
+  │ Consumer │── next() ─────────►│ Iterator │
   │          │◄── { value, done } │          │
-  │ 制御権は │                    │ 値を提供 │
-  │ 利用者側 │                    │          │
+  │ Control  │                    │ Provides │
+  │ is with  │                    │ values   │
+  │ consumer │                    │          │
   └──────────┘                    └──────────┘
 
-  内部イテレータ (forEach, map)
+  Internal Iterator (forEach, map)
   ┌──────────┐                    ┌───────────┐
-  │ 利用者   │── callback ───────►│ Collection│
+  │ Consumer │── callback ───────►│ Collection│
   │          │                    │           │
-  │ コール   │◄── callback(item) ─│ 走査を    │
-  │ バックを │                    │ 制御する  │
-  │ 渡すだけ │                    │           │
+  │ Just     │◄── callback(item) ─│ Controls  │
+  │ provides │                    │ traversal │
+  │ callback │                    │           │
   └──────────┘                    └───────────┘
 
-  使い分け:
-  外部: 複数イテレータの同時走査、peek、早期終了
-  内部: シンプルな全要素処理、関数型スタイル
+  When to use which:
+  External: simultaneous traversal of multiple iterators, peek, early exit
+  Internal: simple full-element processing, functional style
 ```
 
 ---
 
-## 8. 深掘り: Iterator の設計判断
+## 8. Deep Dive: Iterator Design Decisions
 
-### イテレータの使い捨て問題
+### The Single-Use Iterator Problem
 
 ```
-Iterator は1回しか走査できない（使い捨て）:
+Iterators can only be traversed once (single-use):
   const gen = fibonacci();
   [...gen]  // [0, 1, 1, 2, ...]
-  [...gen]  // [] ← 空! 使い切り
+  [...gen]  // [] ← empty! iterator is exhausted
 
-Iterable は何度でも走査可能:
+Iterables can be traversed multiple times:
   const range = new Range(1, 5);
   [...range]  // [1, 2, 3, 4]
-  [...range]  // [1, 2, 3, 4] ← 何度でもOK
+  [...range]  // [1, 2, 3, 4] ← works every time
 
-理由: Iterable は [Symbol.iterator]() で毎回新しい Iterator を生成する
-     Generator は1つの Iterator インスタンスで、状態を内部に保持
+Reason: Iterable creates a new Iterator via [Symbol.iterator]() each time
+        A Generator is a single Iterator instance that holds its state internally
 
-  ★ 設計指針:
-    再利用するコレクション → Iterable インターフェースを実装（class + [Symbol.iterator]）
-    1回限りのストリーム → Generator 関数で十分
+  ★ Design guidelines:
+    Reusable collections → Implement the Iterable interface (class + [Symbol.iterator])
+    One-time streams → A Generator function is sufficient
 ```
 
-### 遅延評価 vs 即時評価
+### Lazy Evaluation vs Eager Evaluation
 
 ```
-即時評価 (Array.map/filter):
+Eager evaluation (Array.map/filter):
   [1,2,3,4,5].filter(x => x > 2).map(x => x * 2)
-  ステップ1: filter で中間配列 [3,4,5] を生成
-  ステップ2: map で結果配列 [6,8,10] を生成
-  → 2つの配列がメモリに存在
+  Step 1: filter produces intermediate array [3,4,5]
+  Step 2: map produces result array [6,8,10]
+  → Two arrays exist in memory
 
-遅延評価 (Iterator パイプライン):
+Lazy evaluation (Iterator pipeline):
   Iter.from([1,2,3,4,5]).filter(x => x > 2).map(x => x * 2).toArray()
-  → 中間配列なし、1要素ずつ処理
+  → No intermediate arrays, one element processed at a time
   → 1 → filter(skip) → 2 → filter(skip) → 3 → filter(pass) → map(6) → ...
 
-判断基準:
-  データが小さい(< 1000件) → 即時評価でOK（可読性優先）
-  データが大きい(> 10000件) → 遅延評価が有効
-  無限シーケンス → 遅延評価が必須
-  複数回走査 → 即時評価（配列に変換）
+Decision criteria:
+  Small data (< 1000 items) → Eager evaluation is fine (prioritize readability)
+  Large data (> 10000 items) → Lazy evaluation is effective
+  Infinite sequences → Lazy evaluation is required
+  Multiple traversals → Eager evaluation (convert to array)
 ```
 
 ---
 
-## 9. 比較表
+## 9. Comparison Tables
 
-### 走査方法の比較
+### Comparison of Traversal Methods
 
-| 特性 | for ループ | Array.map/filter | Generator | Iter パイプライン |
+| Property | for loop | Array.map/filter | Generator | Iter pipeline |
 |------|-----------|-----------------|-----------|-----------------|
-| 遅延評価 | 不可 | 不可（即座に配列生成） | 可能 | 可能 |
-| 無限シーケンス | 不可 | 不可 | 可能 | 可能 |
-| メモリ効率 | 良い | 中間配列が生成 | 最良 | 最良 |
-| チェーン可読性 | 低い | 高い | 中 | 高い |
-| 非同期対応 | 要工夫 | なし | AsyncGenerator | 拡張可能 |
-| 早期終了 (break) | 可能 | 不可（forEach） | 可能 | 可能 |
-| TypeScript 型推論 | 完全 | 完全 | 完全 | 完全 |
+| Lazy evaluation | No | No (array created immediately) | Yes | Yes |
+| Infinite sequences | No | No | Yes | Yes |
+| Memory efficiency | Good | Intermediate arrays created | Best | Best |
+| Chain readability | Low | High | Medium | High |
+| Async support | Requires work | None | AsyncGenerator | Extensible |
+| Early exit (break) | Yes | No (forEach) | Yes | Yes |
+| TypeScript type inference | Full | Full | Full | Full |
 
-### イテレータの種類
+### Types of Iterators
 
-| イテレータ種類 | 同期 Iterator | AsyncIterator | Generator | AsyncGenerator |
+| Iterator type | Sync Iterator | AsyncIterator | Generator | AsyncGenerator |
 |--------------|-------------|---------------|-----------|---------------|
-| プロトコル | Symbol.iterator | Symbol.asyncIterator | function* | async function* |
-| 構文 | for...of | for await...of | yield | yield (async内) |
-| ユースケース | コレクション走査 | API/Stream処理 | 遅延シーケンス | ページネーション |
-| 実行制御 | next() | next() (Promise) | yield で停止 | yield + await |
-| リソース解放 | return() | return() | try/finally | try/finally |
+| Protocol | Symbol.iterator | Symbol.asyncIterator | function* | async function* |
+| Syntax | for...of | for await...of | yield | yield (inside async) |
+| Use case | Collection traversal | API/Stream processing | Lazy sequences | Pagination |
+| Execution control | next() | next() (Promise) | suspend with yield | yield + await |
+| Resource release | return() | return() | try/finally | try/finally |
 
-### 言語間のイテレータ対応
+### Iterator Correspondence Across Languages
 
-| 概念 | JavaScript/TS | Python | Rust | Java |
+| Concept | JavaScript/TS | Python | Rust | Java |
 |------|--------------|--------|------|------|
 | Iterable | Symbol.iterator | `__iter__` | `IntoIterator` | `Iterable<T>` |
 | Iterator | `{ next() }` | `__next__` | `Iterator` trait | `Iterator<T>` |
-| Generator | `function*` | `yield` | -- (Iterator で代替) | -- |
-| 遅延パイプライン | 自前実装 | `itertools` | `.iter().map().filter()` | `Stream API` |
-| 非同期イテレータ | `async function*` | `async for` | `Stream` | `Flow (Kotlin)` |
+| Generator | `function*` | `yield` | -- (replaced by Iterator) | -- |
+| Lazy pipeline | Custom implementation | `itertools` | `.iter().map().filter()` | `Stream API` |
+| Async iterator | `async function*` | `async for` | `Stream` | `Flow (Kotlin)` |
 
 ---
 
-## 10. アンチパターン
+## 10. Anti-Patterns
 
-### アンチパターン 1: 全データをメモリに載せてから処理
+### Anti-Pattern 1: Loading All Data into Memory Before Processing
 
 ```typescript
 // ============================
-// [NG] 100万件を配列に全て読み込み
+// [BAD] Load 1 million records into an array
 // ============================
-const allUsers = await fetchAllUsers(); // メモリに100万件!
+const allUsers = await fetchAllUsers(); // 1 million records in memory!
 const activeUsers = allUsers.filter(u => u.active);
 const names = activeUsers.map(u => u.name);
-// → 中間配列が2つ生成される
-// → メモリ使用量: 100万件 × 3 配列
+// → Two intermediate arrays are created
+// → Memory usage: 1 million records × 3 arrays
 
 // ============================
-// [OK] ジェネレータで1件ずつ処理
+// [GOOD] Process one record at a time using a generator
 // ============================
 async function* fetchActiveUserNames(): AsyncGenerator<string> {
   for await (const user of fetchAllPages<User>('/api/users')) {
@@ -1311,35 +1314,35 @@ async function* fetchActiveUserNames(): AsyncGenerator<string> {
   }
 }
 
-// メモリ使用量はページサイズ分のみ
+// Memory usage is only the page size
 const names2: string[] = [];
 for await (const name of fetchActiveUserNames()) {
   names2.push(name);
-  if (names2.length >= 100) break; // 早期終了も可能
+  if (names2.length >= 100) break; // early exit is also possible
 }
 ```
 
-### アンチパターン 2: イテレータの再利用
+### Anti-Pattern 2: Reusing an Iterator
 
 ```typescript
 // ============================
-// [NG] 同じイテレータを2回消費しようとする
+// [BAD] Trying to consume the same iterator twice
 // ============================
 function* nums() { yield 1; yield 2; yield 3; }
 const iter = nums();
 
 console.log([...iter]); // [1, 2, 3]
-console.log([...iter]); // [] ← 空! イテレータは使い切り
+console.log([...iter]); // [] ← empty! iterator is exhausted
 
 // ============================
-// [OK 方法1] Iterable を保持し、必要なときに新しい Iterator を生成
+// [GOOD Option 1] Hold an Iterable and create a new Iterator when needed
 // ============================
 const range = new Range(1, 4);
 console.log([...range]); // [1, 2, 3]
-console.log([...range]); // [1, 2, 3] ← Iterable なので何度でも
+console.log([...range]); // [1, 2, 3] ← works any number of times since it's Iterable
 
 // ============================
-// [OK 方法2] ジェネレータをファクトリ関数でラップ
+// [GOOD Option 2] Wrap the generator in a factory function
 // ============================
 function numsIterable(): Iterable<number> {
   return {
@@ -1352,49 +1355,49 @@ console.log([...reusable]); // [1, 2, 3]
 console.log([...reusable]); // [1, 2, 3] ← OK
 ```
 
-### アンチパターン 3: 非同期処理での forEach / map の誤用
+### Anti-Pattern 3: Misusing forEach / map with Async Processing
 
 ```typescript
 // ============================
-// [NG] forEach 内で async/await が期待通り動かない
+// [BAD] async/await inside forEach does not work as expected
 // ============================
 const urls = ['url1', 'url2', 'url3'];
 
-// forEach は同期的に全コールバックを起動する
+// forEach launches all callbacks synchronously
 urls.forEach(async (url) => {
   const data = await fetch(url);
-  console.log(data); // 順序不定、エラーも捕捉できない
+  console.log(data); // order is non-deterministic, errors cannot be caught
 });
-console.log('完了'); // ← forEach のコールバックより先に実行される!
+console.log('Done'); // ← executes before the forEach callbacks!
 
 // ============================
-// [OK] for...of + await で逐次処理
+// [GOOD] Sequential processing with for...of + await
 // ============================
 for (const url of urls) {
   const data = await fetch(url);
-  console.log(data); // 順序保証、try/catch で捕捉可能
+  console.log(data); // order is guaranteed, catchable with try/catch
 }
-console.log('完了'); // ← 全 fetch 完了後に実行
+console.log('Done'); // ← executes after all fetches complete
 
-// [OK] 並列実行が必要な場合は Promise.all
+// [GOOD] Use Promise.all when parallel execution is needed
 const results = await Promise.all(urls.map(url => fetch(url)));
 ```
 
 ---
 
-## 11. 演習問題
+## 11. Exercises
 
-### 演習 1（基礎）: 二分木のイテレータ
+### Exercise 1 (Basic): Binary Tree Iterator
 
-以下の仕様を満たす二分木のイテレータを実装してください。
+Implement a binary tree iterator that meets the following specification.
 
-**仕様:**
-- 二分探索木 (BST) クラスを定義
-- 3つの走査方法を Generator で実装: `inOrder()`, `preOrder()`, `postOrder()`
-- デフォルトの `[Symbol.iterator]` は中順 (in-order) 走査
+**Specification:**
+- Define a binary search tree (BST) class
+- Implement three traversal methods using Generator: `inOrder()`, `preOrder()`, `postOrder()`
+- The default `[Symbol.iterator]` should use in-order traversal
 
 ```typescript
-// ヒント
+// Hint
 interface BSTNode<T> {
   value: T;
   left: BSTNode<T> | null;
@@ -1402,36 +1405,36 @@ interface BSTNode<T> {
 }
 ```
 
-**期待される出力:**
+**Expected output:**
 ```
-BST に 5, 3, 7, 1, 4, 6, 8 を挿入
+Insert 5, 3, 7, 1, 4, 6, 8 into BST
 
-inOrder:   [1, 3, 4, 5, 6, 7, 8]  // 昇順ソート
-preOrder:  [5, 3, 1, 4, 7, 6, 8]  // 根 → 左 → 右
-postOrder: [1, 4, 3, 6, 8, 7, 5]  // 左 → 右 → 根
+inOrder:   [1, 3, 4, 5, 6, 7, 8]  // sorted ascending
+preOrder:  [5, 3, 1, 4, 7, 6, 8]  // root → left → right
+postOrder: [1, 4, 3, 6, 8, 7, 5]  // left → right → root
 
-for (const value of bst) { ... }   // inOrder で走査
+for (const value of bst) { ... }   // traverses in inOrder
 [...bst]                            // [1, 3, 4, 5, 6, 7, 8]
 ```
 
 ---
 
-### 演習 2（応用）: 非同期パイプライン
+### Exercise 2 (Applied): Async Pipeline
 
-以下の仕様を満たす非同期イテレータパイプラインを実装してください。
+Implement an async iterator pipeline that meets the following specification.
 
-**仕様:**
-- `AsyncIter<T>` クラスを実装
-- `map`, `filter`, `take`, `buffer` (N件ずつバッチ化) を遅延評価で提供
-- `for await...of` で消費可能
+**Specification:**
+- Implement an `AsyncIter<T>` class
+- Provide `map`, `filter`, `take`, and `buffer` (batching N items at a time) with lazy evaluation
+- Consumable via `for await...of`
 
-**期待される出力:**
+**Expected output:**
 ```
 const pipeline = AsyncIter.from(fetchAllPages<User>('/api/users'))
   .filter(user => user.active)
   .map(user => user.name)
-  .buffer(10)  // 10件ずつバッチ化
-  .take(5);    // 5バッチ（最大50件）
+  .buffer(10)  // batch 10 items at a time
+  .take(5);    // 5 batches (up to 50 items)
 
 for await (const batch of pipeline) {
   console.log(`Processing batch of ${batch.length} names`);
@@ -1441,17 +1444,17 @@ for await (const batch of pipeline) {
 
 ---
 
-### 演習 3（発展）: コルーチンによるジョブスケジューラ
+### Exercise 3 (Advanced): Coroutine-Based Job Scheduler
 
-以下の仕様を満たすコルーチンベースのジョブスケジューラを実装してください。
+Implement a coroutine-based job scheduler that meets the following specification.
 
-**仕様:**
-- Generator の `next(value)` による双方向通信を活用
-- ジョブは Generator 関数で定義し、`yield` で実行権を返す
-- スケジューラが複数ジョブをラウンドロビンで実行
+**Specification:**
+- Use two-way communication via Generator's `next(value)`
+- Define jobs as Generator functions that yield to give up execution
+- The scheduler runs multiple jobs in round-robin fashion
 
 ```typescript
-// ヒント: ジョブの定義
+// Hint: job definition
 function* downloadJob(url: string): Generator<string, void, void> {
   yield `Starting download: ${url}`;
   yield `Downloading... 50%`;
@@ -1460,13 +1463,13 @@ function* downloadJob(url: string): Generator<string, void, void> {
 }
 ```
 
-**期待される出力:**
+**Expected output:**
 ```
 scheduler.add(downloadJob('file1.zip'));
 scheduler.add(downloadJob('file2.zip'));
 scheduler.run();
 
-// ラウンドロビン実行:
+// Round-robin execution:
 // [Job1] Starting download: file1.zip
 // [Job2] Starting download: file2.zip
 // [Job1] Downloading... 50%
@@ -1480,33 +1483,33 @@ scheduler.run();
 
 ---
 
-## トラブルシューティング
+## Troubleshooting
 
-### よくあるエラーと解決策
+### Common Errors and Solutions
 
-| エラー | 原因 | 解決策 |
+| Error | Cause | Solution |
 |--------|------|--------|
-| 初期化エラー | 設定ファイルの不備 | 設定ファイルのパスと形式を確認 |
-| タイムアウト | ネットワーク遅延/リソース不足 | タイムアウト値の調整、リトライ処理の追加 |
-| メモリ不足 | データ量の増大 | バッチ処理の導入、ページネーションの実装 |
-| 権限エラー | アクセス権限の不足 | 実行ユーザーの権限確認、設定の見直し |
-| データ不整合 | 並行処理の競合 | ロック機構の導入、トランザクション管理 |
+| Initialization error | Misconfigured configuration file | Check the path and format of the configuration file |
+| Timeout | Network delay / insufficient resources | Adjust timeout value, add retry logic |
+| Out of memory | Growth in data volume | Introduce batch processing, implement pagination |
+| Permission error | Insufficient access rights | Check execution user's permissions, review settings |
+| Data inconsistency | Concurrent processing conflicts | Introduce locking mechanism, manage transactions |
 
-### デバッグの手順
+### Debugging Steps
 
-1. **エラーメッセージの確認**: スタックトレースを読み、発生箇所を特定する
-2. **再現手順の確立**: 最小限のコードでエラーを再現する
-3. **仮説の立案**: 考えられる原因をリストアップする
-4. **段階的な検証**: ログ出力やデバッガを使って仮説を検証する
-5. **修正と回帰テスト**: 修正後、関連する箇所のテストも実行する
+1. **Check the error message**: Read the stack trace to identify where it occurred
+2. **Establish reproduction steps**: Reproduce the error with minimal code
+3. **Form a hypothesis**: List possible causes
+4. **Verify incrementally**: Validate hypotheses using log output or a debugger
+5. **Fix and regression test**: After fixing, run tests for related areas as well
 
 ```python
-# デバッグ用ユーティリティ
+# Debug utility
 import logging
 import traceback
 from functools import wraps
 
-# ロガーの設定
+# Logger configuration
 logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s [%(levelname)s] %(name)s: %(message)s'
@@ -1514,77 +1517,77 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 def debug_decorator(func):
-    """関数の入出力をログ出力するデコレータ"""
+    """Decorator that logs function inputs and outputs"""
     @wraps(func)
     def wrapper(*args, **kwargs):
-        logger.debug(f"呼び出し: {func.__name__}(args={args}, kwargs={kwargs})")
+        logger.debug(f"Calling: {func.__name__}(args={args}, kwargs={kwargs})")
         try:
             result = func(*args, **kwargs)
-            logger.debug(f"戻り値: {func.__name__} -> {result}")
+            logger.debug(f"Return value: {func.__name__} -> {result}")
             return result
         except Exception as e:
-            logger.error(f"例外発生: {func.__name__}: {e}")
+            logger.error(f"Exception in: {func.__name__}: {e}")
             logger.error(traceback.format_exc())
             raise
     return wrapper
 
 @debug_decorator
 def process_data(items):
-    """データ処理（デバッグ対象）"""
+    """Data processing (debug target)"""
     if not items:
-        raise ValueError("空のデータ")
+        raise ValueError("Empty data")
     return [item * 2 for item in items]
 ```
 
-### パフォーマンス問題の診断
+### Diagnosing Performance Issues
 
-パフォーマンス問題が発生した場合の診断手順:
+Steps to diagnose performance issues:
 
-1. **ボトルネックの特定**: プロファイリングツールで計測
-2. **メモリ使用量の確認**: メモリリークの有無をチェック
-3. **I/O待ちの確認**: ディスクやネットワークI/Oの状況を確認
-4. **同時接続数の確認**: コネクションプールの状態を確認
+1. **Identify the bottleneck**: Measure with profiling tools
+2. **Check memory usage**: Look for memory leaks
+3. **Check for I/O waits**: Inspect disk and network I/O status
+4. **Check concurrent connections**: Review connection pool status
 
-| 問題の種類 | 診断ツール | 対策 |
+| Problem type | Diagnostic tool | Solution |
 |-----------|-----------|------|
-| CPU負荷 | cProfile, py-spy | アルゴリズム改善、並列化 |
-| メモリリーク | tracemalloc, objgraph | 参照の適切な解放 |
-| I/Oボトルネック | strace, iostat | 非同期I/O、キャッシュ |
-| DB遅延 | EXPLAIN, slow query log | インデックス、クエリ最適化 |
+| CPU load | cProfile, py-spy | Algorithm improvement, parallelization |
+| Memory leak | tracemalloc, objgraph | Properly release references |
+| I/O bottleneck | strace, iostat | Async I/O, caching |
+| DB latency | EXPLAIN, slow query log | Index, query optimization |
 ---
 
 ## 12. FAQ
 
-### Q1: ジェネレータと普通の関数、どちらを使うべきですか？
+### Q1: When should I use a generator versus a regular function?
 
-データ量が有限で小さい場合は通常の関数（配列を返す）で十分です。以下の場合にジェネレータを検討してください。
+A regular function (returning an array) is sufficient when the data is finite and small. Consider a generator in the following cases:
 
-1. **無限シーケンス**: フィボナッチ数列、乱数列、連番など終わりのないデータ
-2. **大量データの逐次処理**: ファイル読み込み、API ページネーション、ログ解析
-3. **途中で処理を中断する可能性**: 条件に合う最初の要素を見つけたら停止
-4. **メモリ制約が厳しい場面**: 中間配列を生成したくない
+1. **Infinite sequences**: Fibonacci series, random sequences, counters, and other endless data
+2. **Sequential processing of large data**: File reading, API pagination, log analysis
+3. **Possibility of stopping midway**: Stop when the first element matching a condition is found
+4. **Memory-constrained environments**: When you want to avoid creating intermediate arrays
 
-ジェネレータの最大のメリットは「**必要になるまで計算しない**」遅延評価です。
+The biggest advantage of generators is lazy evaluation — **"don't compute until needed"**.
 
-### Q2: for...of と forEach の違いは何ですか？
+### Q2: What is the difference between for...of and forEach?
 
-| 比較項目 | `for...of` | `Array.forEach` |
+| Comparison | `for...of` | `Array.forEach` |
 |---------|-----------|----------------|
-| 対象 | 全 Iterable | Array のみ |
-| break | 可能 | 不可能 |
-| continue | 可能 | return で代替 |
-| async/await | 正常動作 | 期待通り動かない |
-| Generator 対応 | 可能 | 不可能 |
-| return | ループを抜ける | コールバックを抜ける（ループは継続） |
+| Target | All Iterables | Arrays only |
+| break | Possible | Not possible |
+| continue | Possible | Use return as substitute |
+| async/await | Works correctly | Does not work as expected |
+| Generator support | Yes | No |
+| return | Exits the loop | Exits the callback (loop continues) |
 
-基本方針: `for...of` を優先し、`forEach` は副作用のない単純な全要素処理のみに使用。
+Basic guideline: prefer `for...of`; use `forEach` only for simple, side-effect-free processing of all elements.
 
-### Q3: AsyncGenerator のエラーハンドリングはどうすべきですか？
+### Q3: How should error handling be done with AsyncGenerator?
 
-`for await...of` のブロック内で `try/catch` を使います。また、Generator の `throw()` メソッドで外部からエラーを注入することもできます。
+Use `try/catch` inside the `for await...of` block. You can also inject errors from the outside using the Generator's `throw()` method.
 
 ```typescript
-// 実践的なエラーハンドリング
+// Practical error handling
 async function* resilientFetch<T>(
   urls: string[]
 ): AsyncGenerator<T> {
@@ -1593,90 +1596,90 @@ async function* resilientFetch<T>(
       const res = await fetch(url);
       if (!res.ok) {
         console.warn(`Skipping ${url}: ${res.status}`);
-        continue; // 個別ページのエラーはスキップ
+        continue; // skip errors on individual pages
       }
       const data = await res.json();
       yield data;
     } catch (err) {
       console.warn(`Network error for ${url}:`, err);
-      // 致命的でなければ continue、致命的なら throw
+      // continue if non-fatal, throw if fatal
     }
   }
 }
 ```
 
-ページネーションのような処理では、個別ページのエラーはリトライまたはスキップし、致命的なエラーのみ全体を中断するような設計が実用的です。`finally` ブロックでリソースのクリーンアップ（ストリームの解放、コネクションのクローズ）を忘れないでください。
+For processing such as pagination, a practical design is to retry or skip errors on individual pages and only abort the entire process for fatal errors. Don't forget to clean up resources in `finally` blocks (releasing streams, closing connections).
 
-### Q4: Iterator パターンは関数型プログラミングとどう関係しますか？
+### Q4: How does the Iterator pattern relate to functional programming?
 
-Iterator パターンは関数型プログラミングの **遅延リスト (Lazy List)** と本質的に同じ概念です。Haskell のリストは遅延評価で、必要な要素のみ計算されます。JavaScript の Generator はこの概念を命令型言語に持ち込んだものです。
+The Iterator pattern is essentially the same concept as **Lazy Lists** in functional programming. Lists in Haskell are lazily evaluated, computing only the elements needed. JavaScript's Generator brings this concept into an imperative language.
 
-Rust の `Iterator` trait は、`map`, `filter`, `fold` などの関数型操作を遅延評価で提供しており、Iterator パターンと関数型プログラミングの融合の好例です。
+Rust's `Iterator` trait provides functional operations like `map`, `filter`, and `fold` with lazy evaluation, making it a great example of the fusion of the Iterator pattern and functional programming.
 
-### Q5: Generator の yield* と yield の違いは何ですか？
+### Q5: What is the difference between yield* and yield in a Generator?
 
-`yield` は1つの値を送出します。`yield*` は別の Iterable のすべての値を順に送出します（デリゲート）。
+`yield` emits a single value. `yield*` emits all values from another Iterable one by one (delegation).
 
 ```typescript
 function* example() {
-  yield 1;               // 1つの値
-  yield* [2, 3, 4];      // 配列の全要素を順に
-  yield* anotherGen();   // 別の Generator の全要素を順に
+  yield 1;               // a single value
+  yield* [2, 3, 4];      // all elements of the array in order
+  yield* anotherGen();   // all elements of another Generator in order
   yield 5;
 }
-// 結果: 1, 2, 3, 4, (anotherGen の全出力), 5
+// Result: 1, 2, 3, 4, (all output from anotherGen), 5
 ```
 
-`yield*` はツリーの再帰走査で特に有用です。子ノードのイテレータに走査を委譲する場合に、明示的なループなしで自然に書けます。
+`yield*` is especially useful for recursive tree traversal. When delegating traversal to a child node's iterator, it can be written naturally without an explicit loop.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is the most important thing. Understanding deepens not just through theory but by actually writing code and verifying how it behaves.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping to advanced topics. We recommend thoroughly understanding the fundamental concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world development?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Item | Key Points |
 |------|------|
-| Iterator プロトコル | `Symbol.iterator` + `next()` で統一的な走査インターフェース |
-| Iterable vs Iterator | Iterable は何度でも走査可能、Iterator は1回使い切り |
-| for...of | Iterator プロトコルに基づくループ構文。break/continue/await 対応 |
-| Generator | `function*` と `yield` による遅延評価。無限シーケンスも表現可能 |
-| yield* | 別のイテレータにデリゲート。ツリー走査の再帰に有効 |
-| AsyncGenerator | `async function*` で非同期データの逐次処理 |
-| パイプライン | map/filter/take を遅延評価で連鎖。中間配列なし |
-| 外部 vs 内部 | 外部: 利用者が制御（peek, 複数同時走査）、内部: コレクションが制御（forEach） |
+| Iterator protocol | Unified traversal interface via `Symbol.iterator` + `next()` |
+| Iterable vs Iterator | Iterable can be traversed multiple times; Iterator is single-use |
+| for...of | Loop syntax based on the Iterator protocol. Supports break/continue/await |
+| Generator | Lazy evaluation with `function*` and `yield`. Can express infinite sequences |
+| yield* | Delegates to another iterator. Useful for recursive tree traversal |
+| AsyncGenerator | Sequential async data processing with `async function*` |
+| Pipeline | Chain map/filter/take with lazy evaluation. No intermediate arrays |
+| External vs Internal | External: consumer controls (peek, multiple simultaneous traversals); Internal: collection controls (forEach) |
 
 ---
 
-## 次に読むべきガイド
+## What to Read Next
 
-- [02-command.md](./02-command.md) -- Command パターンと操作のカプセル化（Command 履歴の走査に Iterator を活用）
-- [03-state.md](./03-state.md) -- State パターンと状態遷移
-- [../01-structural/04-composite.md](../01-structural/04-composite.md) -- Composite パターン（ツリー走査に Iterator を活用）
-- [../03-functional/02-fp-patterns.md](../03-functional/02-fp-patterns.md) -- 関数型パターン（パイプライン、合成）
-- [../03-functional/00-monad.md](../03-functional/00-monad.md) -- モナドパターン（Iterator は List モナドと関連）
+- [02-command.md](./02-command.md) -- Command pattern and encapsulation of operations (Iterator used to traverse Command history)
+- [03-state.md](./03-state.md) -- State pattern and state transitions
+- [../01-structural/04-composite.md](../01-structural/04-composite.md) -- Composite pattern (Iterator used for tree traversal)
+- [../03-functional/02-fp-patterns.md](../03-functional/02-fp-patterns.md) -- Functional patterns (pipelines, composition)
+- [../03-functional/00-monad.md](../03-functional/00-monad.md) -- Monad pattern (Iterator is related to the List monad)
 
 ---
 
-## 参考文献
+## References
 
-1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- Iterator パターンの原典。Chapter 5, pp.257-271
-2. **MDN - Iterators and generators** -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators -- JavaScript のイテレータとジェネレータの公式リファレンス
-3. **Exploring ES6 - Iterables and iterators** -- Axel Rauschmayer -- ES6 仕様に基づく詳細な解説
-4. **Python itertools documentation** -- https://docs.python.org/3/library/itertools.html -- Python のイテレータユーティリティ
-5. **Rust Iterator trait documentation** -- https://doc.rust-lang.org/std/iter/trait.Iterator.html -- 遅延評価イテレータの優れた実装例
+1. **Design Patterns: Elements of Reusable Object-Oriented Software** -- Gamma, Helm, Johnson, Vlissides (GoF, 1994) -- The original source of the Iterator pattern. Chapter 5, pp.257-271
+2. **MDN - Iterators and generators** -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators -- Official reference for JavaScript iterators and generators
+3. **Exploring ES6 - Iterables and iterators** -- Axel Rauschmayer -- Detailed explanation based on the ES6 specification
+4. **Python itertools documentation** -- https://docs.python.org/3/library/itertools.html -- Python's iterator utilities
+5. **Rust Iterator trait documentation** -- https://doc.rust-lang.org/std/iter/trait.Iterator.html -- An excellent implementation example of lazy evaluation iterators

--- a/03-software-design/design-patterns-guide/docs/03-functional/00-monad.md
+++ b/03-software-design/design-patterns-guide/docs/03-functional/00-monad.md
@@ -1,42 +1,42 @@
-# モナド (Monad)
+# Monad
 
-> Maybe/Either、IO、Promise などのモナドパターンを理解し、副作用を制御しつつ合成可能なデータフローを構築する
+> Understand monad patterns such as Maybe/Either, IO, and Promise to build composable data flows while controlling side effects
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. **モナドの本質** --- bind (flatMap) による計算の連鎖と、コンテキスト内での値の変換がなぜ必要か
-2. **実用的なモナド** --- Maybe/Option、Either/Result、Promise/Future、IO、List、Reader の具体的実装と活用
-3. **モナド則** --- 3つの法則（左単位元・右単位元・結合則）の意味と検証方法
-4. **鉄道指向プログラミング** --- Either/Result を用いたエラーハンドリングパイプラインの設計
-5. **モナド合成** --- モナドトランスフォーマー、do 記法、async/await との関係
+1. **The essence of monads** --- Why chaining computations via bind (flatMap) and transforming values within a context is necessary
+2. **Practical monads** --- Concrete implementations and usage of Maybe/Option, Either/Result, Promise/Future, IO, List, and Reader
+3. **Monad laws** --- The meaning and verification of the three laws (left identity, right identity, associativity)
+4. **Railway-oriented programming** --- Designing error-handling pipelines using Either/Result
+5. **Monad composition** --- Monad transformers, do-notation, and their relationship with async/await
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---|---|---|
-| TypeScript ジェネリクス | クラス・関数のジェネリクス定義 | [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/generics.html) |
-| 高階関数 | map, filter, reduce の理解 | [関数型パターン](./02-fp-patterns.md) |
-| Promise/async-await | 非同期処理の基礎 | [MDN Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) |
-| 代数的データ型 | Union 型、判別共用体 | [TypeScript Union Types](https://www.typescriptlang.org/docs/handbook/2/narrowing.html) |
-| ファンクタの概念 | map の意味 | [ファンクタ・アプリカティブ](./01-functor-applicative.md) |
+| TypeScript generics | Defining generics for classes and functions | [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/generics.html) |
+| Higher-order functions | Understanding map, filter, reduce | [Functional Patterns](./02-fp-patterns.md) |
+| Promise/async-await | Basics of asynchronous processing | [MDN Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) |
+| Algebraic data types | Union types, discriminated unions | [TypeScript Union Types](https://www.typescriptlang.org/docs/handbook/2/narrowing.html) |
+| Functor concept | Meaning of map | [Functor and Applicative](./01-functor-applicative.md) |
 
 ---
 
-## WHY --- なぜモナドが必要か
+## WHY --- Why Are Monads Necessary?
 
-### 問題: 副作用と分岐の爆発
+### Problem: Explosion of Side Effects and Branches
 
-実際のプログラムでは、あらゆる操作が「失敗するかもしれない」「値がないかもしれない」「非同期かもしれない」というコンテキストを伴う。これらを愚直に扱うと、null チェック・エラーハンドリング・コールバックのネストが爆発する。
+In real programs, every operation comes with a context: "this might fail," "this value might not exist," or "this might be asynchronous." Handling these naively leads to an explosion of null checks, error handling, and nested callbacks.
 
 ```
-問題: コンテキスト付き計算の連鎖
+Problem: Chaining computations with context
 ====================================
 
-[素朴な実装 --- ネストの爆発]
+[Naive implementation --- explosion of nesting]
 
-  getUser(id) ──→ null チェック ──→ getAddress(user) ──→ null チェック ──→ getCity(addr)
+  getUser(id) ──→ null check ──→ getAddress(user) ──→ null check ──→ getCity(addr)
                     |                                      |
                     v                                      v
                   return default                        return default
@@ -46,100 +46,98 @@
                       v                                    v
                     handleError                          handleError
 
-  // ネスト地獄
+  // Nesting hell
   if (user != null) {
     if (user.address != null) {
       if (user.address.city != null) {
-        // ようやく本来のロジック
+        // Finally, the actual logic
       }
     }
   }
 
-[モナドによる解決 --- フラットな合成]
+[Solution with monads --- flat composition]
 
   Maybe.of(user)
     .flatMap(u => Maybe.fromNullable(u.address))
     .flatMap(a => Maybe.fromNullable(a.city))
     .getOrElse("Unknown")
 
-  // 各ステップで「失敗したら自動スキップ」
-  // ネストなし。直線的。合成可能。
+  // Each step automatically skips if "failed"
+  // No nesting. Linear. Composable.
 ```
 
-### 解決: コンテキスト内での合成可能な計算
+### Solution: Composable Computation Within a Context
 
-モナドは **コンテキスト(文脈)付きの値** に対する **合成可能な計算の連鎖** を提供する抽象化である。
+A monad is an abstraction that provides **composable chains of computation** over **values with context**.
 
-- **Maybe/Option**: 「値がないかもしれない」コンテキスト。null ならスキップ
-- **Either/Result**: 「失敗するかもしれない」コンテキスト。エラーならスキップ
-- **Promise/Future**: 「まだ完了していない」コンテキスト。完了後に次を実行
-- **IO**: 「副作用がある」コンテキスト。実行を遅延して合成
-- **List/Array**: 「複数の値がある」コンテキスト。各要素に適用してフラットに
-- **Reader**: 「環境に依存する」コンテキスト。依存を引き回す
+- **Maybe/Option**: The context of "a value might not exist." Skip if null
+- **Either/Result**: The context of "this might fail." Skip if there is an error
+- **Promise/Future**: The context of "not yet complete." Execute next after completion
+- **IO**: The context of "has side effects." Defer execution and compose
+- **List/Array**: The context of "multiple values." Apply to each element and flatten
+- **Reader**: The context of "depends on an environment." Thread dependencies implicitly
 
-すべてのモナドは同じインターフェース (`unit` + `bind`) を持ち、同じ法則に従う。この統一性により、異なるコンテキストの計算を同じパターンで扱える。
+All monads share the same interface (`unit` + `bind`) and follow the same laws. This uniformity allows computations from different contexts to be handled with the same pattern.
 
 ---
 
-## モナドの定義
+## Definition of a Monad
 
-Philip Wadler (1992) "Monads for functional programming" より:
+From Philip Wadler (1992) "Monads for functional programming":
 
 > A monad is a triple (M, unit, bind) where M is a type constructor, unit lifts a value into the monadic context, and bind sequences computations within the context.
 
-日本語訳: モナドは三つ組 (M, unit, bind) であり、M は型コンストラクタ、unit は値をモナドコンテキストに持ち上げ、bind はコンテキスト内で計算を連鎖させる。
-
 ```
-モナドの構成要素
+Components of a Monad
 ==================
 
-  型コンストラクタ M:
-    通常の型 T を「コンテキスト付きの型」M<T> に変換する
+  Type constructor M:
+    Converts a normal type T into a "contextual type" M<T>
 
   unit (return, of, pure):
     T  --->  M<T>
-    値をコンテキストに入れる。副作用なし。
+    Places a value into the context. No side effects.
 
   bind (flatMap, >>=, then, and_then):
     M<T>  --->  (T -> M<U>)  --->  M<U>
-    コンテキスト内の値を取り出し、次の計算に渡し、結果をフラットにする。
+    Extracts the value from the context, passes it to the next computation, and flattens the result.
 
-  ※ map との違い:
-    map  : M<T> -> (T ->   U ) -> M<U>    (値を変換)
-    bind : M<T> -> (T -> M<U>) -> M<U>    (コンテキストを変換)
+  * Difference from map:
+    map  : M<T> -> (T ->   U ) -> M<U>    (transforms the value)
+    bind : M<T> -> (T -> M<U>) -> M<U>    (transforms the context)
 
-  map は bind + unit で定義できる:
+  map can be defined in terms of bind + unit:
     m.map(f) === m.bind(x => unit(f(x)))
 
-モナド則 (Monad Laws)
+Monad Laws
 =======================
 
-  1. 左単位元 (Left Identity):
+  1. Left Identity:
      unit(a).bind(f) === f(a)
-     「値をコンテキストに入れてから bind」= 「直接関数に渡す」
+     "bind after putting a value into context" = "pass directly to the function"
 
-  2. 右単位元 (Right Identity):
+  2. Right Identity:
      m.bind(unit) === m
-     「コンテキストの値を取り出して unit で戻す」= 「何もしない」
+     "extract the value from context and put it back with unit" = "do nothing"
 
-  3. 結合則 (Associativity):
+  3. Associativity:
      m.bind(f).bind(g) === m.bind(x => f(x).bind(g))
-     「左から順に bind」= 「入れ子にして bind」
+     "bind left to right" = "bind with nesting"
 
-  図解:
-    値 a  --[unit]--> M<a>  --[bind(f)]--> M<b>  --[bind(g)]--> M<c>
+  Diagram:
+    value a  --[unit]--> M<a>  --[bind(f)]--> M<b>  --[bind(g)]--> M<c>
 
-  これらの法則により、モナドは合成の順序に依存しない
-  一貫した振る舞いを保証する。
+  These laws guarantee that monads behave consistently
+  regardless of the order of composition.
 ```
 
 ---
 
-## コード例 1: Maybe/Option モナド --- 完全実装
+## Code Example 1: Maybe/Option Monad --- Full Implementation
 
 ```typescript
 // =============================================================
-// Maybe モナド: null 安全な計算の連鎖
+// Maybe Monad: Chaining null-safe computations
 // =============================================================
 
 class Maybe<T> {
@@ -173,7 +171,7 @@ class Maybe<T> {
     return maybeFn.flatMap(fn => this.map(fn));
   }
 
-  // --- ユーティリティ ---
+  // --- Utilities ---
   getOrElse(defaultValue: T): T {
     return this.value ?? defaultValue;
   }
@@ -196,12 +194,12 @@ class Maybe<T> {
     return this.value != null;
   }
 
-  // パターンマッチ
+  // Pattern matching
   match<U>(patterns: { just: (value: T) => U; nothing: () => U }): U {
     return this.value != null ? patterns.just(this.value) : patterns.nothing();
   }
 
-  // デバッグ用 (副作用を挿入しつつチェーンを維持)
+  // For debugging (insert side effect while maintaining the chain)
   tap(fn: (value: T) => void): Maybe<T> {
     if (this.value != null) fn(this.value);
     return this;
@@ -213,26 +211,26 @@ class Maybe<T> {
 }
 
 // =============================================================
-// モナド則の検証
+// Verification of Monad Laws
 // =============================================================
 const f = (x: number) => Maybe.of(x * 2);
 const g = (x: number) => (x > 0 ? Maybe.of(x + 1) : Maybe.nothing<number>());
 
-// 左単位元: unit(a).bind(f) === f(a)
+// Left Identity: unit(a).bind(f) === f(a)
 console.log(Maybe.of(5).flatMap(f).toString());  // Just(10)
 console.log(f(5).toString());                     // Just(10)
 
-// 右単位元: m.bind(unit) === m
+// Right Identity: m.bind(unit) === m
 console.log(Maybe.of(5).flatMap(Maybe.of).toString());  // Just(5)
 console.log(Maybe.of(5).toString());                     // Just(5)
 
-// 結合則: m.bind(f).bind(g) === m.bind(x => f(x).bind(g))
+// Associativity: m.bind(f).bind(g) === m.bind(x => f(x).bind(g))
 const m = Maybe.of(3);
 console.log(m.flatMap(f).flatMap(g).toString());              // Just(7)
 console.log(m.flatMap(x => f(x).flatMap(g)).toString());      // Just(7)
 
 // =============================================================
-// 実践的な使用例: ネストされたオブジェクトの安全な探索
+// Practical usage: Safe traversal of nested objects
 // =============================================================
 interface Company {
   name: string;
@@ -253,7 +251,7 @@ function getCeoCity(company: Company | null): string {
     .getOrElse("Unknown");
 }
 
-// テスト
+// Tests
 const company1: Company = {
   name: "Acme",
   ceo: { name: "Alice", address: { city: "Tokyo", country: "JP" } }
@@ -262,12 +260,12 @@ const company2: Company = { name: "Beta" };
 const company3: Company = { name: "Gamma", ceo: { name: "Bob" } };
 
 console.log(getCeoCity(company1));  // "Tokyo"
-console.log(getCeoCity(company2));  // "Unknown" (ceo なし)
-console.log(getCeoCity(company3));  // "Unknown" (address なし)
-console.log(getCeoCity(null));      // "Unknown" (company なし)
+console.log(getCeoCity(company2));  // "Unknown" (no ceo)
+console.log(getCeoCity(company3));  // "Unknown" (no address)
+console.log(getCeoCity(null));      // "Unknown" (no company)
 
 // =============================================================
-// Maybe + 配列: 安全な検索
+// Maybe + Array: Safe search
 // =============================================================
 function findFirst<T>(
   items: T[],
@@ -289,7 +287,7 @@ const products: Product[] = [
   { id: 3, name: "Doohickey", discount: 0.25 },
 ];
 
-// 割引価格を安全に計算
+// Safely calculate the discounted price
 function getDiscountedPrice(
   products: Product[],
   productId: number,
@@ -301,24 +299,24 @@ function getDiscountedPrice(
 }
 
 console.log(getDiscountedPrice(products, 1, 100).toString());  // Just(90)
-console.log(getDiscountedPrice(products, 2, 100).toString());  // Nothing (割引なし)
-console.log(getDiscountedPrice(products, 9, 100).toString());  // Nothing (商品なし)
+console.log(getDiscountedPrice(products, 2, 100).toString());  // Nothing (no discount)
+console.log(getDiscountedPrice(products, 9, 100).toString());  // Nothing (no product)
 ```
 
 ---
 
-## コード例 2: Either/Result モナド --- 鉄道指向プログラミング
+## Code Example 2: Either/Result Monad --- Railway-Oriented Programming
 
 ```typescript
 // =============================================================
-// Either モナド: 型安全なエラーハンドリング
+// Either Monad: Type-safe error handling
 // =============================================================
 
 type Either<L, R> =
   | { readonly tag: "Left"; readonly value: L }
   | { readonly tag: "Right"; readonly value: R };
 
-// --- コンストラクタ ---
+// --- Constructors ---
 const Left = <L, R = never>(value: L): Either<L, R> => ({
   tag: "Left",
   value,
@@ -328,7 +326,7 @@ const Right = <R, L = never>(value: R): Either<L, R> => ({
   value,
 });
 
-// --- モナド操作 (関数スタイル) ---
+// --- Monad operations (functional style) ---
 const EitherM = {
   // unit
   of<R>(value: R): Either<never, R> {
@@ -348,12 +346,12 @@ const EitherM = {
     return either.tag === "Right" ? fn(either.value) : either;
   },
 
-  // mapLeft: エラー側を変換
+  // mapLeft: transform the error side
   mapLeft<L, R, U>(either: Either<L, R>, fn: (l: L) => U): Either<U, R> {
     return either.tag === "Left" ? Left(fn(either.value)) : either;
   },
 
-  // bimap: 両側を変換
+  // bimap: transform both sides
   bimap<L, R, U, V>(
     either: Either<L, R>,
     leftFn: (l: L) => U,
@@ -364,7 +362,7 @@ const EitherM = {
       : Right(rightFn(either.value));
   },
 
-  // fold (パターンマッチ)
+  // fold (pattern matching)
   fold<L, R, U>(
     either: Either<L, R>,
     onLeft: (l: L) => U,
@@ -375,7 +373,7 @@ const EitherM = {
       : onRight(either.value);
   },
 
-  // tryCatch: 例外を Either に変換
+  // tryCatch: convert exceptions to Either
   tryCatch<R>(fn: () => R): Either<Error, R> {
     try {
       return Right(fn());
@@ -384,7 +382,7 @@ const EitherM = {
     }
   },
 
-  // fromNullable: null/undefined を Left に変換
+  // fromNullable: convert null/undefined to Left
   fromNullable<L, R>(
     value: R | null | undefined,
     error: L
@@ -392,7 +390,7 @@ const EitherM = {
     return value == null ? Left(error) : Right(value);
   },
 
-  // 複数の Either を結合 (すべて Right なら成功)
+  // Combine multiple Eithers (succeeds only if all are Right)
   sequence<L, R>(eithers: Either<L, R>[]): Either<L, R[]> {
     const results: R[] = [];
     for (const either of eithers) {
@@ -404,10 +402,10 @@ const EitherM = {
 };
 
 // =============================================================
-// 鉄道指向プログラミング: バリデーションパイプライン
+// Railway-oriented programming: Validation pipeline
 // =============================================================
 
-// 構造化エラー型
+// Structured error type
 interface ValidationError {
   field: string;
   message: string;
@@ -420,7 +418,7 @@ const vError = (
   code: string
 ): ValidationError => ({ field, message, code });
 
-// 各バリデーション関数は Either を返す
+// Each validation function returns an Either
 function validateEmail(
   email: string
 ): Either<ValidationError, string> {
@@ -470,7 +468,7 @@ function validateUsername(
   return Right(name);
 }
 
-// --- 鉄道: 最初のエラーで停止 ---
+// --- Railway: stop at first error ---
 interface RegistrationInput {
   username: string;
   email: string;
@@ -488,7 +486,7 @@ interface ValidatedUser {
 function validateRegistration(
   input: RegistrationInput
 ): Either<ValidationError, ValidatedUser> {
-  // 各ステップが Left を返した時点でパイプライン全体が Left になる
+  // The entire pipeline becomes Left when any step returns Left
   const username = validateUsername(input.username);
   const email = EitherM.flatMap(username, () => validateEmail(input.email));
   const password = EitherM.flatMap(email, () => validatePassword(input.password));
@@ -502,7 +500,7 @@ function validateRegistration(
   }));
 }
 
-// テスト
+// Tests
 const good = validateRegistration({
   username: "alice",
   email: "alice@example.com",
@@ -521,7 +519,7 @@ const bad = validateRegistration({
 console.log(bad);
 // { tag: "Left", value: { field: "username", message: "Min 3 chars", code: "USERNAME_TOO_SHORT" } }
 
-// --- 鉄道: すべてのエラーを収集 (Validation モナド) ---
+// --- Railway: collect all errors (Validation monad) ---
 function validateAllErrors(
   input: RegistrationInput
 ): Either<ValidationError[], ValidatedUser> {
@@ -566,11 +564,11 @@ console.log(allBad);
 
 ---
 
-## コード例 3: Result モナド --- TypeScript 型安全実装
+## Code Example 3: Result Monad --- TypeScript Type-Safe Implementation
 
 ```typescript
 // =============================================================
-// Result<T, E>: Rust スタイルの型安全エラーハンドリング
+// Result<T, E>: Rust-style type-safe error handling
 // =============================================================
 
 class Result<T, E> {
@@ -632,7 +630,7 @@ class Result<T, E> {
       : Result.err(this._error as E);
   }
 
-  // --- 値の取得 ---
+  // --- Value extraction ---
   unwrap(): T {
     if (!this._ok) throw new Error("Called unwrap on Err");
     return this._value as T;
@@ -651,14 +649,14 @@ class Result<T, E> {
     return this._error as E;
   }
 
-  // --- パターンマッチ ---
+  // --- Pattern matching ---
   match<U>(patterns: { ok: (value: T) => U; err: (error: E) => U }): U {
     return this._ok
       ? patterns.ok(this._value as T)
       : patterns.err(this._error as E);
   }
 
-  // --- 合成 ---
+  // --- Composition ---
   and<U>(other: Result<U, E>): Result<U, E> {
     return this._ok ? other : Result.err(this._error as E);
   }
@@ -667,7 +665,7 @@ class Result<T, E> {
     return this._ok ? this : other;
   }
 
-  // --- 変換 ---
+  // --- Conversion ---
   toMaybe(): Maybe<T> {
     return this._ok ? Maybe.of(this._value as T) : Maybe.nothing();
   }
@@ -680,7 +678,7 @@ class Result<T, E> {
 }
 
 // =============================================================
-// 実践例: JSON パース -> バリデーション -> ビジネスロジック
+// Practical example: JSON parse -> validation -> business logic
 // =============================================================
 
 interface Config {
@@ -725,14 +723,14 @@ function normalizeConfig(config: Config): Result<Config, string> {
   return Result.ok(config);
 }
 
-// flatMap の連鎖 = 鉄道指向パイプライン
+// Chaining flatMap = railway-oriented pipeline
 function loadConfig(raw: string): Result<Config, string> {
   return parseJson(raw)
     .flatMap(validateConfig)
     .flatMap(normalizeConfig);
 }
 
-// テスト
+// Tests
 console.log(loadConfig('{"host":"localhost","port":8080,"maxRetries":3}').toString());
 // Ok({"host":"127.0.0.1","port":8080,"maxRetries":3})
 
@@ -748,15 +746,15 @@ console.log(loadConfig('{"host":"example.com","port":99999,"maxRetries":3}').toS
 
 ---
 
-## コード例 4: IO モナドと Promise
+## Code Example 4: IO Monad and Promise
 
 ```typescript
 // =============================================================
-// IO モナド: 副作用の遅延実行と合成
+// IO Monad: Deferred execution and composition of side effects
 // =============================================================
 
-// IO は「副作用を持つ計算」を値として扱う
-// 実行されるまで副作用は発生しない (参照透過性の維持)
+// IO treats "computations with side effects" as values
+// Side effects do not occur until execution (preserving referential transparency)
 class IO<T> {
   constructor(private readonly effect: () => T) {}
 
@@ -775,17 +773,17 @@ class IO<T> {
     return new IO(() => fn(this.effect()).run());
   }
 
-  // 副作用を実行
+  // Execute the side effect
   run(): T {
     return this.effect();
   }
 
-  // 2つの IO を順次実行
+  // Run two IOs sequentially
   andThen<U>(next: IO<U>): IO<U> {
     return this.flatMap(() => next);
   }
 
-  // デバッグ用
+  // For debugging
   tap(fn: (value: T) => void): IO<T> {
     return new IO(() => {
       const result = this.effect();
@@ -795,13 +793,13 @@ class IO<T> {
   }
 }
 
-// --- IO ユーティリティ ---
+// --- IO utilities ---
 const ConsoleIO = {
   log(message: string): IO<void> {
     return new IO(() => console.log(message));
   },
   readLine(prompt: string): IO<string> {
-    // 実際の readline 実装は省略
+    // Actual readline implementation is omitted
     return new IO(() => {
       console.log(prompt);
       return "simulated-input";
@@ -816,10 +814,10 @@ const ConsoleIO = {
 };
 
 // =============================================================
-// IO の合成: プログラム全体を純粋に記述
+// IO composition: Describe an entire program purely
 // =============================================================
 
-// このプログラム定義自体は純粋 (副作用なし)
+// This program definition itself is pure (no side effects)
 const greetProgram: IO<void> = ConsoleIO.currentTime()
   .map(date => date.toISOString())
   .flatMap(time =>
@@ -827,21 +825,21 @@ const greetProgram: IO<void> = ConsoleIO.currentTime()
       .andThen(ConsoleIO.log(`[${time}] Welcome to IO Monad`))
   );
 
-// run() を呼ぶまで何も起きない
-// greetProgram.run();  // 実行時にのみ副作用が発生
+// Nothing happens until run() is called
+// greetProgram.run();  // Side effects only occur at execution time
 
 // =============================================================
-// 比較: IO vs 直接副作用
+// Comparison: IO vs direct side effects
 // =============================================================
 
-// [NG] 直接副作用 --- テスト困難
+// [NG] Direct side effects --- hard to test
 function greetDirect(): void {
-  const time = new Date().toISOString();  // 副作用: 現在時刻
-  console.log(`[${time}] Hello!`);        // 副作用: コンソール出力
-  console.log(`[${time}] Welcome`);       // 副作用: コンソール出力
+  const time = new Date().toISOString();  // side effect: current time
+  console.log(`[${time}] Hello!`);        // side effect: console output
+  console.log(`[${time}] Welcome`);       // side effect: console output
 }
 
-// [OK] IO モナド --- テスト可能
+// [OK] IO monad --- testable
 function greetIO(
   getTime: () => IO<Date>,
   log: (msg: string) => IO<void>
@@ -854,7 +852,7 @@ function greetIO(
     );
 }
 
-// テスト時: モック IO を注入
+// During testing: inject mock IOs
 const logs: string[] = [];
 const mockGetTime = () => IO.of(new Date("2025-01-01T00:00:00Z"));
 const mockLog = (msg: string) => new IO(() => { logs.push(msg); });
@@ -864,15 +862,15 @@ console.log(logs);
 // ["[2025-01-01T00:00:00.000Z] Hello!", "[2025-01-01T00:00:00.000Z] Welcome"]
 
 // =============================================================
-// Promise = 非同期 IO モナド
-// async/await = do 記法の糖衣構文
+// Promise = asynchronous IO monad
+// async/await = syntactic sugar for do-notation
 // =============================================================
 
-// Promise のモナド的性質
+// Monadic nature of Promise
 // then = flatMap (bind)
 // Promise.resolve = unit
 
-// [モナディックスタイル (then チェーン)]
+// [Monadic style (then chain)]
 function fetchUserOrdersChain(userId: string): Promise<OrderSummary> {
   return fetchUser(userId)                                // Promise<User>
     .then(user => fetchOrders(user.id))                   // flatMap: User -> Promise<Order[]>
@@ -884,11 +882,11 @@ function fetchUserOrdersChain(userId: string): Promise<OrderSummary> {
     }));
 }
 
-// [do 記法スタイル (async/await)]
+// [do-notation style (async/await)]
 async function fetchUserOrdersAwait(userId: string): Promise<OrderSummary> {
   const user = await fetchUser(userId);                    // bind
   const orders = await fetchOrders(user.id);               // bind
-  const activeOrders = orders.filter(o => o.active);       // 純粋計算
+  const activeOrders = orders.filter(o => o.active);       // pure computation
 
   return {                                                 // unit (return)
     userId,
@@ -897,7 +895,7 @@ async function fetchUserOrdersAwait(userId: string): Promise<OrderSummary> {
   };
 }
 
-// 型定義 (上記コード用)
+// Type definitions (for the code above)
 interface OrderSummary {
   userId: string;
   totalOrders: number;
@@ -910,18 +908,18 @@ declare function fetchOrders(userId: string): Promise<Array<{ active: boolean; a
 
 ---
 
-## コード例 5: List モナドと Reader モナド
+## Code Example 5: List Monad and Reader Monad
 
 ```typescript
 // =============================================================
-// List モナド: 非決定性計算
-// flatMap = 各要素に関数を適用してフラットに
+// List Monad: Non-deterministic computation
+// flatMap = apply a function to each element and flatten
 // =============================================================
 
-// Array は実は List モナド
-// Array.prototype.flatMap が bind に相当
+// Array is actually a List monad
+// Array.prototype.flatMap corresponds to bind
 
-// 例: チェスのナイトの移動
+// Example: chess knight moves
 type Position = [number, number];
 
 function knightMoves([x, y]: Position): Position[] {
@@ -934,17 +932,17 @@ function knightMoves([x, y]: Position): Position[] {
     .filter(([nx, ny]) => nx >= 1 && nx <= 8 && ny >= 1 && ny <= 8);
 }
 
-// 3手後に到達可能なすべての位置 (List モナドの flatMap)
+// All positions reachable in 3 moves (flatMap of List monad)
 function knightReachableIn3(start: Position): Position[] {
   return [start]
-    .flatMap(knightMoves)   // 1手目: すべての可能な位置
-    .flatMap(knightMoves)   // 2手目: さらにすべての可能な位置
-    .flatMap(knightMoves);  // 3手目: さらに
+    .flatMap(knightMoves)   // Move 1: all possible positions
+    .flatMap(knightMoves)   // Move 2: all further possible positions
+    .flatMap(knightMoves);  // Move 3: further
 }
 
-console.log(`(1,1) から3手で到達可能: ${knightReachableIn3([1, 1]).length} 通り`);
+console.log(`Reachable from (1,1) in 3 moves: ${knightReachableIn3([1, 1]).length} positions`);
 
-// List Comprehension としての flatMap
+// flatMap as List Comprehension
 // Haskell: [(x, y) | x <- [1..3], y <- [1..3], x /= y]
 // Python:  [(x, y) for x in range(1,4) for y in range(1,4) if x != y]
 const pairs = [1, 2, 3]
@@ -953,11 +951,11 @@ const pairs = [1, 2, 3]
 console.log(pairs); // [[1,2],[1,3],[2,1],[2,3],[3,1],[3,2]]
 
 // =============================================================
-// Reader モナド: 依存性注入
+// Reader Monad: Dependency injection
 // =============================================================
 
-// Reader<E, A> は E -> A の関数をラップしたモナド
-// 環境 E を暗黙的に引き回す
+// Reader<E, A> is a monad that wraps a function E -> A
+// Threads environment E implicitly
 class Reader<E, A> {
   constructor(public readonly run: (env: E) => A) {}
 
@@ -965,12 +963,12 @@ class Reader<E, A> {
     return new Reader(() => value);
   }
 
-  // 環境そのものを取得
+  // Retrieve the environment itself
   static ask<E>(): Reader<E, E> {
     return new Reader(env => env);
   }
 
-  // 環境の一部を取得
+  // Retrieve part of the environment
   static asks<E, A>(fn: (env: E) => A): Reader<E, A> {
     return new Reader(fn);
   }
@@ -984,7 +982,7 @@ class Reader<E, A> {
   }
 }
 
-// 実践例: 設定と DB 接続を引き回す
+// Practical example: threading config and DB connection
 interface AppEnv {
   db: { query: (sql: string) => string[] };
   config: { maxResults: number; locale: string };
@@ -1000,7 +998,7 @@ const getMaxResults: Reader<AppEnv, number> =
 const getLocale: Reader<AppEnv, string> =
   Reader.asks((env: AppEnv) => env.config.locale);
 
-// flatMap で Reader を合成 --- 環境は暗黙的に引き回される
+// Compose Readers with flatMap --- environment is threaded implicitly
 const getUserReport: Reader<AppEnv, string> = getUsers
   .flatMap(users =>
     getMaxResults.flatMap(max =>
@@ -1011,7 +1009,7 @@ const getUserReport: Reader<AppEnv, string> = getUsers
     )
   );
 
-// 実行: 環境を一箇所で注入
+// Execution: inject the environment in one place
 const env: AppEnv = {
   db: { query: () => ["Alice", "Bob", "Charlie", "Dave", "Eve"] },
   config: { maxResults: 3, locale: "ja-JP" },
@@ -1021,7 +1019,7 @@ const env: AppEnv = {
 console.log(getUserReport.run(env));
 // "[ja-JP] Found 3 users (max: 3)"
 
-// テスト: モック環境で実行
+// Testing: run with a mock environment
 const testEnv: AppEnv = {
   db: { query: () => ["TestUser"] },
   config: { maxResults: 10, locale: "en-US" },
@@ -1034,14 +1032,15 @@ console.log(getUserReport.run(testEnv));
 
 ---
 
-## コード例 6: Python でのモナドパターン
+## Code Example 6: Monad Patterns in Python
 
 ```python
 """
-Python でのモナド実装
+Monad implementation in Python
 =====================
-Python は静的型が弱いため、Haskell や TypeScript ほど厳密な
-モナド実装は一般的でないが、同じ概念は dataclass + Protocol で表現できる。
+Python's weak static typing means strict monad implementations
+like those in Haskell or TypeScript are less common, but the same
+concepts can be expressed with dataclass + Protocol.
 """
 
 from __future__ import annotations
@@ -1054,11 +1053,11 @@ U = TypeVar("U")
 E = TypeVar("E")
 
 # =============================================================
-# Maybe モナド
+# Maybe monad
 # =============================================================
 
 class Maybe(ABC, Generic[T]):
-    """Maybe モナド: 値がないかもしれない計算"""
+    """Maybe monad: computation that might not have a value"""
 
     @staticmethod
     def of(value: T) -> "Just[T]":
@@ -1125,7 +1124,7 @@ class Nothing(Maybe[T]):
         return "Nothing()"
 
 
-# 使用例
+# Usage examples
 def safe_div(a: float, b: float) -> Maybe[float]:
     if b == 0:
         return Nothing()
@@ -1136,7 +1135,7 @@ def safe_sqrt(x: float) -> Maybe[float]:
         return Nothing()
     return Just(x ** 0.5)
 
-# flatMap の連鎖
+# Chaining flatMap
 result = (
     safe_div(100, 4)          # Just(25.0)
     .flat_map(safe_sqrt)      # Just(5.0)
@@ -1146,18 +1145,18 @@ print(result)  # Just(10.0)
 
 result_err = (
     safe_div(100, 0)          # Nothing()
-    .flat_map(safe_sqrt)      # Nothing() (スキップ)
-    .map(lambda x: x * 2)    # Nothing() (スキップ)
+    .flat_map(safe_sqrt)      # Nothing() (skipped)
+    .map(lambda x: x * 2)    # Nothing() (skipped)
 )
 print(result_err)  # Nothing()
 
 
 # =============================================================
-# Result モナド
+# Result monad
 # =============================================================
 
 class Result(ABC, Generic[T, E]):
-    """Result モナド: 成功か失敗かの計算"""
+    """Result monad: computation that is either success or failure"""
 
     @staticmethod
     def ok(value: T) -> "Ok[T, E]":
@@ -1236,7 +1235,7 @@ class Err(Result[T, E]):
         return f"Err({self._error!r})"
 
 
-# 実践例: ファイル処理パイプライン
+# Practical example: file processing pipeline
 import json
 
 def read_file(path: str) -> Result[str, str]:
@@ -1259,7 +1258,7 @@ def extract_field(data: dict, field: str) -> Result[object, str]:
         return Err(f"Missing field: {field}")
     return Ok(data[field])
 
-# 鉄道指向パイプライン
+# Railway-oriented pipeline
 def get_config_value(path: str, field: str) -> Result[object, str]:
     return (
         read_file(path)
@@ -1267,19 +1266,19 @@ def get_config_value(path: str, field: str) -> Result[object, str]:
         .flat_map(lambda data: extract_field(data, field))
     )
 
-# テスト
+# Test
 # result = get_config_value("config.json", "database_url")
 # print(result)
 
 
 # =============================================================
-# Python 特有: コンテキストマネージャもモナド的
+# Python-specific: context managers are also monadic
 # =============================================================
 from contextlib import contextmanager
 
 @contextmanager
 def managed_connection(url: str):
-    """コンテキストマネージャ = Resource モナドの一種"""
+    """Context manager = a kind of Resource monad"""
     conn = f"Connection({url})"
     print(f"Opening {conn}")
     try:
@@ -1287,21 +1286,21 @@ def managed_connection(url: str):
     finally:
         print(f"Closing {conn}")
 
-# with 文 = do 記法の糖衣構文
+# with statement = syntactic sugar for do-notation
 # with managed_connection("db://localhost") as conn:
 #     print(f"Using {conn}")
 ```
 
 ---
 
-## コード例 7: モナド合成とモナドトランスフォーマー
+## Code Example 7: Monad Composition and Monad Transformers
 
 ```typescript
 // =============================================================
-// モナド合成: 複数のモナドを組み合わせる実践パターン
+// Monad composition: Practical patterns for combining multiple monads
 // =============================================================
 
-// --- 基本型定義 ---
+// --- Base type definitions ---
 type Result<T, E = Error> =
   | { readonly ok: true; readonly value: T }
   | { readonly ok: false; readonly error: E };
@@ -1309,8 +1308,8 @@ type Result<T, E = Error> =
 const Ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
 const Err = <E>(error: E): Result<never, E> => ({ ok: false, error });
 
-// --- ResultT<Promise>: Promise + Result のモナドトランスフォーマー ---
-// 「非同期で、失敗するかもしれない計算」を合成可能にする
+// --- ResultT<Promise>: monad transformer for Promise + Result ---
+// Makes "asynchronous computation that might fail" composable
 
 class AsyncResult<T, E = Error> {
   constructor(private readonly promise: Promise<Result<T, E>>) {}
@@ -1324,7 +1323,7 @@ class AsyncResult<T, E = Error> {
     return new AsyncResult(Promise.resolve(Err(error)));
   }
 
-  // Promise<T> を安全にラップ
+  // Safely wrap Promise<T>
   static fromPromise<T>(promise: Promise<T>): AsyncResult<T, Error> {
     return new AsyncResult(
       promise
@@ -1359,7 +1358,7 @@ class AsyncResult<T, E = Error> {
     );
   }
 
-  // --- ユーティリティ ---
+  // --- Utilities ---
   async toPromise(): Promise<Result<T, E>> {
     return this.promise;
   }
@@ -1369,7 +1368,7 @@ class AsyncResult<T, E = Error> {
     return result.ok ? result.value : defaultValue;
   }
 
-  // タイムアウト付き
+  // With timeout
   withTimeout(ms: number): AsyncResult<T, E | Error> {
     const timeout = new Promise<Result<T, E | Error>>(resolve =>
       setTimeout(() => resolve(Err(new Error(`Timeout: ${ms}ms`))), ms)
@@ -1377,7 +1376,7 @@ class AsyncResult<T, E = Error> {
     return new AsyncResult(Promise.race([this.promise as Promise<Result<T, E | Error>>, timeout]));
   }
 
-  // リトライ
+  // Retry
   retry(times: number, delayMs: number = 0): AsyncResult<T, E> {
     return new AsyncResult(
       this.promise.then(async result => {
@@ -1392,7 +1391,7 @@ class AsyncResult<T, E = Error> {
 }
 
 // =============================================================
-// 実践例: API クライアント
+// Practical example: API client
 // =============================================================
 
 interface User {
@@ -1413,7 +1412,7 @@ interface Project {
   budget: number;
 }
 
-// API 関数 (各呼び出しは非同期 + 失敗可能)
+// API functions (each call is async + can fail)
 function fetchUserById(id: string): AsyncResult<User, string> {
   return AsyncResult.fromPromise(
     fetch(`/api/users/${id}`).then(r => {
@@ -1441,7 +1440,7 @@ function fetchProjectById(id: string): AsyncResult<Project, string> {
   ).mapErr(e => `Failed to fetch project: ${e.message}`);
 }
 
-// flatMap の連鎖: エラーは自動的に伝播
+// Chain of flatMap: errors propagate automatically
 async function getUserTeamBudget(userId: string): Promise<Result<number, string>> {
   return fetchUserById(userId)
     .flatMap(user => fetchTeamById(user.teamId))
@@ -1458,17 +1457,17 @@ async function getUserTeamBudget(userId: string): Promise<Result<number, string>
 }
 
 // =============================================================
-// do 記法スタイル: ジェネレータベースの合成
+// do-notation style: generator-based composition
 // =============================================================
 
-// ジェネレータを使った「do 記法」の疑似実装
+// Pseudo-implementation of "do-notation" using generators
 function* doResult<T>(): Generator<Result<any, any>, T, any> {
-  // ジェネレータ内で yield で Result を「束縛」
-  // Left/Err が返った時点でジェネレータを中断
+  // Inside the generator, yield "binds" a Result
+  // The generator is interrupted when Left/Err is returned
   return undefined as T;
 }
 
-// 実用的な do 記法 (runDo)
+// Practical do-notation (runDo)
 function runDo<T, E>(
   gen: () => Generator<Result<T, E>, T, T>
 ): Result<T, E> {
@@ -1478,7 +1477,7 @@ function runDo<T, E>(
   while (!next.done) {
     const result = next.value;
     if (!result.ok) {
-      return result;  // エラーならジェネレータを中断
+      return result;  // Interrupt the generator on error
     }
     next = iterator.next(result.value);
   }
@@ -1486,7 +1485,7 @@ function runDo<T, E>(
   return Ok(next.value);
 }
 
-// do 記法での使用例
+// Usage with do-notation
 function processOrder(orderId: string): Result<string, string> {
   return runDo(function* () {
     const parsed = yield parseOrderId(orderId);         // bind
@@ -1496,13 +1495,13 @@ function processOrder(orderId: string): Result<string, string> {
   });
 }
 
-// 型定義用ダミー
+// Dummy type declarations
 declare function parseOrderId(id: string): Result<number, string>;
 declare function findOrder(id: number): Result<{ id: number; total: number }, string>;
 declare function validateOrder(order: { id: number; total: number }): Result<{ id: number; total: number }, string>;
 
 // =============================================================
-// MaybeT: Maybe + Promise のトランスフォーマー
+// MaybeT: Transformer for Maybe + Promise
 // =============================================================
 
 class MaybeAsync<T> {
@@ -1549,7 +1548,7 @@ class MaybeAsync<T> {
   }
 }
 
-// 使用例: 非同期 + null の両方を扱う
+// Usage example: handling both async and null
 async function findUserAvatar(userId: string): Promise<string> {
   return MaybeAsync.fromPromise(fetchUserMaybe(userId))
     .flatMap(user =>
@@ -1565,77 +1564,77 @@ declare function fetchProfileMaybe(id: string): Promise<{ avatarUrl: string } | 
 
 ---
 
-## 深掘り 1: モナドの階層 --- Functor, Applicative, Monad
+## Deep Dive 1: Monad Hierarchy --- Functor, Applicative, Monad
 
 ```
-型クラスの階層 (Haskell の型クラス体系)
+Type class hierarchy (Haskell's type class system)
 =========================================
 
   Functor          map:    (a -> b)   -> F a -> F b
-    |               「箱の中の値を変換」
+    |               "transform the value inside the box"
     v
   Applicative      apply:  F (a -> b) -> F a -> F b
-    |               「箱の中の関数を、箱の中の値に適用」
+    |               "apply a function inside a box to a value inside a box"
     v
   Monad            bind:   (a -> M b) -> M a -> M b
-                    「箱の中の値を取り出し、新しい箱を作る関数に渡す」
+                    "extract the value from the box and pass it to a function that creates a new box"
 
-Functor < Applicative < Monad の関係:
-  - すべてのモナドはアプリカティブ
-  - すべてのアプリカティブはファンクタ
-  - モナドが最も強力 (前のステップの結果に基づいて次の計算を決定できる)
+Relationship: Functor < Applicative < Monad
+  - Every monad is an applicative
+  - Every applicative is a functor
+  - Monads are the most powerful (can choose the next computation based on the previous result)
 
-Applicative vs Monad の違い:
-  Applicative: 計算の構造が静的 (事前に決まる)
+Difference between Applicative and Monad:
+  Applicative: computation structure is static (determined in advance)
     liftA2 (+) (Just 3) (Just 5) --> Just 8
-    すべての計算が独立して実行される
+    All computations are executed independently
 
-  Monad: 計算の構造が動的 (前の結果に依存)
+  Monad: computation structure is dynamic (depends on previous result)
     Just 3 >>= (\x -> if x > 0 then Just (x + 1) else Nothing)
-    前のステップの結果を見て、次の計算を選べる
+    Can choose the next computation by looking at the result of the previous step
 
-TypeScript での対応:
-  Functor     → Array.map, Promise.then (値を返す場合)
-  Applicative → Promise.all (独立した計算を並列実行)
-  Monad       → Array.flatMap, Promise.then (Promise を返す場合)
+Correspondence in TypeScript:
+  Functor     → Array.map, Promise.then (when returning a value)
+  Applicative → Promise.all (run independent computations in parallel)
+  Monad       → Array.flatMap, Promise.then (when returning a Promise)
 ```
 
-| 抽象化 | 操作 | 「できること」 | TypeScript での例 |
+| Abstraction | Operation | "What it can do" | TypeScript example |
 |---|---|---|---|
-| **Functor** | `map` | 箱の中の値を変換 | `[1,2,3].map(x => x*2)` |
-| **Applicative** | `apply` / `liftA2` | 独立した箱同士を結合 | `Promise.all([p1, p2])` |
-| **Monad** | `flatMap` / `bind` | 前の結果に基づく次の計算 | `promise.then(x => fetch(x.url))` |
+| **Functor** | `map` | Transform the value in the box | `[1,2,3].map(x => x*2)` |
+| **Applicative** | `apply` / `liftA2` | Combine independent boxes | `Promise.all([p1, p2])` |
+| **Monad** | `flatMap` / `bind` | Choose the next computation based on the previous result | `promise.then(x => fetch(x.url))` |
 
-**使い分けの指針**:
+**Decision guide**:
 
-- 各計算が **独立** しているなら **Applicative** で十分 (並列実行可能)
-- 前の計算の **結果** に基づいて次の計算を **選択** する必要があるなら **Monad** が必要
+- If each computation is **independent**, **Applicative** is sufficient (can run in parallel)
+- If you need to **choose** the next computation based on the **result** of the previous one, **Monad** is required
 
 ```typescript
-// Applicative: 独立した計算 → 並列実行可能
+// Applicative: independent computations → can run in parallel
 const [user, products, settings] = await Promise.all([
   fetchUser(id),
   fetchProducts(),
   fetchSettings(),
 ]);
 
-// Monad: 依存のある計算 → 逐次実行
-const user = await fetchUser(id);              // 1. ユーザー取得
-const team = await fetchTeam(user.teamId);     // 2. チーム取得 (user に依存)
-const projects = await fetchProjects(team.id); // 3. プロジェクト取得 (team に依存)
+// Monad: dependent computations → sequential execution
+const user = await fetchUser(id);              // 1. Fetch user
+const team = await fetchTeam(user.teamId);     // 2. Fetch team (depends on user)
+const projects = await fetchProjects(team.id); // 3. Fetch projects (depends on team)
 ```
 
 ---
 
-## 深掘り 2: 実世界のモナドパターン
+## Deep Dive 2: Real-World Monad Patterns
 
-### 2.1 Redux / useReducer: State モナドの具現化
+### 2.1 Redux / useReducer: Realization of the State Monad
 
 ```typescript
-// Redux の dispatch チェーンは State モナドの bind に相当
+// Redux's dispatch chain corresponds to the bind of the State monad
 // state -> action -> newState
 
-// React の useReducer: State モナドを UI に統合
+// React's useReducer: integrating the State monad into UI
 type State = { count: number; history: number[] };
 type Action =
   | { type: "increment" }
@@ -1659,50 +1658,50 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-// State モナドの型:  State s a = s -> (a, s)
-// reducer の型:      State -> Action -> State
-// dispatch の型:     Action -> void (状態は暗黙的に管理)
+// Type of State monad:  State s a = s -> (a, s)
+// Type of reducer:      State -> Action -> State
+// Type of dispatch:     Action -> void (state is managed implicitly)
 ```
 
-### 2.2 Express/Koa ミドルウェア: Reader + Writer + IO モナドの合成
+### 2.2 Express/Koa Middleware: Composition of Reader + Writer + IO Monads
 
 ```typescript
-// ミドルウェアは「環境(req/res) + ログ + 副作用」のモナド合成
-// Reader: req/res コンテキストを読み取る
-// Writer: ヘッダーやログを蓄積
-// IO: レスポンス送信、DB アクセスなどの副作用
+// Middleware is a monad composition of "environment (req/res) + logging + side effects"
+// Reader: reads req/res context
+// Writer: accumulates headers and logs
+// IO: side effects like sending responses, DB access, etc.
 
-// Koa の ctx.state は Reader + State の合成
-// next() は Continuation モナドの bind に相当
+// Koa's ctx.state is a composition of Reader + State
+// next() corresponds to bind in the Continuation monad
 ```
 
-### 2.3 RxJS Observable: List + IO + Promise の合成モナド
+### 2.3 RxJS Observable: Combined Monad of List + IO + Promise
 
 ```typescript
-// Observable は以下のモナドの合成と見なせる:
-// - List: 複数の値 (時間軸上に分散)
-// - IO: 副作用 (subscribe するまで実行されない = lazy)
-// - Promise: 非同期 (時間的に遅延)
+// Observable can be seen as a composition of the following monads:
+// - List: multiple values (spread across the time axis)
+// - IO: side effects (not executed until subscribe = lazy)
+// - Promise: asynchronous (delayed in time)
 
-// pipe = モナド合成のパイプライン
-// switchMap/mergeMap/concatMap = flatMap のバリエーション
-//   switchMap: 新しい値が来たら前の subscription をキャンセル
-//   mergeMap:  並行して実行
-//   concatMap: 順次実行 (待ち行列)
+// pipe = monad composition pipeline
+// switchMap/mergeMap/concatMap = variations of flatMap
+//   switchMap: cancel the previous subscription when a new value arrives
+//   mergeMap:  execute concurrently
+//   concatMap: execute sequentially (queue)
 ```
 
 ---
 
-## 深掘り 3: Rust の ? 演算子 --- モナドの最良の糖衣構文
+## Deep Dive 3: Rust's ? Operator --- The Best Syntactic Sugar for Monads
 
 ```rust
-// Rust の ? 演算子は Result/Option の flatMap (and_then) の糖衣構文
-// Haskell の do 記法、JavaScript の async/await と同じ役割
+// Rust's ? operator is syntactic sugar for Result/Option's flatMap (and_then)
+// It serves the same role as Haskell's do-notation and JavaScript's async/await
 
 use std::fs;
 use std::num::ParseIntError;
 
-// --- エラー型の定義 ---
+// --- Error type definition ---
 #[derive(Debug)]
 enum AppError {
     Io(std::io::Error),
@@ -1722,10 +1721,10 @@ impl From<ParseIntError> for AppError {
     }
 }
 
-// --- ? 演算子を使ったフラットなエラーハンドリング ---
+// --- Flat error handling using the ? operator ---
 fn read_config(path: &str) -> Result<Config, AppError> {
-    let content = fs::read_to_string(path)?;          // Io エラーを自動変換
-    let port: u16 = content.trim().parse()?;          // Parse エラーを自動変換
+    let content = fs::read_to_string(path)?;          // Automatically convert Io error
+    let port: u16 = content.trim().parse()?;          // Automatically convert Parse error
 
     if port < 1024 {
         return Err(AppError::Validation(
@@ -1736,7 +1735,7 @@ fn read_config(path: &str) -> Result<Config, AppError> {
     Ok(Config { port })
 }
 
-// --- ? 演算子なしの等価コード (flatMap の手動展開) ---
+// --- Equivalent code without the ? operator (manual expansion of flatMap) ---
 fn read_config_verbose(path: &str) -> Result<Config, AppError> {
     let content = match fs::read_to_string(path) {
         Ok(c) => c,
@@ -1761,7 +1760,7 @@ struct Config {
     port: u16,
 }
 
-// --- Option の ? 演算子 ---
+// --- ? operator with Option ---
 struct User {
     address: Option<Address>,
 }
@@ -1771,78 +1770,78 @@ struct Address {
 }
 
 fn get_city(user: &Option<User>) -> Option<&str> {
-    // ? は None なら早期リターン
+    // ? returns early if None
     let user = user.as_ref()?;
     let address = user.address.as_ref()?;
     let city = address.city.as_deref()?;
     Some(city)
 }
 
-// --- and_then チェーンスタイル ---
+// --- and_then chain style ---
 fn get_city_chain(user: &Option<User>) -> Option<&str> {
     user.as_ref()
         .and_then(|u| u.address.as_ref())
         .and_then(|a| a.city.as_deref())
 }
 
-// --- Iterator + Result の組み合わせ ---
+// --- Combining Iterator + Result ---
 fn parse_numbers(inputs: &[&str]) -> Result<Vec<i64>, ParseIntError> {
     inputs.iter()
         .map(|s| s.parse::<i64>())   // Iterator<Item = Result<i64, _>>
-        .collect()                     // Result<Vec<i64>, _> に自動変換!
+        .collect()                     // Automatically converted to Result<Vec<i64>, _>!
 }
 
-// collect() は Iterator<Item = Result<T, E>> -> Result<Vec<T>, E> に対応
-// これも モナドの traverse/sequence の実現
+// collect() handles Iterator<Item = Result<T, E>> -> Result<Vec<T>, E>
+// This is also a realization of monad's traverse/sequence
 ```
 
 ---
 
-## モナド比較表
+## Monad Comparison Table
 
-### 主要モナド一覧
+### Overview of Major Monads
 
-| モナド | コンテキスト | unit | bind の動作 | 言語での対応 |
+| Monad | Context | unit | bind behavior | Language counterpart |
 |---|---|---|---|---|
-| **Maybe/Option** | 値の有無 | `Some(x)` | None ならスキップ | Rust: `Option`, TS: `?.`, Python: `Optional` |
-| **Either/Result** | 成功/失敗 | `Right(x)` / `Ok(x)` | Left/Err ならスキップ | Rust: `Result`, Go: `error`, TS: `Promise.catch` |
-| **Promise/Future** | 非同期 | `Promise.resolve(x)` | 完了後に次を実行 | JS: `Promise`, Rust: `Future`, Python: `asyncio` |
-| **IO** | 副作用 | `IO.of(x)` | 実行を遅延して合成 | Haskell: `IO`, Effect-TS: `Effect` |
-| **List/Array** | 複数の値 | `[x]` | 各要素に適用・結合 | JS: `Array.flatMap`, Python: リスト内包表記 |
-| **Reader** | 依存注入 | `Reader.of(x)` | 環境を暗黙的に引き回す | DI コンテナ, React Context |
-| **Writer** | ログ蓄積 | `Writer.of(x)` | 値＋ログを伝搬 | ミドルウェアのログ蓄積 |
-| **State** | 状態管理 | `State.of(x)` | 状態を引き回す | Redux, useReducer |
+| **Maybe/Option** | Presence of value | `Some(x)` | Skip if None | Rust: `Option`, TS: `?.`, Python: `Optional` |
+| **Either/Result** | Success/failure | `Right(x)` / `Ok(x)` | Skip if Left/Err | Rust: `Result`, Go: `error`, TS: `Promise.catch` |
+| **Promise/Future** | Asynchronous | `Promise.resolve(x)` | Execute next after completion | JS: `Promise`, Rust: `Future`, Python: `asyncio` |
+| **IO** | Side effects | `IO.of(x)` | Defer execution and compose | Haskell: `IO`, Effect-TS: `Effect` |
+| **List/Array** | Multiple values | `[x]` | Apply to each element and combine | JS: `Array.flatMap`, Python: list comprehension |
+| **Reader** | Dependency injection | `Reader.of(x)` | Thread environment implicitly | DI containers, React Context |
+| **Writer** | Log accumulation | `Writer.of(x)` | Propagate value + log | Middleware log accumulation |
+| **State** | State management | `State.of(x)` | Thread state through computations | Redux, useReducer |
 
-### 言語ごとの糖衣構文対応
+### Syntactic Sugar by Language
 
-| 概念 | Haskell | Rust | TypeScript | Python |
+| Concept | Haskell | Rust | TypeScript | Python |
 |---|---|---|---|---|
 | Maybe bind | `>>=` / `do` | `?` / `and_then()` | `?.` / `flatMap` | `or None` / `if x is not None` |
-| Either bind | `>>=` / `do` | `?` / `and_then()` | `then` / `catch` | 例外 / `try/except` |
-| do 記法 | `do { x <- m; ... }` | `let x = m?;` | `const x = await m;` | `x = await m` |
-| for 内包表記 | `[f x | x <- xs]` | `xs.iter().map(f)` | `xs.flatMap(f)` | `[f(x) for x in xs]` |
-| 型制約 | 型クラス `Monad m =>` | トレイト `impl Monad` | インターフェース | Protocol / ABC |
+| Either bind | `>>=` / `do` | `?` / `and_then()` | `then` / `catch` | exceptions / `try/except` |
+| do-notation | `do { x <- m; ... }` | `let x = m?;` | `const x = await m;` | `x = await m` |
+| for comprehension | `[f x | x <- xs]` | `xs.iter().map(f)` | `xs.flatMap(f)` | `[f(x) for x in xs]` |
+| type constraint | type class `Monad m =>` | trait `impl Monad` | interface | Protocol / ABC |
 
-### 糖衣構文の対応関係
+### Correspondence of Syntactic Sugar
 
-| モナド操作 | Haskell do 記法 | Rust ? 演算子 | JS async/await |
+| Monad operation | Haskell do-notation | Rust ? operator | JS async/await |
 |---|---|---|---|
 | bind | `x <- action` | `let x = action?;` | `const x = await action;` |
 | return | `return x` | `Ok(x)` | `return x` |
 | sequence | `action1 >> action2` | `action1?; action2?;` | `await a1; await a2;` |
-| 失敗 | `fail "msg"` | `Err(e)?` | `throw new Error()` |
+| failure | `fail "msg"` | `Err(e)?` | `throw new Error()` |
 
 ---
 
-## アンチパターン
+## Anti-patterns
 
-### 1. モナドの過剰使用 --- 言語ネイティブ機能の無視
+### 1. Overuse of Monads --- Ignoring Native Language Features
 
-**問題**: すべてに自作 Maybe/Either を適用し、チームに馴染みのないライブラリ依存を増やす。TypeScript では Optional Chaining (`?.`) と Nullish Coalescing (`??`) で十分なケースが多い。
+**Problem**: Applying custom Maybe/Either to everything increases unfamiliar library dependencies for the team. In TypeScript, Optional Chaining (`?.`) and Nullish Coalescing (`??`) are often sufficient.
 
 ```typescript
 // =============================================================
-// [NG] 自作 Maybe で不必要に複雑化
+// [NG] Unnecessarily complex with custom Maybe
 // =============================================================
 function getUserCityBad(user: User | null): string {
   return Maybe.fromNullable(user)
@@ -1852,49 +1851,49 @@ function getUserCityBad(user: User | null): string {
 }
 
 // =============================================================
-// [OK] TypeScript のネイティブ機能で十分
+// [OK] Native TypeScript features are sufficient
 // =============================================================
 function getUserCityGood(user: User | null): string {
   return user?.address?.city ?? "Unknown";
 }
 
 // =============================================================
-// [OK] ただし、複雑なロジックが絡む場合は Maybe が有効
+// [OK] However, Maybe is effective when complex logic is involved
 // =============================================================
 function getDiscountedPrice(user: User | null): Maybe<number> {
   return Maybe.fromNullable(user)
-    .flatMap(u => findMembership(u.id))        // DB 検索 (nullable)
-    .filter(m => m.isActive)                    // 条件フィルタ
-    .flatMap(m => calculateDiscount(m.tier))    // ビジネスロジック (失敗可能)
+    .flatMap(u => findMembership(u.id))        // DB lookup (nullable)
+    .filter(m => m.isActive)                    // conditional filter
+    .flatMap(m => calculateDiscount(m.tier))    // business logic (can fail)
     .map(discount => basePrice * (1 - discount));
 }
-// Optional Chaining だけではこの分岐を表現しきれない
+// Optional chaining alone cannot express this branching
 
-// 判断基準:
-// - 単純な null チェックの連鎖 → ?. と ?? を使う
-// - 条件分岐 + ビジネスロジック + 失敗可能性 → Maybe/Result を使う
+// Decision criteria:
+// - Simple null check chain → use ?. and ??
+// - Conditional branches + business logic + possibility of failure → use Maybe/Result
 ```
 
-### 2. 安易な unwrap --- モナドの安全性の破壊
+### 2. Careless Unwrapping --- Destroying Monad Safety
 
-**問題**: `Option.unwrap()` や `Result.unwrap()` を安易に使うと、実行時パニック/例外が発生する。モナドが提供する型安全性が完全に台無しになる。
+**Problem**: Careless use of `Option.unwrap()` or `Result.unwrap()` causes runtime panics/exceptions. The type safety provided by monads is completely undermined.
 
 ```rust
 // =============================================================
-// [NG] unwrap の乱用
+// [NG] Abuse of unwrap
 // =============================================================
 fn process_bad(input: &str) -> String {
-    let value = input.parse::<i32>().unwrap();     // パニック!
-    let item = find_item(value).unwrap();          // パニック!
-    let result = validate(item).unwrap();          // パニック!
+    let value = input.parse::<i32>().unwrap();     // panic!
+    let item = find_item(value).unwrap();          // panic!
+    let result = validate(item).unwrap();          // panic!
     format!("Done: {}", result)
 }
 
 // =============================================================
-// [OK] unwrap の代替手段を使う
+// [OK] Use alternatives to unwrap
 // =============================================================
 
-// 方法1: ? 演算子 (推奨)
+// Method 1: ? operator (recommended)
 fn process_good(input: &str) -> Result<String, AppError> {
     let value = input.parse::<i32>()?;
     let item = find_item(value)?;
@@ -1902,7 +1901,7 @@ fn process_good(input: &str) -> Result<String, AppError> {
     Ok(format!("Done: {}", result))
 }
 
-// 方法2: パターンマッチ
+// Method 2: Pattern matching
 fn process_match(input: &str) -> String {
     match input.parse::<i32>() {
         Ok(value) => match find_item(value) {
@@ -1913,15 +1912,15 @@ fn process_match(input: &str) -> String {
     }
 }
 
-// 方法3: unwrap_or / unwrap_or_else (デフォルト値がある場合)
+// Method 3: unwrap_or / unwrap_or_else (when a default value is available)
 fn process_default(input: &str) -> String {
     let value = input.parse::<i32>().unwrap_or(0);
     let item = find_item(value).unwrap_or_default();
     format!("Result: {}", item)
 }
 
-// 方法4: expect (unwrap よりましだが、本番コードでは避ける)
-// デバッグ情報を付与できるが、パニックは発生する
+// Method 4: expect (better than unwrap, but avoid in production code)
+// Can attach debug information, but still panics
 fn process_expect(input: &str) -> i32 {
     input.parse::<i32>()
         .expect(&format!("Failed to parse '{}' as i32", input))
@@ -1929,24 +1928,24 @@ fn process_expect(input: &str) -> i32 {
 ```
 
 ```typescript
-// TypeScript でも同様
+// Same applies in TypeScript
 // =============================================================
-// [NG] 型ガードなしでのアクセス
+// [NG] Access without type guard
 // =============================================================
 const result = validateUser(input);
-console.log(result.value.name);  // result が Left/Err なら runtime error
+console.log(result.value.name);  // runtime error if result is Left/Err
 
 // =============================================================
-// [OK] 型を尊重したアクセス
+// [OK] Type-respecting access
 // =============================================================
 const result = validateUser(input);
 if (result.tag === "Right") {
-  console.log(result.value.name);  // 型安全
+  console.log(result.value.name);  // type-safe
 } else {
-  console.error(result.value);     // エラーハンドリング
+  console.error(result.value);     // error handling
 }
 
-// [OK] fold/match でパターンマッチ
+// [OK] Pattern matching with fold/match
 EitherM.fold(
   result,
   error => console.error(`Validation failed: ${error}`),
@@ -1954,34 +1953,34 @@ EitherM.fold(
 );
 ```
 
-### 3. モナドの混在 --- Either と例外の混在
+### 3. Mixing Monads --- Mixing Either with Exceptions
 
-**問題**: Either/Result を使ったエラーハンドリングと、従来の try/catch を無秩序に混在させると、エラーの流れが追跡不能になる。
+**Problem**: Randomly mixing Either/Result-based error handling with traditional try/catch makes error flow impossible to track.
 
 ```typescript
 // =============================================================
-// [NG] Either と例外の混在
+// [NG] Mixing Either and exceptions
 // =============================================================
 function processBad(input: string): Either<string, Output> {
-  const parsed = parseInput(input);  // Either を返す
+  const parsed = parseInput(input);  // returns Either
   if (parsed.tag === "Left") return parsed;
 
-  // ここで突然 throw! Either のパイプラインが壊れる
+  // Suddenly throws here! The Either pipeline is broken
   const data = JSON.parse(parsed.value.raw);  // throws!
 
-  const validated = validateData(data);  // Either を返す
+  const validated = validateData(data);  // returns Either
   if (validated.tag === "Left") return validated;
 
   return Right(transform(validated.value));
 }
 
-// 呼び出し側: Either だけケアしても JSON.parse の例外を見落とす
+// Caller: even if you handle Either, you miss the JSON.parse exception
 
 // =============================================================
-// [OK] エラーハンドリング戦略を統一
+// [OK] Unify the error handling strategy
 // =============================================================
 
-// 方法1: すべて Either に統一 (推奨)
+// Method 1: Unify everything as Either (recommended)
 function processGood(input: string): Either<string, Output> {
   return flatMap(parseInput(input), parsed =>
     flatMap(EitherM.tryCatch(() => JSON.parse(parsed.raw))
@@ -1993,7 +1992,7 @@ function processGood(input: string): Either<string, Output> {
   );
 }
 
-// 方法2: 境界で変換 (外部ライブラリとの接合点)
+// Method 2: Convert at boundaries (integration points with external libraries)
 function safeJsonParse(raw: string): Either<string, unknown> {
   return EitherM.tryCatch(() => JSON.parse(raw))
     .mapLeft(e => `JSON parse error: ${e.message}`);
@@ -2006,10 +2005,10 @@ function processAlsoGood(input: string): Either<string, Output> {
   return map(validated, transform);
 }
 
-// 原則:
-// - プロジェクト内部: Either/Result で統一
-// - 外部ライブラリの境界: tryCatch で Either に変換
-// - 決して Either のパイプライン内部で throw しない
+// Principles:
+// - Inside the project: unify with Either/Result
+// - At external library boundaries: convert to Either with tryCatch
+// - Never throw inside an Either pipeline
 
 declare function parseInput(input: string): Either<string, { raw: string }>;
 declare function validateData(data: unknown): Either<string, { valid: true }>;
@@ -2019,11 +2018,11 @@ type Output = { result: string };
 
 ---
 
-## 演習問題
+## Exercises
 
-### 演習 1: Maybe モナドの活用 (基礎)
+### Exercise 1: Using the Maybe Monad (Basic)
 
-以下の型定義に対し、Maybe モナドを使って安全にネストされたデータにアクセスする関数を実装してください。
+For the following type definitions, implement functions to safely access nested data using the Maybe monad.
 
 ```typescript
 interface Department {
@@ -2037,18 +2036,18 @@ interface Department {
   };
 }
 
-// 実装してください
+// Please implement
 function getManagerEmail(dept: Department | null): string {
-  // Maybe を使って dept?.manager?.contact?.email を安全に取得
-  // 見つからない場合は "N/A" を返す
+  // Use Maybe to safely retrieve dept?.manager?.contact?.email
+  // Return "N/A" if not found
 }
 
 function getManagerPhone(dept: Department | null): Maybe<string> {
-  // Maybe を返す版。呼び出し側で処理を選択できるようにする
+  // Version that returns Maybe. Allows the caller to choose how to handle it
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 getManagerEmail({ name: "Engineering", manager: { name: "Alice", contact: { email: "alice@co.com" } } })
 // => "alice@co.com"
@@ -2066,34 +2065,34 @@ getManagerPhone({ name: "HR", manager: { name: "Bob" } })
 // => Nothing()
 ```
 
-### 演習 2: Result で鉄道指向バリデーション (応用)
+### Exercise 2: Railway-Oriented Validation with Result (Intermediate)
 
-ユーザー入力のバリデーションパイプラインを Result モナドで構築してください。
+Build a validation pipeline for user input using the Result monad.
 
 ```typescript
 interface OrderInput {
-  productId: string;   // 数値文字列であること
-  quantity: string;    // 1-100 の整数文字列であること
-  couponCode?: string; // 存在する場合は "DISCOUNT-" で始まること
+  productId: string;   // must be a numeric string
+  quantity: string;    // must be an integer string from 1-100
+  couponCode?: string; // if present, must start with "DISCOUNT-"
 }
 
 interface ValidatedOrder {
   productId: number;
   quantity: number;
   couponCode: string | null;
-  discountRate: number;  // クーポンがあれば 0.1、なければ 0
+  discountRate: number;  // 0.1 if coupon exists, 0 otherwise
 }
 
-// 各バリデーション関数を実装してください
+// Please implement each validation function
 function validateProductId(raw: string): Result<number, string> { /* ... */ }
 function validateQuantity(raw: string): Result<number, string> { /* ... */ }
 function validateCoupon(code?: string): Result<string | null, string> { /* ... */ }
 
-// 鉄道指向で連鎖させてください
+// Chain them in railway-oriented style
 function validateOrder(input: OrderInput): Result<ValidatedOrder, string> { /* ... */ }
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
 validateOrder({ productId: "42", quantity: "5" })
 // => Ok({ productId: 42, quantity: 5, couponCode: null, discountRate: 0 })
@@ -2111,26 +2110,26 @@ validateOrder({ productId: "42", quantity: "5", couponCode: "INVALID" })
 // => Err("coupon must start with DISCOUNT-")
 ```
 
-### 演習 3: AsyncResult モナドトランスフォーマー (発展)
+### Exercise 3: AsyncResult Monad Transformer (Advanced)
 
-以下の仕様を満たす `AsyncResult` ベースの API クライアントを実装してください。
+Implement an API client based on `AsyncResult` that meets the following specifications.
 
 ```typescript
-// 要件:
-// 1. 各 API 呼び出しは AsyncResult<T, AppError> を返す
-// 2. ネットワークエラー、404、バリデーションエラーを構造化エラー型で表現
-// 3. flatMap でパイプラインを構築
-// 4. タイムアウト (3秒) とリトライ (最大2回) をサポート
-// 5. 最終結果を Result<T, AppError> として返す
+// Requirements:
+// 1. Each API call returns AsyncResult<T, AppError>
+// 2. Network errors, 404s, and validation errors are expressed as structured error types
+// 3. Build a pipeline with flatMap
+// 4. Support timeout (3 seconds) and retry (up to 2 times)
+// 5. Return the final result as Result<T, AppError>
 
 type AppError =
   | { type: "network"; message: string }
   | { type: "notFound"; resource: string; id: string }
   | { type: "validation"; errors: string[] };
 
-// 実装してください
+// Please implement
 class ApiClient {
-  // ユーザー取得 → チーム取得 → メンバー一覧取得 のパイプライン
+  // Pipeline: fetch user → fetch team → fetch member list
   async getTeamMembers(userId: string): Promise<Result<TeamMember[], AppError>> {
     return fetchUser(userId)
       .flatMap(user => fetchTeam(user.teamId))
@@ -2142,17 +2141,17 @@ class ApiClient {
 }
 ```
 
-**期待される出力**:
+**Expected output**:
 ```
-// 正常系
+// Success case
 await client.getTeamMembers("user-1")
 // => { ok: true, value: [{ id: "m1", name: "Alice" }, { id: "m2", name: "Bob" }] }
 
-// ユーザーが見つからない
+// User not found
 await client.getTeamMembers("nonexistent")
 // => { ok: false, error: { type: "notFound", resource: "user", id: "nonexistent" } }
 
-// タイムアウト (3秒後にリトライ2回後)
+// Timeout (after 3 seconds, 2 retries)
 await client.getTeamMembers("slow-user")
 // => { ok: false, error: { type: "network", message: "Timeout: 3000ms" } }
 ```
@@ -2161,110 +2160,110 @@ await client.getTeamMembers("slow-user")
 
 ## FAQ
 
-### Q1: モナドは実際の開発で役に立ちますか？
+### Q1: Are monads useful in real-world development?
 
-**A**: はい。ただし「モナド」という名前を意識する必要はありません。以下はすべてモナドパターンの実例です。
+**A**: Yes. However, you do not need to be aware of the name "monad." The following are all real examples of the monad pattern.
 
-| 日常的なコード | モナドとしての正体 |
+| Everyday code | Its identity as a monad |
 |---|---|
-| `array.flatMap(fn)` | List モナドの bind |
-| `promise.then(fn)` | IO モナドの bind |
-| `async/await` | do 記法の糖衣構文 |
-| `result?` (Rust) | Either モナドの bind |
-| `user?.address?.city` | Maybe モナドの bind (部分的) |
-| `ctx.state` (Koa) | Reader モナドの ask |
+| `array.flatMap(fn)` | bind of the List monad |
+| `promise.then(fn)` | bind of the IO monad |
+| `async/await` | syntactic sugar for do-notation |
+| `result?` (Rust) | bind of the Either monad |
+| `user?.address?.city` | bind of the Maybe monad (partial) |
+| `ctx.state` (Koa) | ask of the Reader monad |
 
-モナドの価値は「既に使っている概念に理論的基盤を与える」ことにある。理論を知ることで、新しいコンテキスト(例: 非同期ストリーム)にも同じパターンを適用できるようになる。
+The value of monads is in "giving a theoretical foundation to concepts you already use." Knowing the theory allows you to apply the same patterns to new contexts (e.g., asynchronous streams).
 
-### Q2: Haskell を学ばないとモナドは理解できませんか？
+### Q2: Do I need to learn Haskell to understand monads?
 
-**A**: いいえ。モナドの概念は言語非依存です。TypeScript や Rust で `flatMap` / `and_then` のパターンを実践すれば十分理解できます。Haskell は型クラスでモナドを最も体系的に表現しますが、実用的な理解には不要です。むしろ、Haskell の抽象的な表現から入ると「モナドは難しい」という誤解が生まれやすい。「Promise の then はモナドの bind である」という具体例から入るのが効果的です。
+**A**: No. The concept of monads is language-independent. You can fully understand them by practicing the `flatMap` / `and_then` patterns in TypeScript or Rust. While Haskell expresses monads most systematically through type classes, this is not necessary for practical understanding. In fact, starting from Haskell's abstract notation tends to create the misconception that "monads are difficult." It is more effective to start from concrete examples like "Promise's then is the bind of a monad."
 
-### Q3: モナドトランスフォーマーとは何ですか？
+### Q3: What are monad transformers?
 
-**A**: 複数のモナドを重ねて使う仕組みです。例えば `MaybeT (Either Error)` は「失敗するかもしれない計算で、さらに None の可能性がある」を表現します。
+**A**: They are a mechanism for stacking multiple monads. For example, `MaybeT (Either Error)` represents "a computation that might fail, with an additional possibility of None."
 
-実用的には以下が身近なモナドトランスフォーマーです。
+Practically, the following are familiar monad transformers.
 
-| 組み合わせ | TypeScript での表現 | 用途 |
+| Combination | TypeScript representation | Use case |
 |---|---|---|
-| Promise + Result | `Promise<Result<T, E>>` | 非同期 + エラーハンドリング |
-| Promise + Maybe | `Promise<T \| null>` | 非同期 + 値の有無 |
-| Array + Maybe | `(T \| null)[]` → `T[]` (filter) | コレクション + 欠損値 |
+| Promise + Result | `Promise<Result<T, E>>` | Async + error handling |
+| Promise + Maybe | `Promise<T \| null>` | Async + optional value |
+| Array + Maybe | `(T \| null)[]` → `T[]` (filter) | Collection + missing values |
 
-コード例 7 の `AsyncResult` クラスがこの概念の TypeScript 実装です。
+The `AsyncResult` class in Code Example 7 is a TypeScript implementation of this concept.
 
-### Q4: Either/Result と try/catch のどちらを使うべきですか？
+### Q4: Which should I use: Either/Result or try/catch?
 
-**A**: プロジェクトの方針を統一することが最も重要です。以下が判断基準です。
+**A**: The most important thing is to unify the strategy within a project. Here are the decision criteria.
 
-| 基準 | Either/Result が有利 | try/catch が有利 |
+| Criterion | Either/Result is better | try/catch is better |
 |---|---|---|
-| エラーの型安全性 | 呼び出し側がエラー型を認識 | 型情報が失われる (any/unknown) |
-| エラーの網羅性チェック | 判別共用体でコンパイル時チェック | ランタイムまで不明 |
-| パフォーマンス | 値の生成のみ | スタックトレース生成のコスト |
-| エコシステム | Rust, Haskell, Scala で主流 | Java, Python, JS/TS で主流 |
-| 学習コスト | チームに概念の理解が必要 | 多くの開発者に馴染みがある |
-| 回復不能エラー | 不向き (OOM, stack overflow) | 適切 (finally で cleanup) |
+| Error type safety | Caller recognizes error types | Type information is lost (any/unknown) |
+| Exhaustiveness check | Compile-time check with discriminated unions | Unknown until runtime |
+| Performance | Only creates values | Cost of generating stack traces |
+| Ecosystem | Mainstream in Rust, Haskell, Scala | Mainstream in Java, Python, JS/TS |
+| Learning cost | Team needs to understand the concept | Familiar to most developers |
+| Unrecoverable errors | Not suitable (OOM, stack overflow) | Appropriate (cleanup with finally) |
 
-**推奨**: TypeScript では「関数の戻り値として Result を使い、外部ライブラリの境界で tryCatch を使って Result に変換する」のがバランスが良い。
+**Recommendation**: In TypeScript, a balanced approach is "use Result as function return values, and use tryCatch at external library boundaries to convert to Result."
 
-### Q5: なぜ flatMap であって map ではだめなのですか？
+### Q5: Why flatMap and not map?
 
-**A**: `map` は `M<M<T>>` というネストを生むが、`flatMap` は `M<T>` にフラット化する。これが「モナド」が「ファンクタ」より強力な理由です。
+**A**: `map` produces a nested `M<M<T>>`, but `flatMap` flattens it to `M<T>`. This is why "monads" are more powerful than "functors."
 
 ```typescript
-// map だと二重にラップされる
+// map produces double wrapping
 const result: Maybe<Maybe<string>> =
   Maybe.of(user).map(u => Maybe.fromNullable(u.name));
-// Maybe<Maybe<string>> ← 使いにくい!
+// Maybe<Maybe<string>> ← hard to use!
 
-// flatMap なら自動的にフラットになる
+// flatMap automatically flattens
 const result: Maybe<string> =
   Maybe.of(user).flatMap(u => Maybe.fromNullable(u.name));
-// Maybe<string> ← 直接使える
+// Maybe<string> ← can be used directly
 
-// Promise も同様
-// then は map と flatMap を兼ねるが、内部で自動フラット化している
+// Same with Promise
+// then combines both map and flatMap, but internally auto-flattens
 Promise.resolve(userId)
-  .then(id => fetchUser(id))  // fetchUser は Promise を返す
-  // .then が map なら: Promise<Promise<User>> (二重ラップ)
-  // .then が flatMap だから: Promise<User> (フラット)
+  .then(id => fetchUser(id))  // fetchUser returns a Promise
+  // If .then were map: Promise<Promise<User>> (double wrapped)
+  // Because .then is flatMap: Promise<User> (flat)
 ```
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Item | Key Point |
 |---|---|
-| モナドの本質 | `unit` と `bind (flatMap)` によるコンテキスト付き計算の合成 |
-| モナド則 | 左単位元・右単位元・結合則の3つを満たすこと |
-| Maybe/Option | null 安全性。値がないかもしれない計算の連鎖。`?.` の一般化 |
-| Either/Result | 型安全なエラーハンドリング。鉄道指向プログラミング |
-| Promise/Future | 非同期処理。`async/await` は do 記法の糖衣構文 |
-| IO | 副作用の分離。純粋関数と副作用の境界を明確化。テスト容易性 |
-| List | 非決定性計算。`flatMap` で複数の可能性を探索 |
-| Reader | 依存性注入。環境を暗黙的に引き回す |
-| モナドトランスフォーマー | 複数モナドの合成。`AsyncResult = Promise + Result` |
-| 階層 | Functor < Applicative < Monad。独立計算なら Applicative で十分 |
-| 実践指針 | 言語のネイティブ機能を優先。エラー戦略を統一。unwrap を避ける |
+| Essence of monads | Composition of contextual computation via `unit` and `bind (flatMap)` |
+| Monad laws | Must satisfy three laws: left identity, right identity, associativity |
+| Maybe/Option | Null safety. Chain computations that might not have a value. A generalization of `?.` |
+| Either/Result | Type-safe error handling. Railway-oriented programming |
+| Promise/Future | Asynchronous processing. `async/await` is syntactic sugar for do-notation |
+| IO | Isolation of side effects. Clearly separate pure functions and side effects. Testability |
+| List | Non-deterministic computation. Explore multiple possibilities with `flatMap` |
+| Reader | Dependency injection. Thread environment implicitly |
+| Monad transformers | Composition of multiple monads. `AsyncResult = Promise + Result` |
+| Hierarchy | Functor < Applicative < Monad. Applicative is sufficient for independent computations |
+| Practical guidelines | Prioritize native language features. Unify error strategy. Avoid unwrap |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [ファンクタ・アプリカティブ](./01-functor-applicative.md) --- モナドの前提となる抽象化。map と apply の理解
-- [関数型パターン](./02-fp-patterns.md) --- カリー化、パイプライン、合成とモナドの組み合わせ
-- [Strategy パターン](../02-behavioral/01-strategy.md) --- 関数を値として扱うパターン (高階関数の OOP 版)
-- [Iterator パターン](../02-behavioral/04-iterator.md) --- List モナドの OOP 実装。遅延評価との関係
+- [Functor and Applicative](./01-functor-applicative.md) --- Abstractions that are prerequisites for monads. Understanding map and apply
+- [Functional Patterns](./02-fp-patterns.md) --- Combining currying, pipelines, composition with monads
+- [Strategy Pattern](../02-behavioral/01-strategy.md) --- Treating functions as values (the OOP version of higher-order functions)
+- [Iterator Pattern](../02-behavioral/04-iterator.md) --- OOP implementation of the List monad. Relationship with lazy evaluation
 
 ---
 
-## 参考文献
+## References
 
-1. **Philip Wadler** (1992): [Monads for functional programming](https://homepages.inf.ed.ac.uk/wadler/papers/marktoberdorf/baastad.pdf) --- モナドの理論的基盤を確立した論文
-2. **Bartosz Milewski**: [Category Theory for Programmers](https://bartoszmilewski.com/2014/10/28/category-theory-for-programmers-the-preface/) --- 圏論とモナドの理論的解説
-3. **Scott Wlaschin**: [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) --- Either モナドの実践的解説 (鉄道指向プログラミング)
-4. **Rust by Example**: [Error Handling](https://doc.rust-lang.org/rust-by-example/error.html) --- Result モナドと ? 演算子の実践ガイド
-5. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) --- TypeScript の関数型プログラミングライブラリ (モナドの実装例)
+1. **Philip Wadler** (1992): [Monads for functional programming](https://homepages.inf.ed.ac.uk/wadler/papers/marktoberdorf/baastad.pdf) --- Paper that established the theoretical foundation of monads
+2. **Bartosz Milewski**: [Category Theory for Programmers](https://bartoszmilewski.com/2014/10/28/category-theory-for-programmers-the-preface/) --- Theoretical explanation of category theory and monads
+3. **Scott Wlaschin**: [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) --- Practical explanation of the Either monad (railway-oriented programming)
+4. **Rust by Example**: [Error Handling](https://doc.rust-lang.org/rust-by-example/error.html) --- Practical guide to the Result monad and the ? operator
+5. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) --- Functional programming library for TypeScript (monad implementation examples)

--- a/03-software-design/design-patterns-guide/docs/03-functional/01-functor-applicative.md
+++ b/03-software-design/design-patterns-guide/docs/03-functional/01-functor-applicative.md
@@ -1,128 +1,128 @@
-# ファンクタとアプリカティブ
+# Functor and Applicative
 
-> map と ap の抽象化を理解し、コンテキスト内の値に対する関数適用と合成を型安全に実現する
+> Understand the abstractions of map and ap, and achieve type-safe function application and composition over values in context
 
-## この章で学ぶこと
+## What You Will Learn in This Chapter
 
-1. **ファンクタの本質と法則** — map によるコンテキスト内の値の変換、ファンクタ則（恒等則・合成則）の意味と検証方法
-2. **アプリカティブの理論と実践** — 複数のコンテキスト付き値に対する関数適用、エラー蓄積型バリデーション、並列計算
-3. **型クラス階層の全体像** — Functor < Applicative < Monad の関係性、各レベルの能力と限界、実務での使い分け判断基準
-4. **圏論との接点** — プログラミングにおける圏論的概念の直感的理解と、なぜこの抽象化が有用なのか
+1. **The essence and laws of functors** — Transforming values in context via map, the meaning of functor laws (identity law and composition law) and how to verify them
+2. **Theory and practice of applicatives** — Applying functions to multiple contextualized values, error-accumulating validation, and parallel computation
+3. **The full picture of the type class hierarchy** — The relationship of Functor < Applicative < Monad, the capabilities and limits of each level, and criteria for choosing them in practice
+4. **Connection to category theory** — An intuitive understanding of category-theoretic concepts in programming, and why this abstraction is useful
 
 ---
 
-## 前提知識
+## Prerequisites
 
-このガイドを読む前に、以下の知識を持っていることを推奨します。
+Before reading this guide, it is recommended that you have the following knowledge.
 
-| 前提知識 | 参照先 |
+| Prerequisite | Reference |
 |---|---|
-| TypeScript/Rust の基本的な型システム | [02-programming カテゴリ](../../../../02-programming/) |
-| ジェネリクスとインターフェース | [02-programming カテゴリ](../../../../02-programming/) |
-| 高階関数（map, filter, reduce） | [関数型パターン](./02-fp-patterns.md) |
-| モナドの基礎（flatMap/bind） | [モナド](./00-monad.md) |
-| クリーンコードの原則 | clean-code-principles |
+| Basic type system in TypeScript/Rust | [02-programming category](../../../../02-programming/) |
+| Generics and interfaces | [02-programming category](../../../../02-programming/) |
+| Higher-order functions (map, filter, reduce) | [Functional Patterns](./02-fp-patterns.md) |
+| Monad basics (flatMap/bind) | [Monad](./00-monad.md) |
+| Clean code principles | clean-code-principles |
 
 ---
 
-## 1. ファンクタの本質
+## 1. The Essence of Functors
 
-### 1.1 ファンクタとは何か — WHY から理解する
+### 1.1 What Is a Functor — Understanding from WHY
 
-プログラミングにおいて、値は様々な「コンテキスト（文脈）」に包まれて存在します。
+In programming, values exist wrapped in various "contexts."
 
 ```
-コンテキスト（文脈）の例
+Examples of contexts
 ===========================
 
-値が「存在しないかもしれない」 → Maybe / Option
-値が「エラーかもしれない」     → Result / Either
-値が「複数あるかもしれない」   → Array / List
-値が「未来に届くかもしれない」 → Promise / Future
-値が「副作用を伴うかもしれない」→ IO
-値が「環境に依存するかもしれない」→ Reader
+A value that "might not exist"        → Maybe / Option
+A value that "might be an error"      → Result / Either
+A value that "might be multiple"      → Array / List
+A value that "might arrive in future" → Promise / Future
+A value that "might have side effects"→ IO
+A value that "might depend on env"    → Reader
 
-問題: これらのコンテキスト内の値に対して
-      同じ変換ロジックを適用したい
-      → ファンクタが解決する
+Problem: We want to apply the same transformation logic
+         to values inside these contexts
+         → Functors solve this
 ```
 
-**WHY**: なぜファンクタが必要なのか？
+**WHY**: Why do we need functors?
 
-素朴なアプローチでは、コンテキストごとに別々の変換コードを書く必要があります。
+With a naive approach, you need to write separate transformation code for each context.
 
 ```typescript
-// コンテキストなし
+// Without context
 const doubled = value * 2;
 
-// Maybe コンテキスト — null チェックが必要
+// Maybe context — null check required
 if (maybeValue !== null) {
   const doubled = maybeValue * 2;
 }
 
-// Array コンテキスト — ループが必要
+// Array context — loop required
 const doubled = [];
 for (const v of array) {
   doubled.push(v * 2);
 }
 
-// Promise コンテキスト — コールバックが必要
+// Promise context — callback required
 promise.then(value => value * 2);
 ```
 
-これらはすべて「中の値に関数を適用する」という同じパターンです。ファンクタはこのパターンを `map` という統一的なインターフェースで抽象化します。
+All of these follow the same pattern of "applying a function to the value inside." Functors abstract this pattern with a unified interface called `map`.
 
 ```
-ファンクタ = map を持つ型
+Functor = a type that has map
 ===========================
 
-通常の関数適用:
+Ordinary function application:
   f : A -> B
   f(a)  -->  b
 
-ファンクタでの関数適用:
+Function application with a functor:
   F[A].map(f)  -->  F[B]
 
   Maybe[3].map(x => x * 2)  -->  Maybe[6]
   [1,2,3].map(x => x * 2)   -->  [2,4,6]
   Promise[data].then(parse)  -->  Promise[parsed]
 
-つまり:
-  「コンテキストを維持したまま中身だけを変換する」
-  これがファンクタの本質
+In other words:
+  "Transform only the content while keeping the context"
+  This is the essence of a functor
 ```
 
-### 1.2 ファンクタ則 — なぜ法則が重要なのか
+### 1.2 Functor Laws — Why Laws Matter
 
-ファンクタと名乗るには、`map` メソッドが2つの法則を満たす必要があります。法則を満たさない `map` は予測不可能な動作を引き起こし、リファクタリングの安全性を損ないます。
+To call itself a functor, the `map` method must satisfy two laws. A `map` that violates the laws causes unpredictable behavior and undermines the safety of refactoring.
 
 ```
-ファンクタ則:
-  1. 恒等則 (Identity Law):
+Functor Laws:
+  1. Identity Law:
      fa.map(id) === fa
-     「何もしない関数で map しても変化しない」
+     "Mapping with the identity function changes nothing"
 
-  2. 合成則 (Composition Law):
+  2. Composition Law:
      fa.map(f).map(g) === fa.map(x => g(f(x)))
-     「2回 map するのと、合成した関数で1回 map するのは同じ」
+     "Mapping twice is the same as mapping once with the composed function"
 
-なぜ法則が重要か:
-  - 恒等則: リファクタリング時に map(id) を安全に削除できる
-  - 合成則: パフォーマンス最適化で map の連鎖を1回にまとめられる
-  - 両方: コードの振る舞いを予測可能にする（等式推論）
+Why laws matter:
+  - Identity law: You can safely remove map(id) during refactoring
+  - Composition law: You can optimize performance by merging a chain of maps into one
+  - Both: Make code behavior predictable (equational reasoning)
 ```
 
-### 1.3 ファンクタの図解
+### 1.3 Functor Diagram
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  ファンクタの動作イメージ                            │
+│  How a Functor Works                                 │
 │                                                     │
-│  通常の関数:                                         │
+│  Ordinary function:                                  │
 │    f: A → B                                         │
 │    3  ──f(×2)──▶  6                                 │
 │                                                     │
-│  ファンクタの map:                                   │
+│  Functor map:                                        │
 │    map(f): F[A] → F[B]                              │
 │                                                     │
 │    ┌─────┐              ┌─────┐                     │
@@ -138,45 +138,45 @@ promise.then(value => value * 2);
 │    ┌─────────┐              ┌───────────┐           │
 │    │ Nothing │──map(×2)──▶  │  Nothing  │           │
 │    └─────────┘              └───────────┘           │
-│    (コンテキストが維持される)                         │
+│    (the context is preserved)                        │
 │                                                     │
-│  ポイント:                                           │
-│  - 箱（コンテキスト）の形は変わらない                │
-│  - 中身だけが変換される                              │
-│  - Nothing の場合は何もしない（安全にスキップ）      │
+│  Key points:                                         │
+│  - The shape of the box (context) does not change   │
+│  - Only the contents are transformed                │
+│  - Nothing is left unchanged (safely skipped)       │
 └─────────────────────────────────────────────────────┘
 ```
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  ファンクタ則の図解                                   │
+│  Functor Laws Diagram                                │
 │                                                     │
-│  恒等則: map(id) = id                                │
+│  Identity law: map(id) = id                          │
 │                                                     │
 │  ┌──────┐  map(id)  ┌──────┐                        │
-│  │ F[3] │──────────▶│ F[3] │  何も変わらない         │
+│  │ F[3] │──────────▶│ F[3] │  nothing changes        │
 │  └──────┘           └──────┘                        │
 │                                                     │
-│  合成則: map(g).map(f) = map(g∘f)                    │
+│  Composition law: map(g).map(f) = map(g∘f)           │
 │                                                     │
-│  方法1（2回map）:                                    │
+│  Method 1 (map twice):                               │
 │  ┌──────┐  map(f)  ┌──────┐  map(g)  ┌──────┐      │
 │  │ F[3] │────────▶│ F[6] │────────▶│ F[7] │      │
 │  └──────┘          └──────┘          └──────┘      │
 │                                                     │
-│  方法2（合成して1回map）:                             │
+│  Method 2 (compose then map once):                   │
 │  ┌──────┐  map(g∘f) ┌──────┐                        │
-│  │ F[3] │──────────▶│ F[7] │  同じ結果               │
+│  │ F[3] │──────────▶│ F[7] │  same result            │
 │  └──────┘           └──────┘                        │
 │                                                     │
-│  → パフォーマンス最適化に利用可能                     │
+│  → Can be used for performance optimization          │
 └─────────────────────────────────────────────────────┘
 ```
 
-### コード例 1: TypeScript での完全な Maybe ファンクタ実装
+### Code Example 1: Complete Maybe Functor Implementation in TypeScript
 
 ```typescript
-// === Maybe ファンクタの完全実装 ===
+// === Complete implementation of the Maybe functor ===
 
 class Maybe<T> {
   private constructor(private readonly value: T | null | undefined) {}
@@ -201,7 +201,7 @@ class Maybe<T> {
     return this.value != null;
   }
 
-  // ファンクタの核心: map
+  // The core of a functor: map
   map<U>(fn: (value: T) => U): Maybe<U> {
     if (this.value == null) return Maybe.nothing<U>();
     return Maybe.of(fn(this.value));
@@ -221,99 +221,99 @@ class Maybe<T> {
   }
 }
 
-// --- 使用例 ---
+// --- Usage examples ---
 
-// Array はファンクタ
+// Array is a functor
 const nums = [1, 2, 3];
 const doubled = nums.map(x => x * 2);       // [2, 4, 6]
 const strings = nums.map(x => x.toString()); // ["1", "2", "3"]
 
-// Promise はファンクタ
+// Promise is a functor
 const data = fetch("/api/users")
   .then(res => res.json())    // map
   .then(users => users[0]);   // map
 
-// Maybe はファンクタ
+// Maybe is a functor
 Maybe.of(5)
   .map(x => x * 2)    // Maybe(10)
   .map(x => x + 1);   // Maybe(11)
 
 Maybe.nothing<number>()
-  .map(x => x * 2)    // Nothing (スキップ)
-  .map(x => x + 1);   // Nothing (スキップ)
+  .map(x => x * 2)    // Nothing (skipped)
+  .map(x => x + 1);   // Nothing (skipped)
 
-// --- ファンクタ則の検証 ---
+// --- Verification of functor laws ---
 
-// 恒等関数
+// Identity function
 const id = <T>(x: T): T => x;
 
-// 1. 恒等則: fa.map(id) === fa
+// 1. Identity law: fa.map(id) === fa
 const fa = Maybe.of(42);
 const result1 = fa.map(id);
 console.log(fa.toString());       // Just(42)
-console.log(result1.toString());  // Just(42) ← 同じ
+console.log(result1.toString());  // Just(42) ← same
 
 const nothing = Maybe.nothing<number>();
 const result2 = nothing.map(id);
 console.log(nothing.toString());  // Nothing
-console.log(result2.toString()); // Nothing ← 同じ
+console.log(result2.toString()); // Nothing ← same
 
-// 2. 合成則: fa.map(f).map(g) === fa.map(x => g(f(x)))
+// 2. Composition law: fa.map(f).map(g) === fa.map(x => g(f(x)))
 const f = (x: number) => x * 2;
 const g = (x: number) => x + 1;
 
 const left  = fa.map(f).map(g);
 const right = fa.map(x => g(f(x)));
 console.log(left.toString());  // Just(85)
-console.log(right.toString()); // Just(85) ← 同じ
+console.log(right.toString()); // Just(85) ← same
 ```
 
-### コード例 2: Rust での Option/Result ファンクタ
+### Code Example 2: Option/Result Functor in Rust
 
 ```rust
-// Rust では Option と Result が標準でファンクタ（map を持つ型）
+// In Rust, Option and Result are standard functors (types with map)
 
 fn main() {
-    // === Option はファンクタ ===
+    // === Option is a functor ===
     let x: Option<i32> = Some(5);
     let y = x.map(|n| n * 2);        // Some(10)
     let z = x.map(|n| n.to_string()); // Some("5")
 
     let none: Option<i32> = None;
-    let w = none.map(|n| n * 2);      // None — 安全にスキップ
+    let w = none.map(|n| n * 2);      // None — safely skipped
 
     println!("y = {:?}", y);  // y = Some(10)
     println!("z = {:?}", z);  // z = Some("5")
     println!("w = {:?}", w);  // w = None
 
-    // === Result はファンクタ ===
+    // === Result is a functor ===
     let ok: Result<i32, String> = Ok(42);
     let mapped = ok.map(|n| n * 2);   // Ok(84)
 
     let err: Result<i32, String> = Err("failed".to_string());
-    let err_mapped = err.map(|n| n * 2);  // Err("failed") — エラーは保持
+    let err_mapped = err.map(|n| n * 2);  // Err("failed") — error is preserved
 
     println!("mapped = {:?}", mapped);       // mapped = Ok(84)
     println!("err_mapped = {:?}", err_mapped); // err_mapped = Err("failed")
 
-    // === ファンクタ則の検証 ===
-    // 恒等則
+    // === Verification of functor laws ===
+    // Identity law
     let id_fn = |x: i32| x;
     assert_eq!(Some(5).map(id_fn), Some(5));
     assert_eq!(None::<i32>.map(id_fn), None);
 
-    // 合成則
+    // Composition law
     let f = |x: i32| x * 2;
     let g = |x: i32| x + 1;
     assert_eq!(Some(5).map(f).map(g), Some(5).map(|x| g(f(x))));
     // Some(11) == Some(11)
 
-    // === 実践的なチェーン ===
+    // === Practical chaining ===
     let config = get_config_value("database.port")
         .map(|s| s.trim().to_string())
         .map(|s| s.parse::<u16>())
         .and_then(|r| r.ok());
-    // Option<u16> — 安全な型変換のチェーン
+    // Option<u16> — safe type conversion chain
 
     println!("config = {:?}", config);
 }
@@ -326,70 +326,70 @@ fn get_config_value(key: &str) -> Option<String> {
 }
 ```
 
-### コード例 3: Haskell でのファンクタ型クラス
+### Code Example 3: Functor Type Class in Haskell
 
 ```haskell
--- Haskell では Functor は型クラスとして定義される
--- これがファンクタの理論的な原点
+-- In Haskell, Functor is defined as a type class
+-- This is the theoretical origin of functors
 
 class Functor f where
     fmap :: (a -> b) -> f a -> f b
 
--- Maybe のファンクタインスタンス
+-- Functor instance for Maybe
 instance Functor Maybe where
     fmap _ Nothing  = Nothing
     fmap f (Just a) = Just (f a)
 
--- リストのファンクタインスタンス
+-- Functor instance for lists
 instance Functor [] where
     fmap = map
 
--- 使用例
+-- Usage examples
 example1 = fmap (*2) (Just 5)      -- Just 10
 example2 = fmap (*2) Nothing       -- Nothing
 example3 = fmap (*2) [1, 2, 3]     -- [2, 4, 6]
 
--- <$> は fmap の中置記法
+-- <$> is the infix notation for fmap
 example4 = (*2) <$> Just 5         -- Just 10
 example5 = show <$> [1, 2, 3]      -- ["1", "2", "3"]
 
--- ファンクタ則の検証
--- 恒等則: fmap id x == x
+-- Verification of functor laws
+-- Identity law: fmap id x == x
 prop_identity :: (Functor f, Eq (f a)) => f a -> Bool
 prop_identity x = fmap id x == x
 
--- 合成則: fmap (g . f) x == (fmap g . fmap f) x
+-- Composition law: fmap (g . f) x == (fmap g . fmap f) x
 prop_composition :: (Functor f, Eq (f c)) =>
                     (b -> c) -> (a -> b) -> f a -> Bool
 prop_composition g f x = fmap (g . f) x == (fmap g . fmap f) x
 ```
 
-### 1.4 身近なファンクタの例
+### 1.4 Examples of Everyday Functors
 
-私たちが日常的に使っているファンクタを整理します。
+Here is a summary of the functors we use on a daily basis.
 
 ```typescript
-// 1. Array — 最も身近なファンクタ
+// 1. Array — the most familiar functor
 const numbers = [1, 2, 3, 4, 5];
 const doubled = numbers.map(x => x * 2); // [2, 4, 6, 8, 10]
 
-// 2. Promise — 非同期のファンクタ
-// .then() が map に相当（正確にはモナドの bind でもある）
+// 2. Promise — an asynchronous functor
+// .then() is equivalent to map (strictly speaking, it is also monadic bind)
 const userPromise = fetch("/api/user")
   .then(res => res.json())       // map
   .then(data => data.name);      // map
 
-// 3. DOM NodeList を Array に変換して map
+// 3. Convert DOM NodeList to Array and map
 const elements = Array.from(document.querySelectorAll(".item"));
 const texts = elements.map(el => el.textContent);
 
-// 4. Map オブジェクト — entries を通じてファンクタ的に使える
+// 4. Map object — can be used functor-style via entries
 const prices = new Map([["apple", 100], ["banana", 200]]);
 const discounted = new Map(
   Array.from(prices.entries()).map(([k, v]) => [k, v * 0.9])
 );
 
-// 5. TypeScript の Record 型を map する汎用関数
+// 5. Generic function to map over a TypeScript Record type
 function mapRecord<K extends string, A, B>(
   record: Record<K, A>,
   fn: (a: A) => B
@@ -406,95 +406,95 @@ const doubled2 = mapRecord(inventory, x => x * 2);
 // { apple: 20, banana: 40, cherry: 10 }
 ```
 
-### 1.5 ファンクタではないものとの比較
+### 1.5 Comparison with Non-Functors
 
-ファンクタ則を満たさない、あるいは `map` の意味論が正しくない例を見ることで、ファンクタの理解を深めます。
+By examining examples that do not satisfy the functor laws or where the semantics of `map` are incorrect, we deepen our understanding of functors.
 
 ```typescript
-// === Set は（厳密には）ファンクタではない ===
-// 理由: map で重複が除去される可能性があり、構造が保存されない
+// === Set is not (strictly speaking) a functor ===
+// Reason: map can remove duplicates, which does not preserve structure
 
 const s = new Set([1, 2, 3]);
-// Set には map がないため Array に変換
+// Set has no map, so convert to Array first
 const mapped = new Set(Array.from(s).map(x => x % 2));
-// Set {1, 0} — 要素数が3→2に変わった!
-// ファンクタは構造を保存するべきだが、Set は構造（要素数）を変えうる
+// Set {1, 0} — the number of elements changed from 3 to 2!
+// A functor should preserve structure, but Set can change structure (element count)
 
-// === EventEmitter/Observable の subscribe は map ではない ===
-// 副作用を持つため、ファンクタ則を満たさない
-// ただし、RxJS の Observable.pipe(map(...)) は
-// 適切に実装されればファンクタ則を満たす
+// === subscribe on EventEmitter/Observable is not map ===
+// It has side effects and does not satisfy the functor laws
+// However, Observable.pipe(map(...)) in RxJS
+// satisfies the functor laws if implemented correctly
 
-// === 反例: 恒等則を破る悪い map ===
+// === Counter-example: a bad map that violates the identity law ===
 class BadContainer<T> {
   constructor(public value: T, public count: number = 0) {}
 
   map<U>(fn: (value: T) => U): BadContainer<U> {
-    // count をインクリメント — これは副作用!
+    // Incrementing count — this is a side effect!
     return new BadContainer(fn(this.value), this.count + 1);
   }
 }
 
 const c = new BadContainer(5);
 const c2 = c.map(x => x); // { value: 5, count: 1 }
-// c と c2 は count が異なる → 恒等則違反!
+// c and c2 differ in count → identity law violation!
 ```
 
 ---
 
-## 2. アプリカティブの本質
+## 2. The Essence of Applicatives
 
-### 2.1 アプリカティブが解決する問題
+### 2.1 The Problem Applicatives Solve
 
 ```
-アプリカティブ = ap を持つファンクタ
+Applicative = a functor that has ap
 =====================================
 
-問題: map では引数が1つの関数しか適用できない
+Problem: map can only apply functions with a single argument
 
-  add は 2引数: add(a, b) = a + b
+  add takes 2 arguments: add(a, b) = a + b
   Maybe[3].map(add) → Maybe[(b) => 3 + b]
-  ↑ 関数が Maybe の中に閉じ込められた!
-  この Maybe[(b) => 3 + b] を Maybe[5] に適用したい
-  → ファンクタの map だけでは不可能
+  ↑ The function is trapped inside Maybe!
+  We want to apply this Maybe[(b) => 3 + b] to Maybe[5]
+  → Impossible with functor's map alone
 
-解決: アプリカティブの ap (apply)
+Solution: Applicative's ap (apply)
   F[A → B].ap(F[A])  -->  F[B]
 
   Maybe[add].ap(Maybe[3]).ap(Maybe[5])  -->  Maybe[8]
 
-  コンテキストに閉じ込められた関数を
-  コンテキストに閉じ込められた値に適用できる!
+  A function trapped in a context can be applied
+  to a value trapped in a context!
 
-独立した値の組み合わせ:
-  ファンクタ:      1つの値を変換
-  アプリカティブ:  複数の独立した値を組み合わせ
-  モナド:          前の結果に依存した次の計算
+Combining independent values:
+  Functor:      transforms one value
+  Applicative:  combines multiple independent values
+  Monad:        computation dependent on the previous result
 ```
 
-**WHY**: なぜアプリカティブが必要なのか？
+**WHY**: Why do we need applicatives?
 
-ファンクタの `map` は1引数関数しか受け取れません。しかし実際のプログラミングでは、2つ以上の値を組み合わせて新しい値を作ることが頻繁にあります。
+Functor's `map` can only accept single-argument functions. In real programming, however, it is common to combine two or more values to produce a new value.
 
-- ユーザー名 + メールアドレス + 年齢 → ユーザーオブジェクト
-- 価格 + 数量 → 合計金額
-- 複数の API 結果 → 統合されたレスポンス
+- Username + email address + age → User object
+- Price + quantity → total amount
+- Multiple API results → integrated response
 
-これらの値がそれぞれコンテキスト（Maybe, Result, Promise）に包まれている場合、ファンクタだけでは対応できません。アプリカティブがこの問題を解決します。
+When each of these values is wrapped in a context (Maybe, Result, Promise), a functor alone cannot handle the combination. Applicatives solve this problem.
 
-### 2.2 アプリカティブの図解
+### 2.2 Applicative Diagram
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  ファンクタ vs アプリカティブ vs モナド                        │
+│  Functor vs Applicative vs Monad                              │
 │                                                              │
-│  ■ ファンクタ (map): 1つの値を変換                            │
+│  ■ Functor (map): transforms one value                        │
 │                                                              │
 │    F[A] ──map(f)──▶ F[B]                                    │
 │                                                              │
 │    Maybe[3] ──map(×2)──▶ Maybe[6]                           │
 │                                                              │
-│  ■ アプリカティブ (ap): 複数の独立した値を組み合わせ           │
+│  ■ Applicative (ap): combines multiple independent values     │
 │                                                              │
 │    F[A→B→C]                                                  │
 │      │                                                       │
@@ -504,7 +504,7 @@ const c2 = c.map(x => x); // { value: 5, count: 1 }
 │      │                                                       │
 │    Maybe[add] ── ap(Maybe[3]) ── ap(Maybe[5]) ──▶ Maybe[8]  │
 │                                                              │
-│  ■ モナド (bind/flatMap): 依存する計算を連鎖                  │
+│  ■ Monad (bind/flatMap): chains dependent computations        │
 │                                                              │
 │    F[A] ──bind(A→F[B])──▶ F[B] ──bind(B→F[C])──▶ F[C]     │
 │                                                              │
@@ -515,37 +515,38 @@ const c2 = c.map(x => x); // { value: 5, count: 1 }
 │      │                          ├── bind(getOrders)          │
 │      │                          │     ──▶ Maybe[Orders]     │
 │      │                                                       │
-│    前の結果が次の計算に必要（依存関係あり）                    │
+│    The previous result is needed for the next computation    │
 └──────────────────────────────────────────────────────────────┘
 ```
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  アプリカティブ vs モナドのエラーハンドリング比較              │
+│  Error Handling Comparison: Applicative vs Monad              │
 │                                                              │
-│  ■ モナド (Either/Result): 最初のエラーで停止                 │
+│  ■ Monad (Either/Result): stops at the first error            │
 │                                                              │
-│    validate(name)  ──Err──▶ ここで停止                       │
-│    validate(email) ──────▶ 実行されない                      │
-│    validate(age)   ──────▶ 実行されない                      │
-│    結果: Err("名前が不正")                                    │
+│    validate(name)  ──Err──▶ stops here                       │
+│    validate(email) ──────▶ not executed                      │
+│    validate(age)   ──────▶ not executed                      │
+│    Result: Err("name is invalid")                             │
 │                                                              │
-│  ■ アプリカティブ (Validation): 全エラーを蓄積                │
+│  ■ Applicative (Validation): accumulates all errors           │
 │                                                              │
 │    validate(name)  ──Err1──┐                                 │
-│    validate(email) ──Err2──┼──▶ 全エラーを結合               │
+│    validate(email) ──Err2──┼──▶ combines all errors          │
 │    validate(age)   ──Err3──┘                                 │
-│    結果: Err(["名前が不正", "メールが不正", "年齢が不正"])     │
+│    Result: Err(["name is invalid", "email is invalid",        │
+│                 "age is invalid"])                            │
 │                                                              │
-│  → フォームバリデーションでは                                 │
-│    アプリカティブが圧倒的に便利                               │
+│  → For form validation,                                       │
+│    applicative is overwhelmingly more convenient             │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-### コード例 4: アプリカティブの完全実装（Maybe）
+### Code Example 4: Complete Applicative Implementation (Maybe)
 
 ```typescript
-// === Maybe のファンクタ + アプリカティブ + モナド 完全実装 ===
+// === Complete implementation of Maybe as Functor + Applicative + Monad ===
 
 class Maybe<T> {
   private constructor(private readonly value: T | null | undefined) {}
@@ -566,26 +567,26 @@ class Maybe<T> {
     return this.value == null;
   }
 
-  // --- ファンクタ ---
+  // --- Functor ---
   map<U>(fn: (value: T) => U): Maybe<U> {
     if (this.value == null) return Maybe.nothing<U>();
     return Maybe.of(fn(this.value));
   }
 
-  // --- アプリカティブ ---
-  // ap: Maybe に包まれた関数を Maybe に包まれた値に適用する
+  // --- Applicative ---
+  // ap: apply a function wrapped in Maybe to a value wrapped in Maybe
   ap<U>(maybeFn: Maybe<(value: T) => U>): Maybe<U> {
     if (this.value == null || maybeFn.isNothing()) return Maybe.nothing<U>();
     return Maybe.of(maybeFn.get()(this.value));
   }
 
-  // --- モナド ---
+  // --- Monad ---
   flatMap<U>(fn: (value: T) => Maybe<U>): Maybe<U> {
     if (this.value == null) return Maybe.nothing<U>();
     return fn(this.value);
   }
 
-  // --- ユーティリティ ---
+  // --- Utilities ---
   getOrElse(defaultValue: T): T {
     return this.value == null ? defaultValue : this.value;
   }
@@ -600,14 +601,14 @@ class Maybe<T> {
   }
 }
 
-// === liftA2, liftA3: 多引数関数をアプリカティブに持ち上げ ===
+// === liftA2, liftA3: lift multi-argument functions into the applicative ===
 
 function liftA2<A, B, C>(
   fn: (a: A, b: B) => C,
   ma: Maybe<A>,
   mb: Maybe<B>
 ): Maybe<C> {
-  // カリー化して ap で適用
+  // Curry and apply with ap
   return mb.ap(ma.map(a => (b: B) => fn(a, b)));
 }
 
@@ -620,20 +621,20 @@ function liftA3<A, B, C, D>(
   return mc.ap(mb.ap(ma.map(a => (b: B) => (c: C) => fn(a, b, c))));
 }
 
-// === 使用例 ===
+// === Usage examples ===
 
-// 2つの Maybe 値を組み合わせ
+// Combine two Maybe values
 const price = Maybe.of(100);
 const quantity = Maybe.of(3);
 const total = liftA2((p, q) => p * q, price, quantity);
 console.log(total.toString()); // Just(300)
 
-// 片方が Nothing なら結果も Nothing
+// If either is Nothing, the result is also Nothing
 const noPrice = Maybe.nothing<number>();
 const noTotal = liftA2((p, q) => p * q, noPrice, quantity);
 console.log(noTotal.toString()); // Nothing
 
-// 3つの Maybe 値を組み合わせてユーザーオブジェクトを作成
+// Combine three Maybe values to create a user object
 interface User {
   name: string;
   email: string;
@@ -654,18 +655,18 @@ const user = liftA3(createUser, userName, userEmail, userAge);
 console.log(user.toString());
 // Just({name: "Taro", email: "taro@example.com", age: 30})
 
-// 1つでも Nothing なら全体が Nothing
+// If even one is Nothing, the whole result is Nothing
 const noEmail = Maybe.nothing<string>();
 const noUser = liftA3(createUser, userName, noEmail, userAge);
 console.log(noUser.toString()); // Nothing
 ```
 
-### コード例 5: アプリカティブバリデーション（エラー蓄積）
+### Code Example 5: Applicative Validation (Error Accumulation)
 
 ```typescript
-// === Validation: アプリカティブの最大の利点 ===
-// モナド (flatMap) では最初のエラーで停止するが、
-// アプリカティブではすべてのエラーを収集できる
+// === Validation: the greatest advantage of applicatives ===
+// With a monad (flatMap), computation stops at the first error,
+// but with an applicative, all errors can be collected
 
 type Validation<E, A> =
   | { tag: "Success"; value: A }
@@ -683,7 +684,7 @@ function failOne<E, A>(error: E): Validation<E, A> {
   return { tag: "Failure", errors: [error] };
 }
 
-// map (ファンクタ)
+// map (functor)
 function mapV<E, A, B>(
   va: Validation<E, A>,
   fn: (a: A) => B
@@ -691,13 +692,13 @@ function mapV<E, A, B>(
   return va.tag === "Success" ? success(fn(va.value)) : va;
 }
 
-// ap (アプリカティブ) — エラーを蓄積する
+// ap (applicative) — accumulates errors
 function apV<E, A, B>(
   vf: Validation<E, (a: A) => B>,
   va: Validation<E, A>
 ): Validation<E, B> {
   if (vf.tag === "Failure" && va.tag === "Failure") {
-    return failure([...vf.errors, ...va.errors]);  // 両方のエラーを蓄積!
+    return failure([...vf.errors, ...va.errors]);  // accumulates both errors!
   }
   if (vf.tag === "Failure") return failure(vf.errors);
   if (va.tag === "Failure") return failure(va.errors);
@@ -722,7 +723,7 @@ function liftA3V<E, A, B, C, D>(
   return apV(apV(mapV(va, (a: A) => (b: B) => (c: C) => fn(a, b, c)), vb), vc);
 }
 
-// === バリデーション関数群 ===
+// === Validation functions ===
 
 interface ValidationError {
   field: string;
@@ -731,13 +732,13 @@ interface ValidationError {
 
 function validateName(name: string): Validation<ValidationError, string> {
   if (name.length === 0) {
-    return failOne({ field: "name", message: "名前は必須です" });
+    return failOne({ field: "name", message: "Name is required" });
   }
   if (name.length < 2) {
-    return failOne({ field: "name", message: "名前は2文字以上で入力してください" });
+    return failOne({ field: "name", message: "Name must be at least 2 characters" });
   }
   if (name.length > 50) {
-    return failOne({ field: "name", message: "名前は50文字以下で入力してください" });
+    return failOne({ field: "name", message: "Name must be 50 characters or less" });
   }
   return success(name);
 }
@@ -745,25 +746,25 @@ function validateName(name: string): Validation<ValidationError, string> {
 function validateEmail(email: string): Validation<ValidationError, string> {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
-    return failOne({ field: "email", message: "有効なメールアドレスを入力してください" });
+    return failOne({ field: "email", message: "Please enter a valid email address" });
   }
   return success(email);
 }
 
 function validateAge(age: number): Validation<ValidationError, number> {
   if (!Number.isInteger(age)) {
-    return failOne({ field: "age", message: "年齢は整数で入力してください" });
+    return failOne({ field: "age", message: "Age must be an integer" });
   }
   if (age < 0 || age > 150) {
-    return failOne({ field: "age", message: "年齢は0〜150の範囲で入力してください" });
+    return failOne({ field: "age", message: "Age must be between 0 and 150" });
   }
   if (age < 18) {
-    return failOne({ field: "age", message: "18歳以上である必要があります" });
+    return failOne({ field: "age", message: "Must be 18 years or older" });
   }
   return success(age);
 }
 
-// === ユーザー登録フォームの検証 ===
+// === Validation for user registration form ===
 
 interface UserRegistration {
   name: string;
@@ -788,9 +789,9 @@ function validateUserRegistration(input: {
   );
 }
 
-// === 実行例 ===
+// === Execution examples ===
 
-// 全てのフィールドが不正 → エラーが全て蓄積される
+// All fields are invalid → all errors are accumulated
 const result1 = validateUserRegistration({
   name: "",
   email: "invalid",
@@ -800,14 +801,14 @@ console.log(result1);
 // {
 //   tag: "Failure",
 //   errors: [
-//     { field: "name", message: "名前は必須です" },
-//     { field: "email", message: "有効なメールアドレスを入力してください" },
-//     { field: "age", message: "18歳以上である必要があります" }
+//     { field: "name", message: "Name is required" },
+//     { field: "email", message: "Please enter a valid email address" },
+//     { field: "age", message: "Must be 18 years or older" }
 //   ]
 // }
-// → モナドなら "名前は必須です" だけで停止していた!
+// → With a monad, it would have stopped at "Name is required"!
 
-// 全て有効な場合
+// When all are valid
 const result2 = validateUserRegistration({
   name: "Taro",
   email: "taro@example.com",
@@ -817,23 +818,23 @@ console.log(result2);
 // { tag: "Success", value: { name: "Taro", email: "taro@example.com", age: 25 } }
 ```
 
-### コード例 6: Promise.all はアプリカティブ
+### Code Example 6: Promise.all Is an Applicative
 
 ```typescript
-// === Promise.all はアプリカティブの ap に相当する ===
+// === Promise.all is equivalent to the applicative's ap ===
 
-// WHY: 独立した非同期処理を並列実行できる
-// → 逐次実行に比べて大幅な高速化が可能
+// WHY: Independent async operations can be run in parallel
+// → Significant speedup compared to sequential execution
 
-// --- アプリカティブ（Promise.all）: 独立した処理を並列実行 ---
+// --- Applicative (Promise.all): run independent operations in parallel ---
 async function getUserDashboard(userId: string) {
-  // 3つの API 呼び出しは互いに独立
+  // The 3 API calls are independent of each other
   const [user, orders, settings] = await Promise.all([
     fetchUser(userId),        // 200ms
     fetchOrders(userId),      // 300ms
     fetchSettings(userId),    // 150ms
   ]);
-  // 合計: max(200, 300, 150) = 300ms（並列実行）
+  // Total: max(200, 300, 150) = 300ms (parallel execution)
 
   return {
     userName: user.name,
@@ -842,17 +843,17 @@ async function getUserDashboard(userId: string) {
   };
 }
 
-// --- モナド（async/await逐次）: 依存する処理を直列実行 ---
+// --- Monad (sequential async/await): run dependent operations sequentially ---
 async function getOrderDetails(userId: string) {
   const user = await fetchUser(userId);                   // 200ms
-  const orders = await fetchOrders(user.id);              // 300ms（user に依存）
-  const details = await fetchOrderDetails(orders[0].id);  // 100ms（orders に依存）
-  // 合計: 200 + 300 + 100 = 600ms（逐次実行）
+  const orders = await fetchOrders(user.id);              // 300ms (depends on user)
+  const details = await fetchOrderDetails(orders[0].id);  // 100ms (depends on orders)
+  // Total: 200 + 300 + 100 = 600ms (sequential execution)
 
   return details;
 }
 
-// --- Promise.allSettled: 失敗しても全結果を取得 ---
+// --- Promise.allSettled: get all results even if some fail ---
 async function getUserDataSafe(userId: string) {
   const results = await Promise.allSettled([
     fetchUser(userId),
@@ -869,7 +870,7 @@ async function getUserDataSafe(userId: string) {
   });
 }
 
-// --- 実用的な例: API リクエストの並列バッチ処理 ---
+// --- Practical example: parallel batch API request processing ---
 async function batchFetch<T>(
   urls: string[],
   concurrency: number = 5
@@ -886,14 +887,14 @@ async function batchFetch<T>(
 }
 ```
 
-### コード例 7: Rust でのアプリカティブ的操作
+### Code Example 7: Applicative-Style Operations in Rust
 
 ```rust
-// Rust にはアプリカティブの直接的な構文はないが、
-// 同等のパターンは実現可能
+// Rust has no direct applicative syntax, but
+// equivalent patterns can be achieved
 
 fn main() {
-    // === Option の zip: アプリカティブ的な組み合わせ ===
+    // === Option's zip: applicative-style combination ===
     let x: Option<i32> = Some(3);
     let y: Option<i32> = Some(5);
     let sum = x.zip(y).map(|(a, b)| a + b);
@@ -903,15 +904,15 @@ fn main() {
     let no_sum = x.zip(z).map(|(a, b)| a + b);
     println!("no_sum = {:?}", no_sum); // None
 
-    // === 実践: 設定の並列パース ===
+    // === Practical: parallel config parsing ===
     let config = parse_config("8080", "localhost", "mydb");
     println!("config = {:?}", config);
     // Some(ServerConfig { port: 8080, host: "localhost", db: "mydb" })
 
-    // === エラー蓄積型バリデーション ===
+    // === Error-accumulating validation ===
     let result = validate_user_input("", "bad-email", -5);
     println!("validation = {:?}", result);
-    // Err(["名前は必須です", "無効なメールアドレス", "年齢は0以上"])
+    // Err(["Name is required", "Invalid email address", "Age must be 0 or greater"])
 }
 
 #[derive(Debug)]
@@ -930,7 +931,7 @@ fn parse_config(port_str: &str, host: &str, db: &str) -> Option<ServerConfig> {
     })
 }
 
-// エラー蓄積型バリデーション（アプリカティブ的）
+// Error-accumulating validation (applicative-style)
 fn validate_user_input(
     name: &str,
     email: &str,
@@ -939,13 +940,13 @@ fn validate_user_input(
     let mut errors = Vec::new();
 
     if name.is_empty() {
-        errors.push("名前は必須です".to_string());
+        errors.push("Name is required".to_string());
     }
     if !email.contains('@') {
-        errors.push("無効なメールアドレス".to_string());
+        errors.push("Invalid email address".to_string());
     }
     if age < 0 {
-        errors.push("年齢は0以上".to_string());
+        errors.push("Age must be 0 or greater".to_string());
     }
 
     if errors.is_empty() {
@@ -955,13 +956,13 @@ fn validate_user_input(
     }
 }
 
-// === Iterator の zip: アプリカティブ的操作 ===
+// === Iterator zip: applicative-style operation ===
 fn applicative_iterators() {
     let names = vec!["Alice", "Bob", "Charlie"];
     let ages = vec![30, 25, 35];
     let scores = vec![95, 87, 92];
 
-    // 3つのイテレータを zip で組み合わせ
+    // Combine 3 iterators with zip
     let students: Vec<_> = names.iter()
         .zip(ages.iter())
         .zip(scores.iter())
@@ -981,102 +982,103 @@ fn applicative_iterators() {
 
 ---
 
-## 3. 型クラス階層
+## 3. The Type Class Hierarchy
 
-### 3.1 Functor < Applicative < Monad の関係
+### 3.1 The Relationship of Functor < Applicative < Monad
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  型クラス階層（圏論的な包含関係）                              │
+│  Type class hierarchy (category-theoretic containment)       │
 │                                                             │
 │  ┌─────────────────────────────────────────────────────┐   │
 │  │  Monad                                              │   │
 │  │  bind/flatMap: F[A] → (A → F[B]) → F[B]            │   │
-│  │  依存する計算の連鎖                                  │   │
+│  │  chaining dependent computations                    │   │
 │  │                                                     │   │
 │  │  ┌─────────────────────────────────────────────┐   │   │
 │  │  │  Applicative                                │   │   │
 │  │  │  ap:   F[A → B] → F[A] → F[B]              │   │   │
 │  │  │  pure: A → F[A]                             │   │   │
-│  │  │  独立した値の組み合わせ                      │   │   │
+│  │  │  combining independent values               │   │   │
 │  │  │                                             │   │   │
 │  │  │  ┌─────────────────────────────────────┐   │   │   │
 │  │  │  │  Functor                            │   │   │   │
 │  │  │  │  map/fmap: F[A] → (A → B) → F[B]   │   │   │   │
-│  │  │  │  1つの値の変換                       │   │   │   │
+│  │  │  │  transforming one value              │   │   │   │
 │  │  │  └─────────────────────────────────────┘   │   │   │
 │  │  └─────────────────────────────────────────────┘   │   │
 │  └─────────────────────────────────────────────────────┘   │
 │                                                             │
-│  重要: すべてのモナドはアプリカティブであり、                  │
-│        すべてのアプリカティブはファンクタである                 │
+│  Important: every monad is an applicative, and              │
+│             every applicative is a functor                   │
 │                                                             │
-│  しかし逆は成り立たない:                                      │
-│  - Validation はアプリカティブだがモナドではない               │
-│    (エラー蓄積にはアプリカティブが必要)                        │
+│  But the reverse does not hold:                              │
+│  - Validation is an applicative but not a monad              │
+│    (error accumulation requires an applicative)              │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 使い分け比較表
+### 3.2 Comparison Table for Choosing
 
-| 特性 | Functor (map) | Applicative (ap) | Monad (bind) |
+| Characteristic | Functor (map) | Applicative (ap) | Monad (bind) |
 |---|---|---|---|
-| **1値の変換** | 可能 | 可能 | 可能 |
-| **複数値の組み合わせ** | 不可 | 可能 | 可能 |
-| **エラー蓄積** | 不可 | 可能 | 不可（最初で停止） |
-| **依存する計算** | 不可 | 不可 | 可能 |
-| **並列実行** | — | 可能 | 不可（逐次） |
-| **計算の静的解析** | 可能 | 可能 | 不可（動的） |
-| **日常での例** | Array.map | Promise.all | async/await |
+| **Transform one value** | Possible | Possible | Possible |
+| **Combine multiple values** | Not possible | Possible | Possible |
+| **Error accumulation** | Not possible | Possible | Not possible (stops at first) |
+| **Dependent computation** | Not possible | Not possible | Possible |
+| **Parallel execution** | — | Possible | Not possible (sequential) |
+| **Static analysis of computation** | Possible | Possible | Not possible (dynamic) |
+| **Everyday example** | Array.map | Promise.all | async/await |
 | **Haskell** | fmap / <$> | <*> | >>= / do |
 | **TypeScript** | .map() | Promise.all() | .then() / await |
 | **Rust** | .map() | .zip() | .and_then() / ? |
 
-### 3.3 アプリカティブとモナドの選択基準
+### 3.3 Criteria for Choosing Applicative vs Monad
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  選択フローチャート                                      │
+│  Selection flowchart                                     │
 │                                                         │
-│  「計算 B は計算 A の結果に依存するか？」                 │
+│  "Does computation B depend on the result of A?"         │
 │        │                                                │
-│        ├── YES → モナド（flatMap / bind / await）        │
-│        │         例: fetchUser → fetchOrders(user.id)   │
+│        ├── YES → Monad (flatMap / bind / await)          │
+│        │         e.g.: fetchUser → fetchOrders(user.id)  │
 │        │                                                │
-│        └── NO  → アプリカティブ（ap / Promise.all）      │
-│                  例: fetchUser + fetchProducts + fetchAds│
+│        └── NO  → Applicative (ap / Promise.all)          │
+│                  e.g.: fetchUser + fetchProducts + fetchAds│
 │                                                         │
-│  さらに:                                                 │
-│  「エラーを全て収集したいか？」                           │
+│  Additionally:                                           │
+│  "Do you want to collect all errors?"                    │
 │        │                                                │
-│        ├── YES → Validation（アプリカティブ）             │
-│        │         例: フォームバリデーション               │
+│        ├── YES → Validation (applicative)                │
+│        │         e.g.: form validation                   │
 │        │                                                │
-│        └── NO  → Either/Result（モナド）                 │
-│                  例: 最初のエラーで中断して早期リターン   │
+│        └── NO  → Either/Result (monad)                   │
+│                  e.g.: abort on first error, early return│
 │                                                         │
-│  パフォーマンスの観点:                                    │
-│  - アプリカティブは並列実行が可能                         │
-│  - モナドは逐次実行（前の結果が次に必要なため）           │
-│  - 可能な限りアプリカティブを選ぶと高速                   │
+│  From a performance perspective:                         │
+│  - Applicative allows parallel execution                 │
+│  - Monad requires sequential execution (each step needs  │
+│    the previous result)                                  │
+│  - Prefer applicative when possible for better speed     │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### コード例 8: 各レベルの能力の違いを示す実践例
+### Code Example 8: Practical Example Showing the Difference in Capability at Each Level
 
 ```typescript
-// === ファンクタレベル: 1つの値の変換 ===
+// === Functor level: transforming one value ===
 
-// ユーザーIDから表示名を取得
+// Get display name from user ID
 const displayName = Maybe.fromNullable(user)
   .map(u => u.firstName + " " + u.lastName)
   .map(name => name.trim())
   .map(name => name.toUpperCase());
 // Maybe<string>: Just("TARO YAMADA") or Nothing
 
-// === アプリカティブレベル: 独立した値の組み合わせ ===
+// === Applicative level: combining independent values ===
 
-// フォームの3つのフィールドを独立に検証して結合
+// Independently validate 3 form fields and combine
 const validatedForm = liftA3V(
   (name, email, age) => ({ name, email, age }),
   validateName(formData.name),
@@ -1084,96 +1086,99 @@ const validatedForm = liftA3V(
   validateAge(formData.age)
 );
 // Validation<Error[], FormData>
-// エラーは全フィールド分蓄積される
+// Errors accumulate for all fields
 
-// === モナドレベル: 依存する計算の連鎖 ===
+// === Monad level: chaining dependent computations ===
 
-// ユーザー取得 → 権限チェック → データ取得
+// Fetch user → check permissions → fetch data
 const result = Maybe.fromNullable(userId)
   .flatMap(id => findUser(id))           // Maybe<User>
   .flatMap(user => checkPermission(user)) // Maybe<Permission>
   .flatMap(perm => fetchData(perm));      // Maybe<Data>
-// 各ステップが前のステップの結果に依存
+// Each step depends on the result of the previous step
 
-// === 誤った選択の例 ===
+// === Examples of incorrect choices ===
 
-// [NG] 独立した処理をモナドで書く（不必要に逐次実行）
+// [NG] Writing independent operations with monad (unnecessarily sequential)
 const user2 = await fetchUser(userId);      // 200ms
-const products = await fetchProducts();      // 300ms（user に依存しない!）
-const ads = await fetchAds();                // 100ms（上記に依存しない!）
-// 合計: 600ms
+const products = await fetchProducts();      // 300ms (does not depend on user!)
+const ads = await fetchAds();                // 100ms (does not depend on above!)
+// Total: 600ms
 
-// [OK] アプリカティブで書く（並列実行）
+// [OK] Write with applicative (parallel execution)
 const [user3, products2, ads2] = await Promise.all([
   fetchUser(userId),    // 200ms
   fetchProducts(),      // 300ms
   fetchAds(),           // 100ms
 ]);
-// 合計: 300ms（2倍高速!）
+// Total: 300ms (2x faster!)
 ```
 
-### 3.4 日常での対応表
+### 3.4 Everyday Correspondence Table
 
-| 抽象化 | Array | Promise | Option/Maybe | Result/Either | IO |
+| Abstraction | Array | Promise | Option/Maybe | Result/Either | IO |
 |---|---|---|---|---|---|
 | **Functor (map)** | `.map()` | `.then()` | `.map()` | `.map()` | `.map()` |
-| **Applicative** | `zip`/スプレッド | `Promise.all()` | `liftA2` | `Validation` | `liftA2` |
-| **Monad (bind)** | `.flatMap()` | `async/await` | `.flatMap()`/`?.` | `?` 演算子 | `do` 記法 |
+| **Applicative** | `zip`/spread | `Promise.all()` | `liftA2` | `Validation` | `liftA2` |
+| **Monad (bind)** | `.flatMap()` | `async/await` | `.flatMap()`/`?.` | `?` operator | `do` notation |
 
 ---
 
-## 4. 圏論との接点 — 直感的な理解
+## 4. Connection to Category Theory — Intuitive Understanding
 
-### 4.1 プログラマのための圏論
+### 4.1 Category Theory for Programmers
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  圏論の概念とプログラミングの対応                              │
+│  Correspondence between category theory concepts              │
+│  and programming                                             │
 │                                                              │
-│  圏論           プログラミング                                │
-│  ──────         ─────────────                                │
-│  圏(Category)   型の世界                                      │
-│  対象(Object)   型（Int, String, User, ...）                  │
-│  射(Morphism)   関数（A → B）                                │
-│  合成(∘)         関数合成 (f ∘ g)(x) = f(g(x))               │
-│  恒等射(id)     恒等関数 id(x) = x                           │
+│  Category theory    Programming                              │
+│  ──────────────     ─────────────                            │
+│  Category           The world of types                       │
+│  Object             Type (Int, String, User, ...)            │
+│  Morphism           Function (A → B)                        │
+│  Composition (∘)    Function composition (f ∘ g)(x) = f(g(x))│
+│  Identity (id)      Identity function id(x) = x             │
 │                                                              │
-│  ファンクタ     圏から圏への「構造を保つ写像」                 │
-│                 F: C → D                                     │
-│                 - 対象を対象に:  A → F[A]                     │
-│                 - 射を射に:     (A→B) → (F[A]→F[B])          │
-│                 これが map!                                   │
+│  Functor            A "structure-preserving map" from        │
+│                     one category to another                  │
+│                     F: C → D                                 │
+│                     - Objects to objects:  A → F[A]          │
+│                     - Morphisms to morphisms: (A→B) → (F[A]→F[B])│
+│                     This is map!                             │
 │                                                              │
-│  自然変換       ファンクタ間の「構造を保つ変換」               │
-│                 Maybe[A] → List[A]                           │
-│                 例: maybeToList(Just 5) = [5]                 │
-│                     maybeToList(Nothing) = []                 │
+│  Natural            A "structure-preserving transformation"  │
+│  Transformation     between functors                        │
+│                     Maybe[A] → List[A]                       │
+│                     e.g.: maybeToList(Just 5) = [5]          │
+│                           maybeToList(Nothing) = []          │
 │                                                              │
-│  モナド         自己ファンクタの圏のモノイド                   │
-│                 (join: F[F[A]] → F[A] と pure: A → F[A])     │
-│                 flatMap = join ∘ map                          │
+│  Monad              A monoid in the category of endofunctors │
+│                     (join: F[F[A]] → F[A] and pure: A → F[A])│
+│                     flatMap = join ∘ map                     │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-### 4.2 なぜ圏論が役立つのか
+### 4.2 Why Category Theory Is Useful
 
-圏論を知ることの実用的な価値:
+Practical value of knowing category theory:
 
-1. **API 設計**: ファンクタ則を満たす `map` を設計すれば、ユーザーが安心してリファクタリングできる
-2. **パフォーマンス最適化**: 合成則により、`map` チェーンを1回の `map` にまとめられる
-3. **ライブラリ理解**: fp-ts, cats, scalaz 等のライブラリの API が直感的に理解できる
-4. **パターン発見**: 「この型に map を実装できるか？」と考えることで、新しい抽象化を発見できる
+1. **API design**: Designing a `map` that satisfies the functor laws lets users refactor with confidence
+2. **Performance optimization**: The composition law allows merging a chain of `map` calls into a single `map`
+3. **Understanding libraries**: The APIs of libraries like fp-ts, cats, and scalaz become intuitively understandable
+4. **Pattern discovery**: Asking "can I implement map on this type?" leads to discovering new abstractions
 
 ---
 
-## 5. 高度なトピック
+## 5. Advanced Topics
 
-### 5.1 Traversable — ファンクタの中のアプリカティブ
+### 5.1 Traversable — An Applicative Inside a Functor
 
 ```typescript
-// Traversable: コンテキストの順序を入れ替える
-// 問題: Array<Maybe<number>> があるが、Maybe<Array<number>> が欲しい
-// つまり「1つでも Nothing があれば全体を Nothing にしたい」
+// Traversable: swap the order of contexts
+// Problem: we have Array<Maybe<number>> but want Maybe<Array<number>>
+// In other words, "if even one is Nothing, make the whole thing Nothing"
 
 function sequence<A>(maybes: Maybe<A>[]): Maybe<A[]> {
   return maybes.reduce<Maybe<A[]>>(
@@ -1183,7 +1188,7 @@ function sequence<A>(maybes: Maybe<A>[]): Maybe<A[]> {
   );
 }
 
-// map してから sequence する（より効率的）
+// map then sequence (more efficient)
 function traverse<A, B>(
   fn: (a: A) => Maybe<B>,
   arr: A[]
@@ -1195,14 +1200,14 @@ function traverse<A, B>(
   );
 }
 
-// 使用例
+// Usage examples
 const ids = [1, 2, 3, 4, 5];
 
-// 全ユーザーが見つかれば Just([users])、1人でも見つからなければ Nothing
+// Just([users]) if all users are found, Nothing if any one is not found
 const allUsers = traverse(id => findUserById(id), ids);
 // Maybe<User[]>
 
-// sequence の使用例
+// sequence usage example
 const maybeNumbers: Maybe<number>[] = [
   Maybe.of(1),
   Maybe.of(2),
@@ -1217,24 +1222,24 @@ const withNothing: Maybe<number>[] = [
   Maybe.of(3),
 ];
 const seqResult2 = sequence(withNothing);
-// Nothing — 1つでも Nothing なら全体が Nothing
+// Nothing — if even one is Nothing, the whole is Nothing
 ```
 
-### 5.2 Contravariant Functor — 反変ファンクタ
+### 5.2 Contravariant Functor
 
 ```typescript
-// 通常のファンクタは「出力」側に map する（共変: Covariant）
-// 反変ファンクタは「入力」側に map する（反変: Contravariant）
+// An ordinary functor maps on the "output" side (covariant)
+// A contravariant functor maps on the "input" side (contravariant)
 
-// 通常のファンクタ: F[A] → (A → B) → F[B]
-// 反変ファンクタ:   F[A] → (B → A) → F[B]
+// Ordinary functor:      F[A] → (A → B) → F[B]
+// Contravariant functor: F[A] → (B → A) → F[B]
 
-// 例: 比較関数（Comparator）は反変ファンクタ
+// Example: a Comparator is a contravariant functor
 interface Comparator<A> {
   compare: (a1: A, a2: A) => number;
 }
 
-// contramap: 入力側を変換
+// contramap: transform the input side
 function contramap<A, B>(
   comp: Comparator<A>,
   fn: (b: B) => A
@@ -1244,16 +1249,16 @@ function contramap<A, B>(
   };
 }
 
-// 数値比較器
+// Number comparator
 const numberComparator: Comparator<number> = {
   compare: (a, b) => a - b,
 };
 
-// 文字列の長さで比較（反変マッピング）
+// Compare by string length (contravariant mapping)
 const byLength = contramap(numberComparator, (s: string) => s.length);
 // Comparator<string>
 
-// ユーザーを年齢で比較（反変マッピング）
+// Compare people by age (contravariant mapping)
 interface Person {
   name: string;
   age: number;
@@ -1262,7 +1267,7 @@ interface Person {
 const byAge = contramap(numberComparator, (p: Person) => p.age);
 // Comparator<Person>
 
-// 使用
+// Usage
 const people: Person[] = [
   { name: "Alice", age: 30 },
   { name: "Bob", age: 25 },
@@ -1272,19 +1277,19 @@ const people: Person[] = [
 const sorted = [...people].sort(byAge.compare);
 // [Bob(25), Alice(30), Charlie(35)]
 
-// 反変ファンクタの法則:
-// 1. 恒等則: contramap(id) = id
-// 2. 合成則: contramap(f).contramap(g) = contramap(g . f)
-//            (注意: 通常のファンクタとは合成の順序が逆!)
+// Contravariant functor laws:
+// 1. Identity law: contramap(id) = id
+// 2. Composition law: contramap(f).contramap(g) = contramap(g . f)
+//    (Note: the order of composition is reversed compared to ordinary functors!)
 ```
 
-### 5.3 Free Applicative パターン
+### 5.3 Free Applicative Pattern
 
 ```typescript
-// Free Applicative: アプリカティブな操作を
-// データ構造として構築し、後から解釈する
+// Free Applicative: build applicative operations as
+// a data structure and interpret them later
 
-// 宣言的な API リクエスト定義
+// Declarative API request definition
 type ApiRequest<A> =
   | { tag: "Pure"; value: A }
   | { tag: "Fetch"; url: string; parse: (data: unknown) => A }
@@ -1317,7 +1322,7 @@ function liftA2Req<A, B, C>(
   return apReq(mapReq(ra, (a: A) => (b: B) => fn(a, b)), rb);
 }
 
-// リクエストの宣言（この時点ではまだ実行されない）
+// Request declaration (not executed at this point)
 const userReq = fetchReq("/api/user/1", (d: any) => d as User);
 const ordersReq = fetchReq("/api/orders?user=1", (d: any) => d as Order[]);
 
@@ -1327,7 +1332,7 @@ const dashboardReq = liftA2Req(
   ordersReq
 );
 
-// === インタプリタ1: 並列実行 ===
+// === Interpreter 1: parallel execution ===
 async function runParallel<A>(req: ApiRequest<A>): Promise<A> {
   if (req.tag === "Pure") return req.value;
   if (req.tag === "Fetch") {
@@ -1335,7 +1340,7 @@ async function runParallel<A>(req: ApiRequest<A>): Promise<A> {
     const data = await res.json();
     return req.parse(data);
   }
-  // Ap: 関数と引数を並列実行
+  // Ap: run function and argument in parallel
   const [fn, arg] = await Promise.all([
     runParallel(req.fn),
     runParallel(req.arg),
@@ -1343,14 +1348,14 @@ async function runParallel<A>(req: ApiRequest<A>): Promise<A> {
   return fn(arg);
 }
 
-// === インタプリタ2: URL 収集（テストやログ用） ===
+// === Interpreter 2: collect URLs (for testing or logging) ===
 function collectUrls<A>(req: ApiRequest<A>): string[] {
   if (req.tag === "Pure") return [];
   if (req.tag === "Fetch") return [req.url];
   return [...collectUrls(req.fn), ...collectUrls(req.arg)];
 }
 
-// 使用例
+// Usage examples
 const urls = collectUrls(dashboardReq);
 // ["/api/user/1", "/api/orders?user=1"]
 
@@ -1358,13 +1363,13 @@ const dashboard = await runParallel(dashboardReq);
 // { user: ..., orders: [...] }
 ```
 
-### 5.4 React におけるアプリカティブパターン
+### 5.4 Applicative Patterns in React
 
 ```tsx
-// === React Query (TanStack Query) での並列クエリ ===
+// === Parallel queries with React Query (TanStack Query) ===
 
 function Dashboard({ userId }: { userId: string }) {
-  // 3つのクエリを並列実行（アプリカティブ）
+  // Run 3 queries in parallel (applicative)
   const userQuery = useQuery({
     queryKey: ["user", userId],
     queryFn: () => fetchUser(userId),
@@ -1378,19 +1383,19 @@ function Dashboard({ userId }: { userId: string }) {
     queryFn: () => fetchSettings(userId),
   });
 
-  // 全クエリのローディング状態を組み合わせ
+  // Combine loading states of all queries
   if (userQuery.isLoading || ordersQuery.isLoading || settingsQuery.isLoading) {
     return <Loading />;
   }
 
-  // エラーの蓄積（アプリカティブ的）
+  // Error accumulation (applicative-style)
   const errors = [userQuery.error, ordersQuery.error, settingsQuery.error]
     .filter(Boolean);
   if (errors.length > 0) {
     return <ErrorList errors={errors} />;
   }
 
-  // 全データが揃った時のみレンダリング
+  // Render only when all data is available
   return (
     <DashboardView
       user={userQuery.data!}
@@ -1400,7 +1405,7 @@ function Dashboard({ userId }: { userId: string }) {
   );
 }
 
-// === フォームバリデーション ===
+// === Form validation ===
 function useFormValidation<T extends Record<string, unknown>>(
   validators: Record<keyof T, (value: unknown) => Validation<string, unknown>>
 ) {
@@ -1426,40 +1431,40 @@ function useFormValidation<T extends Record<string, unknown>>(
 }
 ```
 
-### 5.5 Haskell での型クラス階層
+### 5.5 Type Class Hierarchy in Haskell
 
 ```haskell
--- Haskell ではファンクタ・アプリカティブ・モナドは
--- 型クラスとして明示的に定義される
+-- In Haskell, Functor, Applicative, and Monad are
+-- explicitly defined as type classes
 
--- === ファンクタ ===
+-- === Functor ===
 class Functor f where
     fmap :: (a -> b) -> f a -> f b
 
--- === アプリカティブ ===
+-- === Applicative ===
 class Functor f => Applicative f where
     pure  :: a -> f a
     (<*>) :: f (a -> b) -> f a -> f b
 
--- === モナド ===
+-- === Monad ===
 class Applicative m => Monad m where
     (>>=) :: m a -> (a -> m b) -> m b
 
--- === 使用例 ===
+-- === Usage examples ===
 
--- ファンクタ
+-- Functor
 ex1 = fmap (+1) (Just 5)              -- Just 6
 ex2 = fmap (+1) [1, 2, 3]             -- [2, 3, 4]
 
--- アプリカティブ
+-- Applicative
 ex3 = pure (+) <*> Just 3 <*> Just 5  -- Just 8
 ex4 = pure (+) <*> Nothing <*> Just 5 -- Nothing
 
--- リストのアプリカティブ（直積 = 全組み合わせ）
+-- List applicative (Cartesian product = all combinations)
 ex5 = pure (+) <*> [1, 2] <*> [10, 20]
 -- [11, 21, 12, 22]
 
--- アプリカティブスタイルでのユーザー作成
+-- Creating a user in applicative style
 data User = User String String Int deriving (Show)
 
 mkUser :: String -> String -> Int -> User
@@ -1469,7 +1474,7 @@ validUser = mkUser <$> validateName "Taro"
                    <*> validateEmail "taro@example.com"
                    <*> validateAge 25
 
--- モナド（do 記法）
+-- Monad (do notation)
 ex6 = do
     user  <- findUser userId
     perms <- checkPermissions user
@@ -1478,46 +1483,46 @@ ex6 = do
 
 ---
 
-## アンチパターン
+## Anti-Patterns
 
-### 1. モナドを使うべき場面でアプリカティブを使う
+### 1. Using Applicative Where Monad Should Be Used
 
 ```typescript
-// [NG] 前の計算結果に依存する処理をアプリカティブで無理に書く
-// 問題: order は user.id に依存しているのに並列実行しようとしている
+// [NG] Forcing applicative for operations where the result of one depends on another
+// Problem: orders depends on user.id, but we try to run it in parallel
 
-// fetchOrders は userId ではなく user.id（取得結果に含まれるID）を必要とする
+// fetchOrders needs user.id (the ID in the fetched result), not userId
 const [user, orders] = await Promise.all([
   fetchUser(userId),
-  fetchOrders(userId),  // 本来は user.id が必要だが、userId で代用してしまっている
+  fetchOrders(userId),  // should use user.id, but falling back to userId
 ]);
 
-// [OK] 依存関係がある場合はモナド（async/await）を使う
+// [OK] Use monad (async/await) when there is a dependency
 const user = await fetchUser(userId);
-const orders = await fetchOrders(user.id);  // user.id に依存
-const details = await fetchOrderDetails(orders[0].id);  // orders に依存
+const orders = await fetchOrders(user.id);  // depends on user.id
+const details = await fetchOrderDetails(orders[0].id);  // depends on orders
 
-// 判断基準: 「後続の処理が前の処理の"結果"を引数にしているか？」
-// YES → モナド（逐次）、NO → アプリカティブ（並列可能）
+// Criterion: "Does the subsequent operation take the 'result' of the previous one as an argument?"
+// YES → Monad (sequential), NO → Applicative (parallelizable)
 ```
 
-### 2. ファンクタ則を破る map の実装
+### 2. A map Implementation That Violates the Functor Laws
 
 ```typescript
-// [NG] map 内で副作用を行う
+// [NG] Performing side effects inside map
 class BadMaybe<T> {
   private value: T | null;
 
   map<U>(fn: (value: T) => U): BadMaybe<U> {
-    console.log("mapping!");  // 副作用!
-    // 恒等則: badMaybe.map(id) で "mapping!" が出力される
-    // → id を適用しただけなのに観測可能な副作用が発生 → 恒等則違反
+    console.log("mapping!");  // side effect!
+    // Identity law: badMaybe.map(id) will print "mapping!"
+    // → An observable side effect occurs even though only id was applied → identity law violation
     if (this.value == null) return BadMaybe.nothing();
     return BadMaybe.of(fn(this.value));
   }
 }
 
-// [OK] map は純粋な変換のみ、副作用は別メソッドで
+// [OK] map is for pure transformation only; use a separate method for side effects
 class GoodMaybe<T> {
   private value: T | null;
 
@@ -1526,69 +1531,69 @@ class GoodMaybe<T> {
     return GoodMaybe.of(fn(this.value));
   }
 
-  // 副作用用の明示的なメソッド
+  // Explicit method for side effects
   tap(fn: (value: T) => void): GoodMaybe<T> {
     if (this.value != null) fn(this.value);
-    return this; // 元の値を返す
+    return this; // returns the original value
   }
 }
 
-// 使用例
+// Usage example
 GoodMaybe.of(42)
-  .tap(x => console.log(`値: ${x}`))  // 副作用は tap で
-  .map(x => x * 2);                    // map は純粋に
+  .tap(x => console.log(`Value: ${x}`))  // side effects go in tap
+  .map(x => x * 2);                       // map stays pure
 ```
 
-### 3. Validation を Either/Result と混同する
+### 3. Confusing Validation with Either/Result
 
 ```typescript
-// [NG] Either (モナド) でバリデーション → 最初のエラーで停止
+// [NG] Validation with Either (monad) → stops at the first error
 function validateWithEither(input: FormData): Either<string, User> {
-  const name = validateName(input.name);  // Err なら次へ進めない
-  if (name.isLeft()) return name;         // "名前が短すぎます" だけが返る
+  const name = validateName(input.name);  // If Err, cannot proceed to next
+  if (name.isLeft()) return name;         // only "name is too short" is returned
 
-  const email = validateEmail(input.email); // ここに到達しない可能性
+  const email = validateEmail(input.email); // may not be reached
   if (email.isLeft()) return email;
 
-  const age = validateAge(input.age);       // ここにも到達しない可能性
+  const age = validateAge(input.age);       // may not be reached either
   if (age.isLeft()) return age;
 
   return Right(createUser(name.get(), email.get(), age.get()));
 }
-// → ユーザーはエラーを1つずつしか修正できない（UX が悪い）
+// → Users can only fix one error at a time (poor UX)
 
-// [OK] Validation (アプリカティブ) → 全エラーを収集
+// [OK] Validation (applicative) → collects all errors
 function validateWithApplicative(input: FormData): Validation<string[], User> {
   return liftA3V(
     createUser,
-    validateName(input.name),    // 全て独立に実行される
-    validateEmail(input.email),  // 全て独立に実行される
-    validateAge(input.age)       // 全て独立に実行される
+    validateName(input.name),    // all executed independently
+    validateEmail(input.email),  // all executed independently
+    validateAge(input.age)       // all executed independently
   );
-  // ["名前が短すぎます", "無効なメールアドレス", "年齢が不正"] が全て返る
-  // → ユーザーは一度に全てのエラーを確認できる（UX が良い）
+  // ["name is too short", "invalid email address", "age is invalid"] are all returned
+  // → Users can see all errors at once (good UX)
 }
 ```
 
-### 4. 過度な抽象化 — YAGNI
+### 4. Over-Abstraction — YAGNI
 
 ```typescript
-// [NG] 小さなプロジェクトでフルスペックの型クラス階層を実装
-// TypeScript の型システムでは高カインド型をうまく表現できない
+// [NG] Implementing a full type class hierarchy for a small project
+// TypeScript's type system cannot express higher-kinded types well
 interface Functor<F> {
-  map<A, B>(fa: F, fn: (a: A) => B): F;  // F の型パラメータが失われている
+  map<A, B>(fa: F, fn: (a: A) => B): F;  // the type parameter of F is lost
 }
 interface Applicative<F> extends Functor<F> {
   pure<A>(a: A): F;
   ap<A, B>(ff: F, fa: F): F;
 }
-// → 複雑なだけで実用的なメリットが薄い
+// → Just complex with little practical benefit
 
-// [OK] 必要な箇所だけシンプルに実装
-// Maybe.map, Maybe.flatMap を直接実装し、
-// 型クラスの概念を「設計指針」として頭の中で活用する
+// [OK] Implement only what is needed, simply
+// Implement Maybe.map, Maybe.flatMap directly,
+// and use type class concepts as design guidelines in your head
 
-// 本格的に型クラス階層が必要なら fp-ts ライブラリを使う
+// If a proper type class hierarchy is truly needed, use the fp-ts library
 import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/function";
 
@@ -1601,11 +1606,11 @@ const result = pipe(
 
 ---
 
-## 実践演習
+## Practical Exercises
 
-### 演習1（基礎）: Maybe ファンクタの実装とファンクタ則の検証
+### Exercise 1 (Basic): Implement a Maybe Functor and Verify the Functor Laws
 
-**課題**: 以下の `Maybe` クラスの `map` を実装し、ファンクタ則（恒等則・合成則）をテストコードで検証してください。
+**Task**: Implement `map` for the `Maybe` class below and verify the functor laws (identity law and composition law) with test code.
 
 ```typescript
 class Maybe<T> {
@@ -1623,9 +1628,9 @@ class Maybe<T> {
     return this.value === null;
   }
 
-  // TODO: map を実装してください
+  // TODO: Implement map
   map<U>(fn: (value: T) => U): Maybe<U> {
-    // ここを実装
+    // implement here
   }
 
   getOrElse(defaultValue: T): T {
@@ -1639,222 +1644,222 @@ class Maybe<T> {
   }
 }
 
-// TODO: 以下のテストが全て PASS するようにしてください
+// TODO: Make all the following tests PASS
 const id = <T>(x: T): T => x;
 const f = (x: number) => x * 2;
 const g = (x: number) => x + 1;
 
-// テスト1: 恒等則（Just）
+// Test 1: Identity law (Just)
 console.assert(Maybe.of(42).map(id).equals(Maybe.of(42)));
-// テスト2: 恒等則（Nothing）
+// Test 2: Identity law (Nothing)
 console.assert(Maybe.nothing<number>().map(id).equals(Maybe.nothing<number>()));
-// テスト3: 合成則（Just）
+// Test 3: Composition law (Just)
 console.assert(Maybe.of(5).map(f).map(g).equals(Maybe.of(5).map(x => g(f(x)))));
-// テスト4: 合成則（Nothing）
+// Test 4: Composition law (Nothing)
 console.assert(Maybe.nothing<number>().map(f).map(g).equals(Maybe.nothing<number>().map(x => g(f(x)))));
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-恒等則 (Just): PASS — Just(42).map(id) === Just(42)
-恒等則 (Nothing): PASS — Nothing.map(id) === Nothing
-合成則 (Just): PASS — Just(5).map(f).map(g) === Just(5).map(g∘f)
-合成則 (Nothing): PASS — Nothing.map(f).map(g) === Nothing.map(g∘f)
-全テスト通過!
+Identity law (Just): PASS — Just(42).map(id) === Just(42)
+Identity law (Nothing): PASS — Nothing.map(id) === Nothing
+Composition law (Just): PASS — Just(5).map(f).map(g) === Just(5).map(g∘f)
+Composition law (Nothing): PASS — Nothing.map(f).map(g) === Nothing.map(g∘f)
+All tests passed!
 ```
 
-### 演習2（応用）: アプリカティブバリデーションの実装
+### Exercise 2 (Applied): Implement Applicative Validation
 
-**課題**: 以下の要件を満たすアプリカティブバリデーションシステムを構築してください。
+**Task**: Build an applicative validation system that satisfies the following requirements.
 
-要件:
-1. `Validation<E, A>` 型を実装する（Success/Failure）
-2. `map`, `ap` を実装する（`ap` はエラーを蓄積する）
-3. 以下のバリデーション関数を実装する:
-   - `validateUsername`: 3文字以上20文字以下、英数字のみ
-   - `validatePassword`: 8文字以上、大文字・小文字・数字を各1つ以上含む
-   - `validateConfirmPassword`: パスワードと一致すること
-4. `liftA3V` を使って全バリデーションを組み合わせる
-5. 全フィールドが不正な場合にすべてのエラーが蓄積されることを検証する
+Requirements:
+1. Implement the `Validation<E, A>` type (Success/Failure)
+2. Implement `map` and `ap` (`ap` should accumulate errors)
+3. Implement the following validation functions:
+   - `validateUsername`: 3–20 characters, alphanumeric only
+   - `validatePassword`: at least 8 characters, must contain at least one uppercase letter, one lowercase letter, and one digit
+   - `validateConfirmPassword`: must match the password
+4. Use `liftA3V` to combine all validations
+5. Verify that all errors are accumulated when all fields are invalid
 
 ```typescript
-// TODO: Validation 型, map, ap, liftA2V, liftA3V を実装
+// TODO: Implement Validation type, map, ap, liftA2V, liftA3V
 
-// TODO: バリデーション関数を実装
+// TODO: Implement validation functions
 
-// テストケース
+// Test cases
 const result1 = validateRegistration({
-  username: "ab",           // 短すぎる
-  password: "weak",         // 条件不足
-  confirmPassword: "wrong", // 不一致
+  username: "ab",           // too short
+  password: "weak",         // insufficient conditions
+  confirmPassword: "wrong", // does not match
 });
-// 期待: Failure(["ユーザー名は3文字以上...", "パスワードは8文字以上...", ...])
+// Expected: Failure(["Username must be at least 3 characters...", "Password must be at least 8 characters...", ...])
 
 const result2 = validateRegistration({
   username: "validuser",
   password: "Str0ngPass",
   confirmPassword: "Str0ngPass",
 });
-// 期待: Success({ username: "validuser", password: "Str0ngPass" })
+// Expected: Success({ username: "validuser", password: "Str0ngPass" })
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-テスト1 (全フィールド不正):
+Test 1 (all fields invalid):
   Failure:
-    - ユーザー名は3文字以上20文字以下で入力してください
-    - パスワードは8文字以上で入力してください
-    - パスワードに大文字を含めてください
-    - パスワードに数字を含めてください
-    - パスワードが一致しません
+    - Username must be between 3 and 20 characters
+    - Password must be at least 8 characters
+    - Password must contain an uppercase letter
+    - Password must contain a digit
+    - Passwords do not match
 
-テスト2 (全フィールド有効):
+Test 2 (all fields valid):
   Success: { username: "validuser", password: "Str0ngPass" }
 ```
 
-### 演習3（発展）: Free Applicative による宣言的 API クライアント
+### Exercise 3 (Advanced): Declarative API Client Using Free Applicative
 
-**課題**: Free Applicative パターンを使って、宣言的 API クライアントを実装してください。
+**Task**: Implement a declarative API client using the Free Applicative pattern.
 
-要件:
-1. `ApiRequest<A>` 型を定義する（Pure, Fetch, Ap の3つのケース）
-2. `map`, `ap`, `liftA2` を実装する
-3. 以下の2つのインタプリタを実装する:
-   - `runParallel`: リクエストを並列実行する（Promise.all を使用）
-   - `collectUrls`: 実行せずに全 URL を収集する
-4. モックサーバーを使ってテストする
+Requirements:
+1. Define the `ApiRequest<A>` type (three cases: Pure, Fetch, Ap)
+2. Implement `map`, `ap`, and `liftA2`
+3. Implement the following two interpreters:
+   - `runParallel`: execute requests in parallel (using Promise.all)
+   - `collectUrls`: collect all URLs without executing
+4. Test with a mock server
 
 ```typescript
-// TODO: ApiRequest<A> 型を定義
+// TODO: Define ApiRequest<A> type
 
-// TODO: map, ap, liftA2 を実装
+// TODO: Implement map, ap, liftA2
 
-// TODO: runParallel, collectUrls インタプリタを実装
+// TODO: Implement runParallel, collectUrls interpreters
 
-// テストケース
+// Test cases
 const dashboardReq = liftA2Req(
   (user, orders) => ({ user, orders }),
   fetchReq<User>("/api/user/1", data => data as User),
   fetchReq<Order[]>("/api/orders?user=1", data => data as Order[]),
 );
 
-// URL収集（実行せずに解析）
+// Collect URLs (analyze without executing)
 const urls = collectUrls(dashboardReq);
 console.log(urls); // ["/api/user/1", "/api/orders?user=1"]
 
-// 並列実行
+// Parallel execution
 const result = await runParallel(dashboardReq);
 console.log(result); // { user: {...}, orders: [...] }
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-収集されたURL:
+Collected URLs:
   /api/user/1
   /api/orders?user=1
 
-並列実行結果:
-  リクエスト: GET /api/user/1 ... 200 OK (120ms)
-  リクエスト: GET /api/orders?user=1 ... 200 OK (85ms)
-  結合結果: { user: { id: 1, name: "Taro" }, orders: [{ id: 101, ... }] }
+Parallel execution result:
+  Request: GET /api/user/1 ... 200 OK (120ms)
+  Request: GET /api/orders?user=1 ... 200 OK (85ms)
+  Combined result: { user: { id: 1, name: "Taro" }, orders: [{ id: 101, ... }] }
 ```
 
 ---
 
 ## FAQ
 
-### Q1: アプリカティブはいつ使うべきですか？
+### Q1: When should I use an applicative?
 
-**A**: 「複数の独立した計算の結果を組み合わせたい」場合に使います。典型的な3つのケース:
+**A**: Use it when you want to "combine the results of multiple independent computations." Three typical cases:
 
-1. **フォームバリデーション**: 全フィールドのエラーを一度に表示したい場合。モナドでは最初のエラーで停止するため、全エラーを収集するにはアプリカティブ（Validation型）が必要
-2. **並列 API 呼び出し**: `Promise.all` は独立した非同期処理を並列実行するアプリカティブの代表例
-3. **パーサーコンビネータ**: 独立したフィールドのパースを組み合わせる場合
+1. **Form validation**: When you want to display all field errors at once. With a monad, computation stops at the first error, so you need an applicative (Validation type) to collect all errors
+2. **Parallel API calls**: `Promise.all` is the quintessential example of an applicative for running independent async operations in parallel
+3. **Parser combinators**: When combining the parsing of independent fields
 
-### Q2: map と flatMap の違いを簡潔に説明すると？
+### Q2: Can you briefly explain the difference between map and flatMap?
 
-**A**: `map` は「箱の中身を変換して箱に戻す」、`flatMap` は「箱の中身を変換し、結果が二重の箱になったら一重にする」です。
+**A**: `map` "transforms the contents of a box and puts them back in a box," while `flatMap` "transforms the contents of a box, and if the result is a doubly-nested box, flattens it into a single box."
 
 ```typescript
-// map: (A → B) を F[A] に適用 → F[B]
-[1, 2].map(x => [x, x])     // [[1,1], [2,2]] — 二重配列
+// map: applies (A → B) to F[A] → F[B]
+[1, 2].map(x => [x, x])     // [[1,1], [2,2]] — nested array
 
-// flatMap: (A → F[B]) を F[A] に適用 → F[B]（flat + map）
-[1, 2].flatMap(x => [x, x]) // [1, 1, 2, 2]   — 平坦化される
+// flatMap: applies (A → F[B]) to F[A] → F[B] (flat + map)
+[1, 2].flatMap(x => [x, x]) // [1, 1, 2, 2]   — flattened
 
-// Maybe の場合
-Maybe.of(5).map(x => Maybe.of(x * 2))     // Maybe(Maybe(10)) — 二重 Maybe
-Maybe.of(5).flatMap(x => Maybe.of(x * 2)) // Maybe(10)         — 平坦化
+// For Maybe
+Maybe.of(5).map(x => Maybe.of(x * 2))     // Maybe(Maybe(10)) — double Maybe
+Maybe.of(5).flatMap(x => Maybe.of(x * 2)) // Maybe(10)         — flattened
 ```
 
-### Q3: Functor/Applicative/Monad を意識してコードを書く必要がありますか？
+### Q3: Do I need to consciously think about Functor/Applicative/Monad when writing code?
 
-**A**: 明示的に意識する必要はありません。`Array.map`、`Promise.all`、`async/await` を使う時点で既にこれらのパターンを活用しています。理論を知ることで以下のメリットがあります:
+**A**: You do not need to think about them explicitly. When you use `Array.map`, `Promise.all`, and `async/await`, you are already leveraging these patterns. Knowing the theory provides the following benefits:
 
-- **設計判断**: 「この処理は並列実行できるか？（→ アプリカティブ）」「前の結果に依存するか？（→ モナド）」という判断が的確になる
-- **API 理解**: 新しいライブラリの `map`, `flatMap`, `ap` 等のメソッドの意味が直感的に分かる
-- **バグ予防**: ファンクタ則を意識することで、`map` 内での副作用を避けるようになる
+- **Design decisions**: You can make accurate judgments like "can this operation be run in parallel? (→ applicative)" and "does it depend on the previous result? (→ monad)"
+- **Understanding APIs**: The meaning of methods like `map`, `flatMap`, and `ap` in new libraries becomes intuitively clear
+- **Bug prevention**: Being aware of the functor laws helps you avoid side effects inside `map`
 
-### Q4: TypeScript で高カインド型（HKT）は使えますか？
+### Q4: Can higher-kinded types (HKT) be used in TypeScript?
 
-**A**: TypeScript の型システムでは高カインド型を直接サポートしていません。fp-ts ライブラリがブランド型を使ったエミュレーションを提供しています。小規模なプロジェクトでは、各型（Maybe, Either, Validation）に直接 map/flatMap を実装するのが実用的です。
+**A**: TypeScript's type system does not directly support higher-kinded types. The fp-ts library provides an emulation using branded types. For small projects, it is practical to implement `map`/`flatMap` directly on each type (Maybe, Either, Validation).
 
-### Q5: アプリカティブと並列処理の関係は？
+### Q5: What is the relationship between applicatives and parallel processing?
 
-**A**: アプリカティブの `ap` は「計算間に依存関係がない」ことを型レベルで保証します。依存関係がないということは、理論的に並列実行が可能です。`Promise.all` はまさにこの性質を利用しています。ただし、アプリカティブ = 必ず並列実行ではなく、「並列実行が可能」という情報を提供するだけで、実際に並列にするかはインタプリタの実装次第です。
+**A**: Applicative's `ap` guarantees at the type level that "there is no dependency between computations." No dependency means parallel execution is theoretically possible. `Promise.all` makes direct use of this property. However, applicative does not necessarily mean parallel execution; it merely conveys that "parallel execution is possible," and whether it is actually parallelized depends on the interpreter's implementation.
 
-### Q6: Validation はモナドにならないのはなぜですか？
+### Q6: Why can't Validation be a monad?
 
-**A**: モナドの `bind/flatMap` は「前の計算の結果を使って次の計算を決める」ため、エラーの場合は短絡評価（Short-circuit）するしかありません。一方、アプリカティブの `ap` は「両方の計算を独立に実行して結果を組み合わせる」ため、両方がエラーの場合にエラーを蓄積できます。この「エラー蓄積」と「モナドの短絡評価」は本質的に両立しません。
+**A**: Monad's `bind/flatMap` "uses the result of the previous computation to determine the next computation," so in the case of an error, it has no choice but to short-circuit. Applicative's `ap`, on the other hand, "runs both computations independently and combines the results," so when both are errors, errors can be accumulated. This "error accumulation" and "monadic short-circuit evaluation" are fundamentally incompatible.
 
 ```haskell
--- モナドの bind は前の結果に依存する
--- エラーの場合、次の計算に渡す値がないため停止するしかない
-bind (Failure errs) f = Failure errs  -- f を呼べない
+-- Monad's bind depends on the previous result
+-- In case of an error, there is no value to pass to the next computation, so it must stop
+bind (Failure errs) f = Failure errs  -- cannot call f
 bind (Success a)    f = f a
 
--- アプリカティブの ap は両方を独立に評価できる
-ap (Failure e1) (Failure e2) = Failure (e1 ++ e2)  -- 両方のエラーを結合
+-- Applicative's ap can evaluate both independently
+ap (Failure e1) (Failure e2) = Failure (e1 ++ e2)  -- combine both errors
 ```
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Item | Key Points |
 |---|---|
-| ファンクタ | `map` でコンテキスト内の値を変換。Array, Option, Promise, Result 等 |
-| ファンクタ則 | 恒等則: `map(id) = id`、合成則: `map(f).map(g) = map(g . f)` |
-| アプリカティブ | `ap` で独立した複数の値を組み合わせ。エラー蓄積・並列実行が可能 |
-| Validation | アプリカティブの実践例。モナドと違い全エラーを収集できる |
-| モナド | `bind/flatMap` で依存する計算を連鎖。前の結果に基づく次の計算 |
-| 型クラス階層 | Functor < Applicative < Monad（包含関係） |
-| 選択基準 | 独立 → Applicative（並列可能）、依存 → Monad（逐次実行） |
-| Promise.all | アプリカティブの代表例。独立した非同期処理の並列実行 |
-| Traversable | `sequence`/`traverse` でコンテキストの順序を入れ替え |
-| 反変ファンクタ | 「入力」側に map する。Comparator, Predicate 等 |
-| 圏論との関係 | ファンクタは「構造を保つ写像」。法則が安全なリファクタリングを保証 |
-| 実践指針 | 最小限の抽象化を選ぶ（YAGNI）。TypeScript では fp-ts が実用的 |
+| Functor | Transform values in context with `map`. Array, Option, Promise, Result, etc. |
+| Functor laws | Identity: `map(id) = id`, Composition: `map(f).map(g) = map(g . f)` |
+| Applicative | Combine multiple independent values with `ap`. Enables error accumulation and parallel execution |
+| Validation | A practical example of applicative. Can collect all errors, unlike monad |
+| Monad | Chain dependent computations with `bind/flatMap`. Next computation based on previous result |
+| Type class hierarchy | Functor < Applicative < Monad (containment relationship) |
+| Selection criteria | Independent → Applicative (parallelizable), Dependent → Monad (sequential) |
+| Promise.all | The quintessential applicative example. Parallel execution of independent async operations |
+| Traversable | Swap context order with `sequence`/`traverse` |
+| Contravariant functor | Maps on the "input" side. Comparator, Predicate, etc. |
+| Relation to category theory | Functor is a "structure-preserving map." Laws guarantee safe refactoring |
+| Practical guidelines | Choose the minimal abstraction (YAGNI). fp-ts is practical for TypeScript |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [モナド](./00-monad.md) — flatMap/bind の詳細と応用、do 記法
-- [関数型パターン](./02-fp-patterns.md) — カリー化、パイプライン、レンズとの統合
-- クリーンコードの原則 — 関数設計の基本原則
-- [ビヘイビアパターン](../02-behavioral/) — OOP のパターンとの比較
-- [アーキテクチャパターン](../04-architectural/) — 大規模設計での関数型アプローチ
+- [Monad](./00-monad.md) — Details and applications of flatMap/bind, do notation
+- [Functional Patterns](./02-fp-patterns.md) — Integration with currying, pipelines, and lenses
+- Clean code principles — Fundamental principles of function design
+- [Behavioral Patterns](../02-behavioral/) — Comparison with OOP patterns
+- [Architectural Patterns](../04-architectural/) — Functional approaches in large-scale design
 
 ---
 
-## 参考文献
+## References
 
-1. **Haskell Wiki**: [Typeclassopedia](https://wiki.haskell.org/Typeclassopedia) — 型クラス階層の包括的ガイド。Functor, Applicative, Monad の関係を圏論的に解説
-2. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) — TypeScript の関数型プログラミングライブラリ。HKT のエミュレーション手法が参考になる
-3. **Bartosz Milewski**: [Category Theory for Programmers](https://bartoszmilewski.com/2014/10/28/category-theory-for-programmers-the-preface/) — プログラマ向けの圏論入門。ファンクタの数学的背景を理解できる
-4. **Conor McBride, Ross Paterson**: [Applicative Programming with Effects](http://www.staff.city.ac.uk/~ross/papers/Applicative.html) — アプリカティブファンクタの原論文。理論的背景を深く知りたい場合
-5. **Brian Lonsdorf**: [Professor Frisby's Mostly Adequate Guide](https://mostly-adequate.gitbook.io/mostly-adequate-guide/) — JavaScript での関数型プログラミングの実践入門
+1. **Haskell Wiki**: [Typeclassopedia](https://wiki.haskell.org/Typeclassopedia) — A comprehensive guide to the type class hierarchy. Explains the relationship between Functor, Applicative, and Monad from a category-theoretic perspective
+2. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) — Functional programming library for TypeScript. The HKT emulation technique is worth studying
+3. **Bartosz Milewski**: [Category Theory for Programmers](https://bartoszmilewski.com/2014/10/28/category-theory-for-programmers-the-preface/) — An introduction to category theory for programmers. Provides the mathematical background for understanding functors
+4. **Conor McBride, Ross Paterson**: [Applicative Programming with Effects](http://www.staff.city.ac.uk/~ross/papers/Applicative.html) — The original paper on applicative functors. For those who want a deep understanding of the theoretical background
+5. **Brian Lonsdorf**: [Professor Frisby's Mostly Adequate Guide](https://mostly-adequate.gitbook.io/mostly-adequate-guide/) — A practical introduction to functional programming in JavaScript

--- a/03-software-design/design-patterns-guide/docs/03-functional/02-fp-patterns.md
+++ b/03-software-design/design-patterns-guide/docs/03-functional/02-fp-patterns.md
@@ -1,80 +1,80 @@
-# 関数型パターン
+# Functional Patterns
 
-> カリー化、パイプライン、レンズなど、関数型プログラミングの実践的パターンを習得し、合成可能で保守性の高いコードを書く
+> Master practical functional programming patterns such as currying, pipelines, and lenses to write composable and maintainable code
 
-## この章で学ぶこと
+## What You Will Learn in This Chapter
 
-1. **関数合成の基本** — カリー化、部分適用、ポイントフリースタイルの仕組みと使い分け
-2. **パイプラインパターン** — データ変換チェーン、ミドルウェア合成、Railway Oriented Programming
-3. **不変データ操作** — レンズ、Prism、構造共有、Immer との比較
-4. **メモ化と最適化** — 計算キャッシュ、トランスデューサー、遅延評価
-5. **実務応用** — React/Redux での関数型パターン、テスト容易性の向上
+1. **Fundamentals of Function Composition** — How currying, partial application, and point-free style work, and when to use each
+2. **Pipeline Patterns** — Data transformation chains, middleware composition, Railway Oriented Programming
+3. **Immutable Data Manipulation** — Lenses, Prisms, structural sharing, and comparison with Immer
+4. **Memoization and Optimization** — Computation caching, transducers, lazy evaluation
+5. **Practical Applications** — Functional patterns in React/Redux, improving testability
 
 ---
 
-## 前提知識
+## Prerequisites
 
-このガイドを読む前に、以下の知識を持っていることを推奨します。
+Before reading this guide, it is recommended that you have the following knowledge.
 
-| 前提知識 | 参照先 |
+| Prerequisite | Reference |
 |---|---|
-| TypeScript の基本（ジェネリクス、型推論） | [02-programming カテゴリ](../../../../02-programming/) |
-| 高階関数の概念（map, filter, reduce） | JavaScript/TypeScript の基本 |
-| 不変性（Immutability）の基本概念 | クリーンコードの原則 |
-| ファンクタとモナドの基礎 | [ファンクタ・アプリカティブ](./01-functor-applicative.md)、[モナド](./00-monad.md) |
+| TypeScript basics (generics, type inference) | [02-programming category](../../../../02-programming/) |
+| Higher-order function concepts (map, filter, reduce) | JavaScript/TypeScript basics |
+| Basic concept of Immutability | Clean code principles |
+| Basics of Functors and Monads | [Functor & Applicative](./01-functor-applicative.md), [Monad](./00-monad.md) |
 
 ---
 
-## 1. カリー化と部分適用
+## 1. Currying and Partial Application
 
-### 1.1 カリー化とは何か — WHY から理解する
+### 1.1 What Is Currying — Understanding the WHY
 
 ```
-カリー化と部分適用
-====================
+Currying and Partial Application
+==================================
 
-通常の関数:
+Regular function:
   add(a, b) = a + b
   add(3, 5)  --> 8
 
-カリー化:
+Currying:
   add = a => b => a + b
-  add(3)     --> b => 3 + b   (部分適用された関数)
+  add(3)     --> b => 3 + b   (partially applied function)
   add(3)(5)  --> 8
 
-部分適用:
-  add3 = add(3)    // 引数を1つ固定
+Partial Application:
+  add3 = add(3)    // fix one argument
   add3(5)  --> 8
   add3(10) --> 13
 
-利点: 関数の再利用と合成が容易になる
+Benefit: Makes function reuse and composition easier
 ```
 
-**WHY**: なぜカリー化が必要なのか？
+**WHY**: Why do we need currying?
 
-カリー化は一見すると不必要な複雑さに見えますが、以下の3つの重要な利点があります。
+Currying may appear to be unnecessary complexity at first glance, but it provides three important benefits:
 
-1. **関数の再利用**: 引数の一部を固定して特化した関数を作れる
-2. **関数合成**: 1引数関数のチェーンとして合成しやすい
-3. **遅延評価**: 全引数が揃うまで計算を遅延できる
+1. **Function reuse**: Fix some arguments to create specialized functions
+2. **Function composition**: Easier to compose as a chain of single-argument functions
+3. **Lazy evaluation**: Delay computation until all arguments are provided
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│  カリー化の動作イメージ                                 │
+│  How Currying Works                                    │
 │                                                        │
-│  通常の関数: f(a, b, c) → 結果                         │
-│  全引数を一度に渡す                                     │
+│  Regular function: f(a, b, c) → result                 │
+│  Pass all arguments at once                            │
 │                                                        │
-│  カリー化: f(a) → g(b) → h(c) → 結果                  │
-│  引数を1つずつ渡すと、次の関数が返る                    │
+│  Currying: f(a) → g(b) → h(c) → result                │
+│  Pass one argument at a time, each returns the next fn │
 │                                                        │
 │  multiply(2)(5)                                        │
 │       │    │                                           │
-│       │    └─ 最終引数 → 結果 10                       │
-│       └─ 最初の引数 → (b => 2 * b) 関数が返る         │
+│       │    └─ Final argument → result 10               │
+│       └─ First argument → returns function (b => 2 * b)│
 │                                                        │
-│  const double = multiply(2)  ← 部分適用で再利用可能    │
-│  const triple = multiply(3)  ← 別の特化関数も作れる    │
+│  const double = multiply(2)  ← Reusable via partial app│
+│  const triple = multiply(3)  ← Another specialized fn  │
 │                                                        │
 │  double(5)  → 10                                       │
 │  double(7)  → 14                                       │
@@ -82,24 +82,24 @@
 └────────────────────────────────────────────────────────┘
 ```
 
-### コード例 1: カリー化の実装と活用
+### Code Example 1: Implementing and Using Currying
 
 ```typescript
-// === 汎用カリー化関数 ===
+// === General-purpose currying functions ===
 
-// 2引数のカリー化
+// Curry for 2 arguments
 function curry<A, B, C>(fn: (a: A, b: B) => C): (a: A) => (b: B) => C {
   return (a: A) => (b: B) => fn(a, b);
 }
 
-// 3引数のカリー化
+// Curry for 3 arguments
 function curry3<A, B, C, D>(
   fn: (a: A, b: B, c: C) => D
 ): (a: A) => (b: B) => (c: C) => D {
   return (a: A) => (b: B) => (c: C) => fn(a, b, c);
 }
 
-// 任意引数のカリー化（JavaScript の動的な機能を活用）
+// Curry for arbitrary arguments (leveraging JavaScript's dynamic features)
 function curryN(fn: (...args: any[]) => any): (...args: any[]) => any {
   const arity = fn.length;
   return function curried(...args: any[]): any {
@@ -110,7 +110,7 @@ function curryN(fn: (...args: any[]) => any): (...args: any[]) => any {
   };
 }
 
-// === 実用例1: 数値計算 ===
+// === Practical Example 1: Numeric computation ===
 const multiply = curry((a: number, b: number) => a * b);
 const double = multiply(2);
 const triple = multiply(3);
@@ -119,7 +119,7 @@ console.log(double(5));  // 10
 console.log(triple(5));  // 15
 console.log(double(7));  // 14
 
-// === 実用例2: 文字列処理 ===
+// === Practical Example 2: String processing ===
 const prefix = curry((pre: string, str: string) => `${pre}${str}`);
 const addHttps = prefix("https://");
 const addApiPrefix = prefix("/api/v1");
@@ -127,7 +127,7 @@ const addApiPrefix = prefix("/api/v1");
 console.log(addHttps("example.com"));   // "https://example.com"
 console.log(addApiPrefix("/users"));     // "/api/v1/users"
 
-// === 実用例3: フィルタの部分適用 ===
+// === Practical Example 3: Partial application of filters ===
 const filterBy = curry3(
   <T>(key: keyof T, value: T[keyof T], items: T[]) =>
     items.filter(item => item[key] === value)
@@ -155,13 +155,13 @@ console.log(getPendingOrders(orders));
 // [{ id: 2, status: "pending", amount: 200 }]
 ```
 
-### コード例 2: Rust での部分適用
+### Code Example 2: Partial Application in Rust
 
 ```rust
-// Rust ではクロージャで部分適用を実現する
+// In Rust, partial application is achieved using closures
 
 fn main() {
-    // クロージャによる部分適用
+    // Partial application via closures
     let multiply = |a: i32| move |b: i32| a * b;
     let double = multiply(2);
     let triple = multiply(3);
@@ -169,7 +169,7 @@ fn main() {
     println!("double(5) = {}", double(5));  // 10
     println!("triple(5) = {}", triple(5));  // 15
 
-    // 実用例: 文字列フォーマット
+    // Practical example: string formatting
     let format_price = |currency: &str| {
         let currency = currency.to_string();
         move |amount: f64| format!("{}{:.2}", currency, amount)
@@ -181,13 +181,13 @@ fn main() {
     println!("{}", format_usd(19.99));  // $19.99
     println!("{}", format_yen(2000.0)); // ¥2000.00
 
-    // 実用例: バリデーション関数の生成
+    // Practical example: generating validation functions
     let min_length = |min: usize| {
         move |s: &str| -> Result<&str, String> {
             if s.len() >= min {
                 Ok(s)
             } else {
-                Err(format!("{}文字以上必要です（現在{}文字）", min, s.len()))
+                Err(format!("Must be at least {} characters (currently {} characters)", min, s.len()))
             }
         }
     };
@@ -195,46 +195,47 @@ fn main() {
     let validate_username = min_length(3);
     let validate_password = min_length(8);
 
-    println!("{:?}", validate_username("ab"));      // Err("3文字以上必要です（現在2文字）")
+    println!("{:?}", validate_username("ab"));      // Err("Must be at least 3 characters (currently 2 characters)")
     println!("{:?}", validate_username("alice"));    // Ok("alice")
-    println!("{:?}", validate_password("pass"));     // Err("8文字以上必要です（現在4文字）")
+    println!("{:?}", validate_password("pass"));     // Err("Must be at least 8 characters (currently 4 characters)")
     println!("{:?}", validate_password("password123")); // Ok("password123")
 }
 ```
 
-### 1.2 カリー化と部分適用の違い
+### 1.2 Difference Between Currying and Partial Application
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│  カリー化 vs 部分適用                                   │
+│  Currying vs Partial Application                       │
 │                                                        │
-│  ■ カリー化 (Currying):                                │
+│  ■ Currying:                                           │
 │    f(a, b, c) → f(a)(b)(c)                             │
-│    全引数を1つずつ受け取る関数に変換する                │
-│    元の関数の形を変える                                 │
+│    Transforms a function to accept one argument at a   │
+│    time; changes the shape of the original function    │
 │                                                        │
-│  ■ 部分適用 (Partial Application):                     │
-│    f(a, b, c) → g(b, c)   [a を固定]                   │
-│    一部の引数を固定した新しい関数を作る                 │
-│    元の関数を呼び出す際に一部の引数を事前に渡す         │
+│  ■ Partial Application:                                │
+│    f(a, b, c) → g(b, c)   [a is fixed]                 │
+│    Creates a new function with some arguments fixed;   │
+│    passes some arguments upfront when calling the      │
+│    original function                                   │
 │                                                        │
-│  ■ 関係:                                               │
-│    カリー化された関数に引数を1つ渡す                    │
-│    = 部分適用の一形態                                   │
+│  ■ Relationship:                                       │
+│    Passing one argument to a curried function          │
+│    = a form of partial application                     │
 │                                                        │
-│  ■ 実用上の違い:                                       │
-│    カリー化: 関数合成パイプラインで便利                 │
-│    部分適用: 設定値の注入で便利                         │
+│  ■ Practical difference:                               │
+│    Currying: useful in function composition pipelines  │
+│    Partial application: useful for injecting config    │
 └────────────────────────────────────────────────────────┘
 ```
 
 ```typescript
-// 部分適用（カリー化なし）
+// Partial application (without currying)
 function partial<A, B, C>(fn: (a: A, b: B) => C, a: A): (b: B) => C {
   return (b: B) => fn(a, b);
 }
 
-// bind による部分適用（JavaScript 標準）
+// Partial application via bind (JavaScript standard)
 function greet(greeting: string, name: string): string {
   return `${greeting}, ${name}!`;
 }
@@ -247,48 +248,48 @@ console.log(sayHi("Hanako"));   // "Hi, Hanako!"
 
 ---
 
-## 2. パイプラインパターン
+## 2. Pipeline Patterns
 
-### 2.1 パイプラインとは — WHY から理解する
+### 2.1 What Is a Pipeline — Understanding the WHY
 
 ```
-パイプラインの考え方
+The Pipeline Concept
 =====================
 
-データ --> [変換1] --> [変換2] --> [変換3] --> 結果
+Data --> [Transform1] --> [Transform2] --> [Transform3] --> Result
 
-Unix パイプ:
+Unix pipe:
   cat file | grep "error" | sort | uniq -c
 
-関数パイプライン:
+Function pipeline:
   pipe(getData, filter(isActive), map(toDTO), sortBy('name'))
 
-WHY: なぜパイプラインか？
-  1. 宣言的: 「何をするか」を順序通りに記述
-  2. 合成可能: 各ステップが独立、差し替え容易
-  3. テスト容易: 各変換関数を単独でテスト可能
-  4. 読みやすい: データの流れが左→右（上→下）で自然
+WHY: Why pipelines?
+  1. Declarative: describe "what to do" in order
+  2. Composable: each step is independent and swappable
+  3. Testable: each transformation function can be tested in isolation
+  4. Readable: data flows left→right (top→bottom) naturally
 ```
 
 ```
 ┌────────────────────────────────────────────────────────┐
 │  pipe vs compose                                       │
 │                                                        │
-│  pipe:    f → g → h   (左から右、データの流れ順)       │
-│  compose: h ∘ g ∘ f   (右から左、数学的な合成順)       │
+│  pipe:    f → g → h   (left to right, data flow order) │
+│  compose: h ∘ g ∘ f   (right to left, mathematical)    │
 │                                                        │
 │  pipe(f, g, h)(x)    = h(g(f(x)))                     │
 │  compose(h, g, f)(x) = h(g(f(x)))                     │
 │                                                        │
-│  実用上は pipe が読みやすい（データの流れが自然）       │
-│  数学的な議論では compose が使われる                    │
+│  In practice, pipe is more readable (natural data flow)│
+│  compose is used in mathematical discussions           │
 └────────────────────────────────────────────────────────┘
 ```
 
-### コード例 3: 型安全なパイプライン関数
+### Code Example 3: Type-Safe Pipeline Function
 
 ```typescript
-// === 型安全な pipe 関数（オーバーロード） ===
+// === Type-safe pipe function (with overloads) ===
 
 function pipe<A, B>(a: A, ab: (a: A) => B): B;
 function pipe<A, B, C>(a: A, ab: (a: A) => B, bc: (b: B) => C): C;
@@ -302,7 +303,7 @@ function pipe(initial: unknown, ...fns: Function[]): unknown {
   return fns.reduce((acc, fn) => fn(acc), initial);
 }
 
-// === 遅延パイプライン（関数を返す版） ===
+// === Lazy pipeline (returns a function) ===
 
 function pipeWith<A, B>(ab: (a: A) => B): (a: A) => B;
 function pipeWith<A, B, C>(
@@ -315,14 +316,14 @@ function pipeWith(...fns: Function[]): Function {
   return (initial: unknown) => fns.reduce((acc, fn) => fn(acc), initial);
 }
 
-// compose: 右から左
+// compose: right to left
 function compose<A, B, C>(
   bc: (b: B) => C, ab: (a: A) => B
 ): (a: A) => C {
   return (a: A) => bc(ab(a));
 }
 
-// === 実用例: ユーザーデータ変換パイプライン ===
+// === Practical example: user data transformation pipeline ===
 
 interface RawUser {
   first_name: string;
@@ -338,7 +339,7 @@ interface ProcessedUser {
   email: string;
 }
 
-// 各ステップを独立した純粋関数として定義
+// Define each step as an independent pure function
 const filterActive = (users: RawUser[]) =>
   users.filter(u => u.status === "active");
 
@@ -355,7 +356,7 @@ const toProcessedUser = (users: RawUser[]): ProcessedUser[] =>
 const sortByName = (users: ProcessedUser[]) =>
   [...users].sort((a, b) => a.fullName.localeCompare(b.fullName));
 
-// パイプラインとして合成
+// Compose as a pipeline
 const processUsers = pipeWith(
   filterActive,
   filterAdults,
@@ -363,7 +364,7 @@ const processUsers = pipeWith(
   sortByName,
 );
 
-// 使用
+// Usage
 const rawUsers: RawUser[] = [
   { first_name: "Taro", last_name: "Yamada", age: 25, status: "active", email: "TARO@example.com" },
   { first_name: "Hanako", last_name: "Suzuki", age: 16, status: "active", email: "hanako@example.com" },
@@ -379,10 +380,10 @@ console.log(result);
 // ]
 ```
 
-### コード例 4: ミドルウェア合成パターン
+### Code Example 4: Middleware Composition Pattern
 
 ```typescript
-// === Express/Koa スタイルのミドルウェア合成 ===
+// === Express/Koa-style middleware composition ===
 
 type Middleware<T> = (ctx: T, next: () => Promise<void>) => Promise<void>;
 
@@ -399,7 +400,7 @@ function composeMiddleware<T>(...middlewares: Middleware<T>[]): Middleware<T> {
   };
 }
 
-// ミドルウェアの定義
+// Middleware definitions
 interface Context {
   method: string;
   path: string;
@@ -420,7 +421,7 @@ const logger: Middleware<Context> = async (ctx, next) => {
 const auth: Middleware<Context> = async (ctx, next) => {
   const token = ctx.headers.authorization;
   if (!token) throw new Error("Unauthorized: No token provided");
-  // トークン検証（簡略化）
+  // Token validation (simplified)
   ctx.user = { id: "user-1", role: "admin" };
   await next();
 };
@@ -441,10 +442,10 @@ const handler: Middleware<Context> = async (ctx, next) => {
   await next();
 };
 
-// ミドルウェアの合成
+// Compose middleware
 const app = composeMiddleware(errorHandler, logger, auth, handler);
 
-// 使用
+// Usage
 const ctx: Context = {
   method: "GET",
   path: "/api/users",
@@ -459,28 +460,28 @@ console.log(ctx.response); // { status: 200, data: { message: "Hello!" } }
 
 ### 2.2 Railway Oriented Programming
 
-エラーハンドリングをパイプラインに組み込むパターンです。
+A pattern for incorporating error handling into pipelines.
 
 ```
 ┌────────────────────────────────────────────────────────┐
 │  Railway Oriented Programming                          │
 │                                                        │
-│  成功の線路:  ─────[処理1]─────[処理2]─────[処理3]──→  │
-│              ╲           ╲           ╲                  │
-│  失敗の線路:  ─────────────────────────────────────→    │
+│  Success track: ─────[Step1]─────[Step2]─────[Step3]──→│
+│                 ╲           ╲           ╲               │
+│  Failure track:  ─────────────────────────────────────→ │
 │                                                        │
-│  各処理で:                                              │
-│  - 成功 → 成功の線路を継続                              │
-│  - 失敗 → 失敗の線路に切り替え（以降の処理はスキップ） │
+│  At each step:                                         │
+│  - Success → continue on success track                 │
+│  - Failure → switch to failure track (skip remaining)  │
 │                                                        │
-│  Result<E, A> を使って型安全に実現                      │
+│  Achieved type-safely using Result<E, A>               │
 └────────────────────────────────────────────────────────┘
 ```
 
-### コード例 5: Railway Oriented Programming の実装
+### Code Example 5: Implementing Railway Oriented Programming
 
 ```typescript
-// === Result 型の実装 ===
+// === Result type implementation ===
 
 type Result<E, A> =
   | { tag: "Ok"; value: A }
@@ -489,12 +490,12 @@ type Result<E, A> =
 const ok = <E, A>(value: A): Result<E, A> => ({ tag: "Ok", value });
 const err = <E, A>(error: E): Result<E, A> => ({ tag: "Err", error });
 
-// map: 成功時のみ変換（ファンクタ）
+// map: transform only on success (functor)
 function mapR<E, A, B>(result: Result<E, A>, fn: (a: A) => B): Result<E, B> {
   return result.tag === "Ok" ? ok(fn(result.value)) : result;
 }
 
-// flatMap: 成功時のみ次の計算を実行（モナド）
+// flatMap: execute next computation only on success (monad)
 function flatMapR<E, A, B>(
   result: Result<E, A>,
   fn: (a: A) => Result<E, B>
@@ -502,7 +503,7 @@ function flatMapR<E, A, B>(
   return result.tag === "Ok" ? fn(result.value) : result;
 }
 
-// mapError: エラーの変換
+// mapError: transform the error
 function mapError<E1, E2, A>(
   result: Result<E1, A>,
   fn: (e: E1) => E2
@@ -510,7 +511,7 @@ function mapError<E1, E2, A>(
   return result.tag === "Err" ? err(fn(result.error)) : result;
 }
 
-// === Railway パイプライン ===
+// === Railway pipeline ===
 function railway<E, A, B>(
   ...fns: Array<(a: any) => Result<E, any>>
 ): (a: A) => Result<E, B> {
@@ -524,7 +525,7 @@ function railway<E, A, B>(
   };
 }
 
-// === 実用例: ユーザー登録パイプライン ===
+// === Practical example: user registration pipeline ===
 
 interface RegistrationInput {
   username: string;
@@ -557,22 +558,22 @@ type RegistrationError =
   | { type: "duplicate"; field: string }
   | { type: "database"; message: string };
 
-// 各ステップ
+// Each step
 function validateInput(input: RegistrationInput): Result<RegistrationError, ValidatedInput> {
   if (input.username.length < 3) {
-    return err({ type: "validation", message: "ユーザー名は3文字以上" });
+    return err({ type: "validation", message: "Username must be at least 3 characters" });
   }
   if (!input.email.includes("@")) {
-    return err({ type: "validation", message: "無効なメールアドレス" });
+    return err({ type: "validation", message: "Invalid email address" });
   }
   if (input.password.length < 8) {
-    return err({ type: "validation", message: "パスワードは8文字以上" });
+    return err({ type: "validation", message: "Password must be at least 8 characters" });
   }
   return ok(input);
 }
 
 function checkDuplicate(input: ValidatedInput): Result<RegistrationError, ValidatedInput> {
-  // DB チェック（簡略化）
+  // DB check (simplified)
   const existingUsers = ["admin", "root"];
   if (existingUsers.includes(input.username)) {
     return err({ type: "duplicate", field: "username" });
@@ -585,10 +586,10 @@ function hashPassword(input: ValidatedInput): Result<RegistrationError, HashedIn
     return ok({
       username: input.username,
       email: input.email,
-      passwordHash: `hashed_${input.password}`, // 実際にはbcryptを使用
+      passwordHash: `hashed_${input.password}`, // Use bcrypt in production
     });
   } catch {
-    return err({ type: "database", message: "ハッシュ化に失敗" });
+    return err({ type: "database", message: "Failed to hash password" });
   }
 }
 
@@ -600,11 +601,11 @@ function saveToDatabase(input: HashedInput): Result<RegistrationError, User> {
       createdAt: new Date(),
     });
   } catch {
-    return err({ type: "database", message: "保存に失敗" });
+    return err({ type: "database", message: "Failed to save" });
   }
 }
 
-// Railway パイプライン
+// Railway pipeline
 const registerUser = railway<RegistrationError, RegistrationInput, User>(
   validateInput,
   checkDuplicate,
@@ -612,7 +613,7 @@ const registerUser = railway<RegistrationError, RegistrationInput, User>(
   saveToDatabase,
 );
 
-// 使用例
+// Usage examples
 const result1 = registerUser({
   username: "taro",
   email: "taro@example.com",
@@ -625,68 +626,68 @@ const result2 = registerUser({
   email: "bad",
   password: "short",
 });
-console.log(result2); // { tag: "Err", error: { type: "validation", message: "ユーザー名は3文字以上" } }
+console.log(result2); // { tag: "Err", error: { type: "validation", message: "Username must be at least 3 characters" } }
 ```
 
 ---
 
-## 3. 不変データ操作（レンズ）
+## 3. Immutable Data Manipulation (Lenses)
 
-### 3.1 レンズとは — WHY から理解する
+### 3.1 What Is a Lens — Understanding the WHY
 
 ```
-レンズ: 不変データ構造の部分的な読み書き
-=========================================
+Lens: Partial read/write of immutable data structures
+======================================================
 
-深いネストのオブジェクト更新の問題:
+The problem with updating deeply nested objects:
 
-[NG] ミュータブルな直接更新
+[NG] Direct mutable update
   user.address.city = "Tokyo";
-  → 副作用、テスト困難、予測不可能な変更
+  → Side effects, difficult to test, unpredictable changes
 
-[NG] スプレッド地獄
+[NG] Spread hell
   { ...user, address: { ...user.address, city: "Tokyo" } }
-  → ネストが深くなるほど醜くなる
+  → Gets uglier as nesting deepens
 
-[OK] レンズで宣言的に更新
+[OK] Declarative update with lenses
   set(addressCityLens, "Tokyo", user)
-  → 合成可能、型安全、宣言的
+  → Composable, type-safe, declarative
 
-レンズの型:
+Lens type:
   Lens<S, A>
-    get: S -> A          (全体から部分を取得)
-    set: (A, S) -> S     (部分を更新して新しい全体を返す)
+    get: S -> A          (get a part from the whole)
+    set: (A, S) -> S     (update a part and return new whole)
 ```
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│  レンズの動作イメージ                                   │
+│  How Lenses Work                                       │
 │                                                        │
 │  ┌──────────────────┐                                  │
 │  │  User             │                                 │
 │  │  ├─ name: "Taro"  │                                 │
 │  │  └─ address       │ ← addressLens                   │
-│  │     ├─ city: "大阪"│ ← cityLens                     │
+│  │     ├─ city: "Osaka"│ ← cityLens                   │
 │  │     └─ zip: "530"  │                                │
 │  └──────────────────┘                                  │
 │                                                        │
 │  userCityLens = composeLens(addressLens, cityLens)     │
 │                                                        │
-│  get: user → "大阪"                                    │
-│  set("東京", user) → 新しいUser（city: "東京"）        │
-│  over(toUpperCase, user) → 新しいUser（city: "大阪"）  │
+│  get: user → "Osaka"                                   │
+│  set("Tokyo", user) → new User (city: "Tokyo")         │
+│  over(toUpperCase, user) → new User (city: "OSAKA")    │
 │                                                        │
-│  ポイント:                                              │
-│  - 元の user オブジェクトは変更されない（不変）         │
-│  - レンズは合成できる                                   │
-│  - 型安全（TypeScript の型推論が効く）                  │
+│  Key points:                                           │
+│  - Original user object is not changed (immutable)     │
+│  - Lenses can be composed                              │
+│  - Type-safe (TypeScript type inference works)         │
 └────────────────────────────────────────────────────────┘
 ```
 
-### コード例 6: レンズの完全実装
+### Code Example 6: Complete Lens Implementation
 
 ```typescript
-// === レンズの型と基本操作 ===
+// === Lens type and basic operations ===
 
 interface Lens<S, A> {
   get: (s: S) => A;
@@ -700,7 +701,7 @@ function lens<S, A>(
   return { get, set };
 }
 
-// レンズの合成
+// Lens composition
 function composeLens<S, A, B>(outer: Lens<S, A>, inner: Lens<A, B>): Lens<S, B> {
   return {
     get: (s: S) => inner.get(outer.get(s)),
@@ -708,22 +709,22 @@ function composeLens<S, A, B>(outer: Lens<S, A>, inner: Lens<A, B>): Lens<S, B> 
   };
 }
 
-// over: レンズを通して関数を適用
+// over: apply a function through a lens
 function over<S, A>(l: Lens<S, A>, fn: (a: A) => A, s: S): S {
   return l.set(fn(l.get(s)), s);
 }
 
-// view: レンズを通して値を取得（get のエイリアス）
+// view: get a value through a lens (alias for get)
 function view<S, A>(l: Lens<S, A>, s: S): A {
   return l.get(s);
 }
 
-// set: レンズを通して値を設定
+// set: set a value through a lens
 function setL<S, A>(l: Lens<S, A>, a: A, s: S): S {
   return l.set(a, s);
 }
 
-// === プロパティレンズの自動生成 ===
+// === Auto-generating property lenses ===
 function prop<S, K extends keyof S>(key: K): Lens<S, S[K]> {
   return lens(
     (s: S) => s[key],
@@ -731,7 +732,7 @@ function prop<S, K extends keyof S>(key: K): Lens<S, S[K]> {
   );
 }
 
-// === 使用例 ===
+// === Usage examples ===
 
 interface Address {
   city: string;
@@ -745,13 +746,13 @@ interface User {
   address: Address;
 }
 
-// プロパティレンズ
+// Property lenses
 const addressLens = prop<User, "address">("address");
 const cityLens = prop<Address, "city">("city");
 const nameLens = prop<User, "name">("name");
 const ageLens = prop<User, "age">("age");
 
-// レンズの合成
+// Lens composition
 const userCityLens = composeLens(addressLens, cityLens);
 
 const user: User = {
@@ -763,36 +764,36 @@ const user: User = {
 // get
 console.log(view(userCityLens, user)); // "Osaka"
 
-// set — 不変更新
+// set — immutable update
 const updated = setL(userCityLens, "Tokyo", user);
 console.log(updated);
 // { name: "Taro", age: 30, address: { city: "Tokyo", zip: "530-0001", country: "Japan" } }
-console.log(user.address.city); // "Osaka" — 元のオブジェクトは変更されない!
+console.log(user.address.city); // "Osaka" — original object is unchanged!
 
-// over — 関数適用
+// over — apply a function
 const uppercased = over(userCityLens, c => c.toUpperCase(), user);
 console.log(uppercased.address.city); // "OSAKA"
 
-// 複数の更新を合成
+// Compose multiple updates
 const birthday = (u: User): User => {
   const aged = over(ageLens, a => a + 1, u);
-  return over(nameLens, n => `${n} (${aged.age}歳)`, aged);
+  return over(nameLens, n => `${n} (age ${aged.age})`, aged);
 };
 
 console.log(birthday(user));
-// { name: "Taro (31歳)", age: 31, address: { ... } }
+// { name: "Taro (age 31)", age: 31, address: { ... } }
 ```
 
-### 3.2 レンズ vs Immer vs スプレッド構文
+### 3.2 Lens vs Immer vs Spread Syntax
 
-| 手法 | メリット | デメリット | 適用場面 |
+| Approach | Pros | Cons | Best For |
 |---|---|---|---|
-| **スプレッド構文** | 追加ライブラリ不要、直感的 | ネスト深い場合に冗長 | 浅いネスト（1-2段） |
-| **Immer** | ミュータブル風に書ける、構造共有 | ランタイムコスト | 中程度のネスト、Redux |
-| **レンズ** | 合成可能、型安全、再利用可能 | 学習コスト、初期セットアップ | 深いネスト、頻繁な更新 |
+| **Spread syntax** | No extra library needed, intuitive | Verbose for deep nesting | Shallow nesting (1-2 levels) |
+| **Immer** | Write like mutable code, structural sharing | Runtime cost | Moderate nesting, Redux |
+| **Lens** | Composable, type-safe, reusable | Learning curve, initial setup | Deep nesting, frequent updates |
 
 ```typescript
-// === 3つの手法の比較 ===
+// === Comparison of the three approaches ===
 
 const user = {
   name: "Taro",
@@ -805,25 +806,25 @@ const user = {
   },
 };
 
-// 1. スプレッド構文 — 読みにくい
+// 1. Spread syntax — hard to read
 const updated1 = {
   ...user,
   address: {
     ...user.address,
     location: {
       ...user.address.location,
-      lat: 35.68, // 東京の緯度
+      lat: 35.68, // latitude of Tokyo
     },
   },
 };
 
-// 2. Immer — 直感的だがランタイムコスト
+// 2. Immer — intuitive but with runtime cost
 import { produce } from "immer";
 const updated2 = produce(user, draft => {
   draft.address.location.lat = 35.68;
 });
 
-// 3. レンズ — 合成可能で再利用可能
+// 3. Lens — composable and reusable
 const locationLens = composeLens(
   prop<typeof user, "address">("address"),
   composeLens(
@@ -836,38 +837,38 @@ const updated3 = setL(locationLens, 35.68, user);
 
 ---
 
-## 4. メモ化と最適化
+## 4. Memoization and Optimization
 
-### 4.1 メモ化 — WHY から理解する
+### 4.1 Memoization — Understanding the WHY
 
-**WHY**: 純粋関数は同じ入力に対して常に同じ出力を返すため、計算結果をキャッシュして再利用できます。これがメモ化の基本原理です。
+**WHY**: Pure functions always return the same output for the same input, so you can cache and reuse computation results. This is the fundamental principle behind memoization.
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│  メモ化の動作                                           │
+│  How Memoization Works                                 │
 │                                                        │
-│  初回呼び出し:                                          │
-│  fibonacci(10) → 計算実行 → 結果 55 → キャッシュに保存 │
+│  First call:                                           │
+│  fibonacci(10) → compute → result 55 → store in cache  │
 │                                                        │
-│  2回目以降:                                             │
-│  fibonacci(10) → キャッシュヒット → 結果 55（瞬時）    │
+│  Subsequent calls:                                     │
+│  fibonacci(10) → cache hit → result 55 (instant)      │
 │                                                        │
-│  前提条件:                                              │
-│  - 純粋関数であること（副作用なし）                     │
-│  - 参照透過性があること（同じ入力→同じ出力）           │
-│  - 引数空間が有限または頻出パターンがあること           │
+│  Preconditions:                                        │
+│  - Must be a pure function (no side effects)           │
+│  - Must be referentially transparent (same in→same out)│
+│  - Argument space must be finite or have frequent reuse│
 │                                                        │
-│  注意:                                                  │
-│  - メモリ使用量とのトレードオフ                         │
-│  - LRU キャッシュでメモリ制限を設ける                   │
-│  - 引数がオブジェクトの場合はキー生成に注意             │
+│  Caution:                                              │
+│  - Trade-off with memory usage                         │
+│  - Use LRU cache to limit memory                       │
+│  - Be careful with key generation for object arguments │
 └────────────────────────────────────────────────────────┘
 ```
 
-### コード例 7: メモ化の実装
+### Code Example 7: Implementing Memoization
 
 ```typescript
-// === 汎用メモ化関数 ===
+// === General-purpose memoization function ===
 
 function memoize<Args extends unknown[], R>(
   fn: (...args: Args) => R,
@@ -883,14 +884,14 @@ function memoize<Args extends unknown[], R>(
     return result;
   };
 
-  // キャッシュの管理メソッドを追加
+  // Add cache management methods
   (memoized as any).cache = cache;
   (memoized as any).clear = () => cache.clear();
 
   return memoized;
 }
 
-// === LRU キャッシュ付きメモ化 ===
+// === Memoization with LRU cache ===
 
 function memoizeLRU<Args extends unknown[], R>(
   fn: (...args: Args) => R,
@@ -903,7 +904,7 @@ function memoizeLRU<Args extends unknown[], R>(
     const key = keyFn(...args);
     if (cache.has(key)) {
       const value = cache.get(key)!;
-      // LRU: アクセスしたら末尾に移動
+      // LRU: move to end on access
       cache.delete(key);
       cache.set(key, value);
       return value;
@@ -911,7 +912,7 @@ function memoizeLRU<Args extends unknown[], R>(
     const result = fn(...args);
     cache.set(key, result);
     if (cache.size > maxSize) {
-      // 最も古いエントリを削除
+      // Delete the oldest entry
       const oldest = cache.keys().next().value;
       if (oldest !== undefined) cache.delete(oldest);
     }
@@ -919,11 +920,11 @@ function memoizeLRU<Args extends unknown[], R>(
   };
 }
 
-// === TTL（有効期限）付きメモ化 ===
+// === Memoization with TTL (time-to-live) ===
 
 function memoizeTTL<Args extends unknown[], R>(
   fn: (...args: Args) => R,
-  ttlMs: number = 60000 // デフォルト1分
+  ttlMs: number = 60000 // default 1 minute
 ): (...args: Args) => R {
   const cache = new Map<string, { value: R; expiresAt: number }>();
 
@@ -942,44 +943,44 @@ function memoizeTTL<Args extends unknown[], R>(
   };
 }
 
-// === 使用例 ===
+// === Usage examples ===
 
-// 1. フィボナッチ数列
+// 1. Fibonacci sequence
 const fibonacci = memoize((n: number): number =>
   n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2)
 );
 
-console.log(fibonacci(50)); // 12586269025 — 瞬時に計算
+console.log(fibonacci(50)); // 12586269025 — computed instantly
 
-// 2. 高コストなデータ変換
+// 2. Expensive data transformation
 const processLargeDataset = memoizeLRU(
   (data: string[], threshold: number): string[] => {
     console.log("Computing...");
     return data.filter(d => d.length > threshold).sort();
   },
-  50 // 最大50エントリをキャッシュ
+  50 // cache up to 50 entries
 );
 
 const data = ["apple", "banana", "cherry", "date"];
 processLargeDataset(data, 4); // Computing... → ["apple", "banana", "cherry"]
-processLargeDataset(data, 4); // キャッシュヒット → ["apple", "banana", "cherry"]
+processLargeDataset(data, 4); // cache hit → ["apple", "banana", "cherry"]
 
-// 3. API レスポンスのキャッシュ
+// 3. Caching API responses
 const fetchUserCached = memoizeTTL(
   async (userId: string) => {
     const res = await fetch(`/api/users/${userId}`);
     return res.json();
   },
-  30000 // 30秒キャッシュ
+  30000 // cache for 30 seconds
 );
 ```
 
-### コード例 8: Rust でのメモ化
+### Code Example 8: Memoization in Rust
 
 ```rust
 use std::collections::HashMap;
 
-// Rust でのメモ化（HashMap ベース）
+// Memoization in Rust (HashMap-based)
 struct Memoize<F, K, V>
 where
     F: Fn(K) -> V,
@@ -1014,7 +1015,7 @@ where
 }
 
 fn main() {
-    // フィボナッチのメモ化（HashMap使用）
+    // Memoized fibonacci (using HashMap)
     let mut fib_cache: HashMap<u64, u64> = HashMap::new();
 
     fn fib(n: u64, cache: &mut HashMap<u64, u64>) -> u64 {
@@ -1029,31 +1030,31 @@ fn main() {
     println!("fib(50) = {}", fib(50, &mut fib_cache));
     // fib(50) = 12586269025
 
-    // 文字列処理のメモ化
+    // Memoized string processing
     let mut processor = Memoize::new(|s: String| {
         println!("Processing: {}", s);
         s.chars().rev().collect::<String>()
     });
 
     println!("{}", processor.call("hello".to_string())); // Processing: hello → "olleh"
-    println!("{}", processor.call("hello".to_string())); // キャッシュヒット → "olleh"
+    println!("{}", processor.call("hello".to_string())); // cache hit → "olleh"
     println!("{}", processor.call("world".to_string())); // Processing: world → "dlrow"
 }
 ```
 
-### 4.2 トランスデューサー
+### 4.2 Transducers
 
 ```typescript
-// === トランスデューサー: 中間配列なしの変換合成 ===
+// === Transducers: composing transformations without intermediate arrays ===
 
-// 問題: 通常のチェーンは各ステップで中間配列を作る
+// Problem: ordinary chaining creates an intermediate array at each step
 const result1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-  .filter(x => x % 2 === 0)  // [2, 4, 6, 8, 10] — 中間配列1
-  .map(x => x * 10)           // [20, 40, 60, 80, 100] — 中間配列2
-  .filter(x => x > 30);       // [40, 60, 80, 100] — 中間配列3
-// 3回の配列走査、3つの中間配列
+  .filter(x => x % 2 === 0)  // [2, 4, 6, 8, 10] — intermediate array 1
+  .map(x => x * 10)           // [20, 40, 60, 80, 100] — intermediate array 2
+  .filter(x => x > 30);       // [40, 60, 80, 100] — intermediate array 3
+// 3 array traversals, 3 intermediate arrays
 
-// 解決: トランスデューサーは変換を合成し、1回の走査で処理
+// Solution: transducers compose transformations, processing in a single pass
 type Reducer<A, B> = (acc: B, value: A) => B;
 type Transducer<A, B> = <C>(reducer: Reducer<B, C>) => Reducer<A, C>;
 
@@ -1085,7 +1086,7 @@ function transduce<A, B, C>(
   return input.reduce(composed, initial);
 }
 
-// 使用例
+// Usage example
 const xform = composeT(
   filterT<number>(x => x % 2 === 0),
   composeT(
@@ -1102,21 +1103,21 @@ const result2 = transduce(
 );
 
 console.log(result2); // [40, 60, 80, 100]
-// 1回の走査、中間配列なし!
+// Single traversal, no intermediate arrays!
 ```
 
 ---
 
-## 5. 実務での関数型パターン
+## 5. Functional Patterns in Practice
 
-### 5.1 React/Redux での関数型パターン
+### 5.1 Functional Patterns in React/Redux
 
 ```typescript
-// === React Hooks と関数型パターン ===
+// === React Hooks and functional patterns ===
 
-// 1. useMemo — メモ化
+// 1. useMemo — memoization
 function ExpensiveComponent({ data, filter }: Props) {
-  // data や filter が変わらない限り再計算しない
+  // Does not recompute unless data or filter changes
   const processed = useMemo(
     () => data.filter(filter).sort(compareFn).map(toDisplayItem),
     [data, filter]
@@ -1125,13 +1126,13 @@ function ExpensiveComponent({ data, filter }: Props) {
   return <List items={processed} />;
 }
 
-// 2. useReducer — 状態遷移の関数型モデル
+// 2. useReducer — functional model of state transitions
 type Action =
   | { type: "ADD_ITEM"; payload: Item }
   | { type: "REMOVE_ITEM"; payload: string }
   | { type: "UPDATE_ITEM"; payload: { id: string; changes: Partial<Item> } };
 
-// Reducer は純粋関数: (State, Action) → State
+// Reducer is a pure function: (State, Action) → State
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "ADD_ITEM":
@@ -1153,7 +1154,7 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-// 3. カスタムフック — 関数の合成
+// 3. Custom hooks — function composition
 function useFilteredSortedData<T>(
   data: T[],
   filterFn: (item: T) => boolean,
@@ -1169,10 +1170,10 @@ function useFilteredSortedData<T>(
 }
 ```
 
-### コード例 9: Redux Toolkit と関数型パターン
+### Code Example 9: Redux Toolkit and Functional Patterns
 
 ```typescript
-// === Redux Toolkit（Immer ベース）===
+// === Redux Toolkit (Immer-based) ===
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
@@ -1185,7 +1186,7 @@ const todoSlice = createSlice({
   name: "todos",
   initialState: { items: [], filter: "all" } as TodoState,
   reducers: {
-    // Immer により、ミュータブル風に書いても不変更新される
+    // Immer allows mutable-style writing while keeping updates immutable
     addTodo: (state, action: PayloadAction<string>) => {
       state.items.push({
         id: Date.now().toString(),
@@ -1203,7 +1204,7 @@ const todoSlice = createSlice({
   },
 });
 
-// Selector — 純粋関数でデータを導出
+// Selector — derive data using pure functions
 const selectFilteredTodos = (state: RootState): Todo[] => {
   const { items, filter } = state.todos;
   switch (filter) {
@@ -1216,7 +1217,7 @@ const selectFilteredTodos = (state: RootState): Todo[] => {
   }
 };
 
-// メモ化されたセレクタ（reselect パターン）
+// Memoized selector (reselect pattern)
 import { createSelector } from "@reduxjs/toolkit";
 
 const selectTodos = (state: RootState) => state.todos.items;
@@ -1234,10 +1235,10 @@ const selectFilteredTodosMemoized = createSelector(
 );
 ```
 
-### コード例 10: fp-ts を使った関数型プログラミング
+### Code Example 10: Functional Programming with fp-ts
 
 ```typescript
-// === fp-ts: TypeScript の本格的な関数型ライブラリ ===
+// === fp-ts: a full-featured functional programming library for TypeScript ===
 
 import { pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
@@ -1245,7 +1246,7 @@ import * as E from "fp-ts/Either";
 import * as A from "fp-ts/Array";
 import * as TE from "fp-ts/TaskEither";
 
-// 1. Option（Maybe）の使用
+// 1. Using Option (Maybe)
 const getUser = (id: string): O.Option<User> =>
   id === "1" ? O.some({ id: "1", name: "Taro", age: 30 }) : O.none;
 
@@ -1257,24 +1258,24 @@ const result1 = pipe(
 );
 console.log(result1); // "TARO"
 
-// 2. Either（Result）の使用
+// 2. Using Either (Result)
 const parseAge = (s: string): E.Either<string, number> => {
   const n = parseInt(s, 10);
-  return isNaN(n) ? E.left("無効な数値") : E.right(n);
+  return isNaN(n) ? E.left("Invalid number") : E.right(n);
 };
 
 const validateAge = (age: number): E.Either<string, number> =>
-  age >= 0 && age <= 150 ? E.right(age) : E.left("年齢の範囲外");
+  age >= 0 && age <= 150 ? E.right(age) : E.left("Age out of range");
 
 const result2 = pipe(
   parseAge("25"),
   E.flatMap(validateAge),
-  E.map(age => `年齢: ${age}歳`),
-  E.getOrElse(err => `エラー: ${err}`)
+  E.map(age => `Age: ${age}`),
+  E.getOrElse(err => `Error: ${err}`)
 );
-console.log(result2); // "年齢: 25歳"
+console.log(result2); // "Age: 25"
 
-// 3. 配列操作
+// 3. Array operations
 const users: User[] = [
   { id: "1", name: "Taro", age: 30 },
   { id: "2", name: "Hanako", age: 17 },
@@ -1289,7 +1290,7 @@ const adultNames = pipe(
 );
 console.log(adultNames); // ["Jiro", "Taro"]
 
-// 4. TaskEither（非同期 + エラーハンドリング）
+// 4. TaskEither (async + error handling)
 const fetchUser = (id: string): TE.TaskEither<Error, User> =>
   TE.tryCatch(
     () => fetch(`/api/users/${id}`).then(r => r.json()),
@@ -1302,7 +1303,7 @@ const fetchOrders = (userId: string): TE.TaskEither<Error, Order[]> =>
     (err) => new Error(`Failed to fetch orders: ${err}`)
   );
 
-// パイプラインで合成
+// Compose using a pipeline
 const getUserWithOrders = (userId: string) =>
   pipe(
     fetchUser(userId),
@@ -1317,122 +1318,122 @@ const getUserWithOrders = (userId: string) =>
 
 ---
 
-## 関数型パターン一覧比較表
+## Functional Pattern Comparison Table
 
-| パターン | 目的 | TypeScript での実現 | Rust での実現 | Haskell |
+| Pattern | Purpose | TypeScript Implementation | Rust Implementation | Haskell |
 |---|---|---|---|---|
-| **カリー化** | 部分適用で関数を再利用 | arrow function / curry() | クロージャ | デフォルト |
-| **パイプライン** | データ変換の宣言的記述 | pipe() 関数 | メソッドチェーン | `$` / `|>` |
-| **レンズ** | 不変データの部分更新 | 手動実装 / Ramda | なし（所有権で管理） | lens パッケージ |
-| **メモ化** | 計算結果のキャッシュ | Map / useMemo | HashMap | MVar / IORef |
-| **トランスデューサー** | 中間配列なしの変換合成 | reduce ベース | Iterator アダプタ | conduit |
-| **パターンマッチ** | データ構造の分解と分岐 | 型ガード / switch | match 式 | case / pattern |
-| **Railway** | エラーハンドリング | Result 型 | Result<T, E> | Either |
+| **Currying** | Reuse functions via partial application | arrow function / curry() | Closures | Default |
+| **Pipeline** | Declarative description of data transformation | pipe() function | Method chaining | `$` / `|>` |
+| **Lens** | Partial updates to immutable data | Manual / Ramda | None (managed via ownership) | lens package |
+| **Memoization** | Cache computation results | Map / useMemo | HashMap | MVar / IORef |
+| **Transducer** | Compose transformations without intermediate arrays | reduce-based | Iterator adapters | conduit |
+| **Pattern matching** | Destructure and branch on data structures | Type guards / switch | match expression | case / pattern |
+| **Railway** | Error handling pipeline | Result type | Result<T, E> | Either |
 
-### 関数型 vs 手続き型比較表
+### Functional vs Imperative Comparison Table
 
-| 側面 | 関数型 | 手続き型 |
+| Aspect | Functional | Imperative |
 |---|---|---|
-| **状態管理** | 不変データ + 新しい値を返す | ミュータブル変数を直接変更 |
-| **制御フロー** | 再帰、高階関数、パイプライン | ループ、条件分岐 |
-| **副作用** | 分離して管理（IO モナド等） | どこでも発生 |
-| **テスト容易性** | 高い（参照透過性、純粋関数） | 低い（状態依存、モック必要） |
-| **並行性** | 安全（共有状態なし） | 危険（競合状態） |
-| **デバッグ** | 値の追跡が容易 | 状態の追跡が困難 |
-| **パフォーマンス** | GC 依存、構造共有で改善 | 直接メモリ操作で高速 |
-| **学習コスト** | 高い（抽象概念が多い） | 低い（直感的） |
+| **State management** | Immutable data + return new values | Directly mutate mutable variables |
+| **Control flow** | Recursion, higher-order functions, pipelines | Loops, conditionals |
+| **Side effects** | Isolated and managed (IO monad, etc.) | Can occur anywhere |
+| **Testability** | High (referential transparency, pure functions) | Low (state-dependent, requires mocks) |
+| **Concurrency** | Safe (no shared state) | Dangerous (race conditions) |
+| **Debugging** | Easy to trace values | Difficult to trace state |
+| **Performance** | GC-dependent, improved with structural sharing | Fast via direct memory manipulation |
+| **Learning curve** | High (many abstract concepts) | Low (intuitive) |
 
 ---
 
-## アンチパターン
+## Anti-Patterns
 
-### 1. 過度なポイントフリースタイル
+### 1. Excessive Point-Free Style
 
 ```typescript
-// [NG] 引数名を省略しすぎて可読性が著しく低下
+// [NG] Omitting argument names too aggressively, severely hurting readability
 const process = pipe(
   filter(propEq("active", true)),
   map(pick(["id", "name"])),
   sortBy(prop("name"))
 );
-// 何を処理しているか読み取りにくい
-// デバッグ時にどのステップで問題が起きたか追いにくい
+// Hard to tell what is being processed
+// Hard to debug which step caused an issue
 
-// [OK] 適度な命名で意図を明確にする
+// [OK] Use descriptive names to clarify intent
 const getActiveUserNames = (users: User[]) =>
   users
     .filter(u => u.active)
     .map(u => ({ id: u.id, name: u.name }))
     .sort((a, b) => a.name.localeCompare(b.name));
-// 引数名があるので何を処理しているか一目瞭然
+// Argument names make it immediately clear what is being processed
 ```
 
-### 2. 不適切なメモ化
+### 2. Inappropriate Memoization
 
 ```typescript
-// [NG] 副作用のある関数をメモ化
+// [NG] Memoizing a function with side effects
 const badMemo = memoize((url: string) => {
-  console.log(`Fetching: ${url}`);  // 副作用!
+  console.log(`Fetching: ${url}`);  // Side effect!
   return fetch(url).then(r => r.json());
 });
-// 2回目の呼び出しで console.log が実行されない → ログが不完全に
+// console.log won't run on the second call → incomplete logs
 
-// [NG] 引数空間が巨大な関数をメモ化
+// [NG] Memoizing a function with a huge argument space
 const badMemo2 = memoize((data: number[]) => {
   return data.reduce((a, b) => a + b, 0);
 });
-// 異なる配列が毎回渡される → キャッシュが効かずメモリだけ消費
+// Different arrays passed every time → cache never hits, only consumes memory
 
-// [OK] 純粋関数をメモ化 + LRU でメモリ制限
+// [OK] Memoize pure functions + limit memory with LRU
 const goodMemo = memoizeLRU(
   (n: number): number => {
-    // 重い計算（副作用なし）
+    // Expensive computation (no side effects)
     return fibonacci(n);
   },
-  1000 // 最大1000エントリ
+  1000 // up to 1000 entries
 );
 ```
 
-### 3. 不必要な不変性強制
+### 3. Unnecessary Immutability Enforcement
 
 ```typescript
-// [NG] ループ内で毎回新しい配列を作成（パフォーマンス問題）
+// [NG] Creating a new array on every iteration (performance issue)
 function buildLargeArray(n: number): number[] {
   let result: number[] = [];
   for (let i = 0; i < n; i++) {
-    result = [...result, i]; // O(n) のコピーが n 回 = O(n²)
+    result = [...result, i]; // O(n) copy repeated n times = O(n²)
   }
   return result;
 }
 
-// [OK] ローカルスコープ内ではミュータブルを許可し、結果を不変として返す
+// [OK] Allow mutation within local scope, return the result as immutable
 function buildLargeArrayGood(n: number): readonly number[] {
-  const result: number[] = []; // ローカルでミュータブル
+  const result: number[] = []; // mutable locally
   for (let i = 0; i < n; i++) {
-    result.push(i); // O(1) の push が n 回 = O(n)
+    result.push(i); // O(1) push repeated n times = O(n)
   }
-  return result; // 不変な readonly として返す
+  return result; // return as immutable readonly
 }
 ```
 
 ---
 
-## 実践演習
+## Practice Exercises
 
-### 演習1（基礎）: カリー化とパイプラインの実装
+### Exercise 1 (Beginner): Implement Currying and Pipelines
 
-**課題**: 以下の要件を満たす関数を実装してください。
+**Task**: Implement functions that satisfy the following requirements.
 
-1. `curry2` と `curry3` を実装する
-2. `pipe` 関数を実装する（2〜5ステップ）
-3. カリー化した関数をパイプラインで合成して、文字列変換パイプラインを作る
+1. Implement `curry2` and `curry3`
+2. Implement a `pipe` function (2–5 steps)
+3. Compose curried functions in a pipeline to build a string transformation pipeline
 
 ```typescript
-// TODO: curry2, curry3 を実装
+// TODO: implement curry2 and curry3
 
-// TODO: pipe を実装
+// TODO: implement pipe
 
-// テストケース
+// Test cases
 const trim = (s: string) => s.trim();
 const toLower = (s: string) => s.toLowerCase();
 const addPrefix = curry2((prefix: string, s: string) => `${prefix}${s}`);
@@ -1443,20 +1444,20 @@ console.log(normalizeEmail("  TARO@Example.COM  "));
 // "mailto:taro@example.com"
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
 normalizeEmail("  TARO@Example.COM  ") = "mailto:taro@example.com"
 ```
 
-### 演習2（応用）: レンズによる不変データ更新
+### Exercise 2 (Intermediate): Immutable Data Updates with Lenses
 
-**課題**: レンズパターンを使って、ネストしたデータ構造の不変更新を実装してください。
+**Task**: Use the lens pattern to implement immutable updates for a nested data structure.
 
-要件:
-1. `lens`, `composeLens`, `over`, `prop` を実装する
-2. 以下のデータ構造に対して、レンズを使った操作を行う
-3. 元のオブジェクトが変更されていないことをテストで確認する
+Requirements:
+1. Implement `lens`, `composeLens`, `over`, and `prop`
+2. Perform lens-based operations on the following data structure
+3. Verify in tests that the original object has not been modified
 
 ```typescript
 interface Company {
@@ -1471,9 +1472,9 @@ interface Company {
   employees: number;
 }
 
-// TODO: レンズを実装
+// TODO: implement lenses
 
-// テストケース
+// Test cases
 const company: Company = {
   name: "TechCorp",
   ceo: {
@@ -1483,164 +1484,164 @@ const company: Company = {
   employees: 500,
 };
 
-// CEO の住所の都市名を更新
+// Update the CEO's city
 const updated = setL(ceoCityLens, "Osaka", company);
 console.log(updated.ceo.address.city); // "Osaka"
-console.log(company.ceo.address.city); // "Tokyo" ← 元は変更されていない
+console.log(company.ceo.address.city); // "Tokyo" ← original is unchanged
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-更新後: Osaka
-元データ: Tokyo（変更されていない）
-over で大文字化: TOKYO
+Updated: Osaka
+Original: Tokyo (unchanged)
+Uppercased via over: TOKYO
 ```
 
-### 演習3（発展）: Railway Oriented Programming の実装
+### Exercise 3 (Advanced): Implementing Railway Oriented Programming
 
-**課題**: Result 型と Railway パイプラインを実装し、EC サイトの注文処理フローを構築してください。
+**Task**: Implement the Result type and a Railway pipeline to build an order processing flow for an e-commerce site.
 
-要件:
-1. `Result<E, A>` 型と `ok`, `err`, `flatMapR` を実装
-2. 以下の処理ステップを Result を返す関数として実装:
-   - `validateOrder`: 注文内容の検証
-   - `checkStock`: 在庫確認
-   - `calculatePrice`: 価格計算（割引適用）
-   - `processPayment`: 支払い処理
-   - `createShipment`: 配送手配
-3. railway パイプラインで全ステップを合成
-4. 各ステップでのエラーが適切に伝播されることを確認
+Requirements:
+1. Implement the `Result<E, A>` type along with `ok`, `err`, and `flatMapR`
+2. Implement the following processing steps as functions returning Result:
+   - `validateOrder`: validate order contents
+   - `checkStock`: check inventory
+   - `calculatePrice`: calculate price (apply discounts)
+   - `processPayment`: handle payment
+   - `createShipment`: arrange shipping
+3. Compose all steps using a railway pipeline
+4. Verify that errors from each step propagate correctly
 
 ```typescript
-// TODO: Result 型と Railway パイプラインを実装
+// TODO: implement Result type and Railway pipeline
 
-// テストケース
+// Test cases
 const result1 = processOrder({
   items: [{ productId: "p1", quantity: 2 }],
   paymentMethod: "credit_card",
   shippingAddress: "Tokyo",
 });
-// 期待: Ok({ orderId: "...", status: "shipped", ... })
+// Expected: Ok({ orderId: "...", status: "shipped", ... })
 
 const result2 = processOrder({
   items: [],
   paymentMethod: "credit_card",
   shippingAddress: "Tokyo",
 });
-// 期待: Err({ step: "validation", message: "注文に商品が含まれていません" })
+// Expected: Err({ step: "validation", message: "Order contains no items" })
 ```
 
-**期待される出力**:
+**Expected output**:
 
 ```
-テスト1 (正常注文):
+Test 1 (valid order):
   Ok: { orderId: "order_...", status: "shipped", total: 5000 }
 
-テスト2 (空の注文):
-  Err: { step: "validation", message: "注文に商品が含まれていません" }
+Test 2 (empty order):
+  Err: { step: "validation", message: "Order contains no items" }
 
-テスト3 (在庫不足):
-  Err: { step: "stock", message: "商品 p99 の在庫が不足しています" }
+Test 3 (out of stock):
+  Err: { step: "stock", message: "Insufficient stock for product p99" }
 ```
 
 ---
 
 ## FAQ
 
-### Q1: カリー化は JavaScript/TypeScript で実用的ですか？
+### Q1: Is currying practical in JavaScript/TypeScript?
 
-**A**: 部分適用は非常に実用的ですが、フルカリー化は TypeScript の型推論と相性が悪い場合があります。実用的なアプローチとして:
+**A**: Partial application is very practical, but full currying can conflict with TypeScript's type inference in some cases. Practical approaches include:
 
-- `lodash/fp` や `ramda` の `curry` を使う
-- arrow function での手動部分適用: `const double = multiply(2);`
-- TypeScript 5.x 以降では const type parameter の改善により、カリー化の型推論が向上
+- Use `curry` from `lodash/fp` or `ramda`
+- Manual partial application with arrow functions: `const double = multiply(2);`
+- TypeScript 5.x and later improved type inference for currying via const type parameters
 
-ポイントは「必要な箇所だけ部分適用する」ことです。全ての関数をカリー化する必要はありません。
+The key is to "use partial application only where it's needed." There is no need to curry every function.
 
-### Q2: パイプライン演算子 (`|>`) は使えますか？
+### Q2: Can I use the pipeline operator (`|>`)?
 
-**A**: JavaScript の TC39 提案（Stage 2）として進行中ですが、2026年時点では標準化されていません。代替手段:
+**A**: It is progressing as a TC39 proposal (Stage 2) for JavaScript, but as of 2026 it has not been standardized. Alternatives include:
 
-1. `pipe()` ユーティリティ関数（fp-ts, ramda 等）
-2. メソッドチェーン（Array.map().filter() 等）
-3. Babel プラグインでの先行使用（本番環境では非推奨）
+1. `pipe()` utility functions (fp-ts, ramda, etc.)
+2. Method chaining (Array.map().filter(), etc.)
+3. Early adoption via Babel plugin (not recommended for production)
 
-### Q3: Immutable.js や Immer は必要ですか？
+### Q3: Do I need Immutable.js or Immer?
 
-**A**: プロジェクトの規模と複雑さに依存します:
+**A**: It depends on the scale and complexity of your project:
 
-- **小規模（浅いネスト）**: スプレッド構文で十分
-- **中規模（Redux 使用）**: Immer が推奨（Redux Toolkit に内蔵）
-- **大規模（深いネスト、頻繁な更新）**: レンズパターンまたは Immer
-- **Immutable.js**: 構造共有による効率的な不変データ。ただし plain JS との変換コストがある
+- **Small scale (shallow nesting)**: Spread syntax is sufficient
+- **Medium scale (using Redux)**: Immer is recommended (built into Redux Toolkit)
+- **Large scale (deep nesting, frequent updates)**: Lens pattern or Immer
+- **Immutable.js**: Efficient immutable data via structural sharing, but has conversion costs to/from plain JS
 
-### Q4: 関数型プログラミングはパフォーマンスが悪いのでは？
+### Q4: Doesn't functional programming have poor performance?
 
-**A**: 一般的なWebアプリケーションではパフォーマンスの差は無視できるレベルです。不変更新はオブジェクトのコピーコストがありますが、以下の最適化が可能です:
+**A**: In typical web applications, the performance difference is negligible. Immutable updates have object copy costs, but the following optimizations are possible:
 
-- **構造共有**: Immer や Immutable.js は変更されない部分を共有
-- **メモ化**: 再計算を避けて高速化
-- **遅延評価**: 必要になるまで計算を遅延
-- **トランスデューサー**: 中間配列の削減
+- **Structural sharing**: Immer and Immutable.js share unchanged parts
+- **Memoization**: Avoid recomputation for speed
+- **Lazy evaluation**: Delay computation until needed
+- **Transducers**: Reduce intermediate arrays
 
-パフォーマンスが本当に問題になるのは、大量データの繰り返し処理やリアルタイム処理の場合のみです。
+Performance only becomes a real concern for repeated processing of large data volumes or real-time processing scenarios.
 
-### Q5: 関数型パターンを段階的に導入するには？
+### Q5: How do I introduce functional patterns incrementally?
 
-**A**: 以下の順序で段階的に導入するのが効果的です:
+**A**: Introducing them in the following order is effective:
 
-1. **不変性**: `const` の使用、スプレッド構文、`Array.map/filter/reduce`
-2. **純粋関数**: 副作用のない関数を意識的に書く
-3. **パイプライン**: データ変換をパイプラインとして記述
-4. **Result/Option**: null チェックやエラーハンドリングの型安全化
-5. **レンズ/メモ化**: 必要に応じて高度なパターンを導入
+1. **Immutability**: Use `const`, spread syntax, `Array.map/filter/reduce`
+2. **Pure functions**: Consciously write functions without side effects
+3. **Pipelines**: Describe data transformations as pipelines
+4. **Result/Option**: Make null checks and error handling type-safe
+5. **Lenses/Memoization**: Introduce advanced patterns as needed
 
-一気に全てを導入する必要はありません。
+There is no need to introduce everything at once.
 
-### Q6: OOP と関数型プログラミングは共存できますか？
+### Q6: Can OOP and functional programming coexist?
 
-**A**: はい、多くの現代的な言語（TypeScript, Kotlin, Scala, Rust）は両方のパラダイムをサポートしています。実践的な指針:
+**A**: Yes, many modern languages (TypeScript, Kotlin, Scala, Rust) support both paradigms. Practical guidelines:
 
-- **データの変換**: 関数型（map, filter, pipe）
-- **状態のカプセル化**: OOP（クラス、モジュール）
-- **副作用の管理**: 関数型（純粋関数 + 副作用の分離）
-- **抽象化**: 両方（インターフェース + 高階関数）
+- **Data transformation**: functional (map, filter, pipe)
+- **State encapsulation**: OOP (classes, modules)
+- **Side effect management**: functional (pure functions + isolating side effects)
+- **Abstraction**: both (interfaces + higher-order functions)
 
 ---
 
-## まとめ
+## Summary
 
-| 項目 | 要点 |
+| Topic | Key Points |
 |---|---|
-| カリー化 | 引数を1つずつ受け取る関数に変換。部分適用で再利用性向上 |
-| 部分適用 | 一部の引数を固定した新しい関数を生成。設定値の注入に便利 |
-| パイプライン | データ変換を宣言的に記述。可読性と保守性の向上 |
-| compose | 右から左への関数合成。数学的な合成順序 |
-| pipe | 左から右への関数合成。データの流れが自然 |
-| Railway | Result 型を使ったエラーハンドリングパイプライン |
-| レンズ | 不変データ構造の部分的な読み書きを合成可能に |
-| メモ化 | 純粋関数の計算結果をキャッシュ。再計算を回避 |
-| トランスデューサー | 中間配列なしの変換合成。メモリ効率と速度の改善 |
-| ミドルウェア | 関数合成による横断的関心事の分離 |
-| 実践指針 | 可読性とのバランスが重要。段階的導入がベスト |
+| Currying | Transform a function to accept one argument at a time. Improves reusability via partial application |
+| Partial application | Generate a new function with some arguments fixed. Useful for injecting configuration values |
+| Pipeline | Describe data transformations declaratively. Improves readability and maintainability |
+| compose | Function composition from right to left. Mathematical composition order |
+| pipe | Function composition from left to right. Natural data flow |
+| Railway | Error-handling pipeline using the Result type |
+| Lens | Enable composable partial read/write of immutable data structures |
+| Memoization | Cache results of pure functions. Avoid recomputation |
+| Transducer | Compose transformations without intermediate arrays. Improves memory efficiency and speed |
+| Middleware | Separation of cross-cutting concerns via function composition |
+| Practical guideline | Balance with readability is key. Incremental adoption is best |
 
 ---
 
-## 次に読むべきガイド
+## Guides to Read Next
 
-- [モナド](./00-monad.md) — 関数合成のより高度な抽象化
-- [ファンクタ・アプリカティブ](./01-functor-applicative.md) — map と ap の理論的基盤
-- クリーンコードの原則 — 読みやすいコードの基本
-- [ビヘイビアパターン](../02-behavioral/) — OOP パターンとの比較
-- [アーキテクチャパターン](../04-architectural/) — 大規模設計での関数型アプローチ
+- [Monad](./00-monad.md) — A more advanced abstraction for function composition
+- [Functor & Applicative](./01-functor-applicative.md) — Theoretical foundation of map and ap
+- Clean Code Principles — Basics of writing readable code
+- [Behavioral Patterns](../02-behavioral/) — Comparison with OOP patterns
+- [Architectural Patterns](../04-architectural/) — Functional approaches in large-scale design
 
 ---
 
-## 参考文献
+## References
 
-1. **Eric Elliott**: [Composing Software](https://medium.com/javascript-scene/composing-software-an-introduction-27b72500d6ea) — JavaScript での関数型プログラミングの実践的シリーズ
-2. **Brian Lonsdorf**: [Professor Frisby's Mostly Adequate Guide](https://mostly-adequate.gitbook.io/mostly-adequate-guide/) — 関数型プログラミングの入門ガイド（JavaScript ベース）
-3. **Ramda Documentation**: [Ramda](https://ramdajs.com/) — JavaScript の関数型ユーティリティライブラリ。カリー化とパイプラインの実践例が豊富
-4. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) — TypeScript の本格的な関数型プログラミングライブラリ
-5. **Scott Wlaschin**: [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) — エラーハンドリングの関数型アプローチ。F# だが概念は言語非依存
+1. **Eric Elliott**: [Composing Software](https://medium.com/javascript-scene/composing-software-an-introduction-27b72500d6ea) — A practical series on functional programming in JavaScript
+2. **Brian Lonsdorf**: [Professor Frisby's Mostly Adequate Guide](https://mostly-adequate.gitbook.io/mostly-adequate-guide/) — An introductory guide to functional programming (JavaScript-based)
+3. **Ramda Documentation**: [Ramda](https://ramdajs.com/) — A functional utility library for JavaScript. Rich in practical examples of currying and pipelines
+4. **Giulio Canti**: [fp-ts](https://gcanti.github.io/fp-ts/) — A full-featured functional programming library for TypeScript
+5. **Scott Wlaschin**: [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) — A functional approach to error handling. Written in F# but the concepts are language-agnostic

--- a/03-software-design/design-patterns-guide/docs/04-architectural/00-mvc-mvvm.md
+++ b/03-software-design/design-patterns-guide/docs/04-architectural/00-mvc-mvvm.md
@@ -1,80 +1,80 @@
-# MVC / MVVM — UI 設計パターン比較
+# MVC / MVVM — UI Design Pattern Comparison
 
-> MVC、MVP、MVVM の 3 つの UI アーキテクチャパターンを比較し、フレームワークやプラットフォームに応じた最適な選択を行うための実践ガイド。各パターンの歴史的背景、データフロー、テスト戦略、アンチパターンまで、実務で必要な全知識を網羅する。
+> A practical guide for comparing the three UI architecture patterns — MVC, MVP, and MVVM — and choosing the best fit for your framework and platform. Covers historical background, data flow, testing strategies, and anti-patterns — everything you need for real-world work.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| オブジェクト指向プログラミング | 基礎（クラス、インターフェース） | [02-programming](../../../../02-programming/) |
-| TypeScript / JavaScript 基礎 | 中級（型、非同期処理） | [02-programming](../../../../02-programming/) |
-| HTML / CSS / DOM の基本 | 基礎 | [04-web-and-network](../../../../04-web-and-network/) |
-| デザインパターンの基本概念 | 基礎（Observer、Strategy） | ../01-creational/ |
-| クリーンコード原則 | 基礎（関心の分離、単一責任原則） | ../../clean-code-principles/ |
+| Object-Oriented Programming | Basics (classes, interfaces) | [02-programming](../../../../02-programming/) |
+| TypeScript / JavaScript Fundamentals | Intermediate (types, async) | [02-programming](../../../../02-programming/) |
+| HTML / CSS / DOM Basics | Basics | [04-web-and-network](../../../../04-web-and-network/) |
+| Core Design Pattern Concepts | Basics (Observer, Strategy) | ../01-creational/ |
+| Clean Code Principles | Basics (separation of concerns, SRP) | ../../clean-code-principles/ |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. **MVC（Model-View-Controller）** の構造と Web フレームワークでの実装、サーバーサイド・クライアントサイドでの違い
-2. **MVP（Model-View-Presenter）** の特徴と MVC からの改善点、テスト容易性の向上
-3. **MVVM（Model-View-ViewModel）** のデータバインディングとリアクティブ設計、現代フレームワークでの適用
-4. **各パターンの使い分け** — フレームワーク・プラットフォーム別の最適解と移行戦略
-5. **テスト戦略** — 各パターンにおけるユニットテスト・統合テストの書き方
+1. **MVC (Model-View-Controller)** — structure, implementation in web frameworks, and the differences between server-side and client-side usage
+2. **MVP (Model-View-Presenter)** — characteristics, improvements over MVC, and increased testability
+3. **MVVM (Model-View-ViewModel)** — data binding, reactive design, and application in modern frameworks
+4. **Choosing the right pattern** — optimal choices per framework and platform, and migration strategies
+5. **Testing strategies** — how to write unit and integration tests for each pattern
 
 ---
 
-## 1. UI アーキテクチャパターンの全体像
+## 1. Overview of UI Architecture Patterns
 
-### WHY: なぜ UI にアーキテクチャパターンが必要か
+### WHY: Why Do UI Patterns Matter?
 
-GUI アプリケーションは「表示」「入力処理」「ビジネスロジック」「データ永続化」が密結合しやすい。パターンなしで開発すると以下の問題が発生する:
+GUI applications tend to tightly couple "rendering", "input handling", "business logic", and "data persistence". Without patterns, the following problems arise:
 
-1. **テスト困難** — UI 描画なしにロジックを検証できない
-2. **変更の波及** — 画面変更がビジネスロジックに影響する
-3. **並行開発の阻害** — デザイナーと開発者が同一ファイルを編集する衝突
-4. **コード再利用不可** — Web とモバイルで同じロジックを共有できない
+1. **Hard to test** — logic cannot be verified without rendering the UI
+2. **Change propagation** — changes to screens affect business logic
+3. **Blocked parallel development** — designers and developers edit the same files
+4. **No code reuse** — the same logic cannot be shared between web and mobile
 
-これらの問題を解決するため、1979 年の Smalltalk MVC 以降、様々な UI アーキテクチャパターンが考案されてきた。
+To solve these problems, various UI architecture patterns have been devised since Smalltalk MVC in 1979.
 
-### 1.1 3 パターンの歴史的関係と進化
+### 1.1 Historical Relationships and Evolution of the Three Patterns
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                UI アーキテクチャパターンの進化                         │
+│                Evolution of UI Architecture Patterns                │
 │                                                                     │
-│  1979年 Smalltalk-80 (Trygve Reenskaug)                             │
+│  1979 Smalltalk-80 (Trygve Reenskaug)                               │
 │  ┌────────┐                                                         │
-│  │  MVC   │ ← オリジナル: デスクトップ GUI のための分離パターン        │
+│  │  MVC   │ ← Original: separation pattern for desktop GUIs        │
 │  └────┬───┘                                                         │
 │       │                                                             │
-│       ├─── 1996年 Taligent MVP ──────────────┐                      │
-│       │    Dolphin Smalltalk MVP              │                     │
-│       │                                       │                     │
-│  ┌────▼────┐                            ┌────▼─────┐                │
-│  │ Web MVC │ (2004 Rails)               │  MVVM    │ (2005 WPF)    │
-│  │ Server  │                            │ ViewModel│ John Gossman  │
-│  │ Side    │                            └──────────┘                │
+│       ├─── 1996 Taligent MVP ──────────────┐                        │
+│       │    Dolphin Smalltalk MVP            │                       │
+│       │                                     │                       │
+│  ┌────▼────┐                          ┌────▼─────┐                  │
+│  │ Web MVC │ (2004 Rails)             │  MVVM    │ (2005 WPF)      │
+│  │ Server  │                          │ ViewModel│ John Gossman    │
+│  │ Side    │                          └──────────┘                  │
 │  └────┬────┘                                                        │
 │       │                                                             │
 │  ┌────▼────────────────────────────────────────────┐                │
 │  │ Client-Side MV* (2010s)                         │                │
 │  │ Backbone.js → AngularJS → React → Vue → Svelte │                │
-│  │ → 実質的に MVVM + Flux/Redux ハイブリッド        │                │
+│  │ → effectively a MVVM + Flux/Redux hybrid        │                │
 │  └─────────────────────────────────────────────────┘                │
 │                                                                     │
-│  現代のフレームワーク:                                               │
+│  Modern Frameworks:                                                 │
 │  Rails/Django/Laravel → Server-Side MVC                             │
-│  React/Vue/Svelte    → MVVM に近い (Component-Based)               │
-│  SwiftUI/Compose     → MVVM (宣言的 UI)                            │
+│  React/Vue/Svelte    → Close to MVVM (Component-Based)             │
+│  SwiftUI/Compose     → MVVM (Declarative UI)                       │
 │  Android Views       → MVP → MVVM (Jetpack)                        │
-│  WPF / .NET MAUI     → MVVM (データバインディング発祥)              │
+│  WPF / .NET MAUI     → MVVM (origin of data binding)              │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 3 パターンのデータフロー比較
+### 1.2 Data Flow Comparison of the Three Patterns
 
 ```
 ┌────────────────── MVC ──────────────────┐
@@ -82,19 +82,19 @@ GUI アプリケーションは「表示」「入力処理」「ビジネスロ�
 │   User Action                           │
 │       │                                 │
 │       ▼                                 │
-│  ┌──────────┐    更新      ┌──────┐     │
+│  ┌──────────┐   Update    ┌──────┐      │
 │  │Controller│ ───────────→ │Model │     │
 │  └──────────┘              └──┬───┘     │
 │       │                      │          │
-│       │ View選択       通知  │          │
+│       │ Select View   Notify │          │
 │       ▼                      ▼          │
 │  ┌────────────────────────────┐         │
 │  │          View              │         │
 │  └────────────────────────────┘         │
 │                                         │
-│  特徴: Controller が「何を表示するか」   │
-│        を選択。View は Model を直接参照  │
-│        することもある（Observer）        │
+│  Key: Controller selects "what to       │
+│       show". View may reference Model   │
+│       directly (Observer).              │
 └─────────────────────────────────────────┘
 
 ┌────────────────── MVP ──────────────────┐
@@ -102,19 +102,19 @@ GUI アプリケーションは「表示」「入力処理」「ビジネスロ�
 │   User Action                           │
 │       │                                 │
 │       ▼                                 │
-│  ┌──────┐  イベント   ┌──────────┐      │
+│  ┌──────┐  Event      ┌──────────┐      │
 │  │ View │ ──────────→ │Presenter │      │
 │  └──────┘             └────┬─────┘      │
 │       ▲                    │            │
-│       │ UI更新       Model操作          │
+│       │ Update UI    Model op.          │
 │       │                    ▼            │
 │       │               ┌──────┐          │
 │       └────────────── │Model │          │
 │                       └──────┘          │
 │                                         │
-│  特徴: View と Presenter が 1:1 対応。   │
-│        Presenter が View の参照を持ち、  │
-│        明示的に UI を更新する            │
+│  Key: View and Presenter are 1:1.       │
+│       Presenter holds a View reference  │
+│       and explicitly updates the UI.    │
 └─────────────────────────────────────────┘
 
 ┌────────────────── MVVM ─────────────────┐
@@ -122,59 +122,59 @@ GUI アプリケーションは「表示」「入力処理」「ビジネスロ�
 │   User Action                           │
 │       │                                 │
 │       ▼                                 │
-│  ┌──────┐  Data      ┌──────────┐      │
+│  ┌──────┐  Data      ┌──────────┐       │
 │  │ View │←─Binding──→│ViewModel │      │
 │  └──────┘             └─────┬────┘      │
 │                             │           │
-│                       Model操作         │
+│                       Model op.         │
 │                             ▼           │
 │                       ┌──────┐          │
 │                       │Model │          │
 │                       └──────┘          │
 │                                         │
-│  特徴: ViewModel は View を知らない。    │
-│        データバインディングが双方向の    │
-│        同期を自動処理する（リアクティブ）│
+│  Key: ViewModel does not know View.     │
+│       Data binding automatically        │
+│       handles two-way sync (reactive).  │
 └─────────────────────────────────────────┘
 ```
 
-### 1.3 各パターンの責務マトリックス
+### 1.3 Responsibility Matrix for Each Pattern
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    責務の配置比較                                 │
+│               Responsibility Placement Comparison               │
 │                                                                 │
-│  責務              │  MVC           │  MVP          │  MVVM     │
-│  ─────────────────┼────────────────┼───────────────┼───────────│
-│  入力の受付       │  Controller    │  View         │  View     │
-│  入力の解釈       │  Controller    │  Presenter    │  ViewModel│
-│  ビジネスロジック │  Model         │  Model        │  Model    │
-│  表示データ変換   │  View/Controller│  Presenter   │  ViewModel│
-│  UI 描画          │  View          │  View         │  View     │
-│  UI 更新トリガー  │  Model(通知)   │  Presenter    │  Binding  │
-│  状態管理         │  Model         │  Presenter    │  ViewModel│
-│  View の参照      │  Controller持つ │  Presenter持つ│  なし     │
-│  テスト容易性     │  中            │  高           │  高       │
+│  Responsibility      │  MVC           │  MVP          │  MVVM  │
+│  ───────────────────┼────────────────┼───────────────┼────────│
+│  Accept input       │  Controller    │  View         │  View  │
+│  Interpret input    │  Controller    │  Presenter    │  VM    │
+│  Business logic     │  Model         │  Model        │  Model │
+│  Display data xform │  View/Controller│  Presenter   │  VM    │
+│  UI rendering       │  View          │  View         │  View  │
+│  UI update trigger  │  Model (notify)│  Presenter    │  Bind. │
+│  State management   │  Model         │  Presenter    │  VM    │
+│  View reference     │  Controller    │  Presenter    │  None  │
+│  Testability        │  Medium        │  High         │  High  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 2. MVC の実装
+## 2. Implementing MVC
 
-### WHY: なぜ MVC が Web サーバーサイドのデファクトになったか
+### WHY: Why Did MVC Become the Standard for Server-Side Web?
 
-MVC は HTTP のリクエスト/レスポンスモデルと自然に対応する:
-- **リクエスト** → Controller がルーティング
-- **ビジネスロジック** → Model で処理
-- **レスポンス** → View がHTML生成
+MVC maps naturally to HTTP's request/response model:
+- **Request** → Controller handles routing
+- **Business logic** → processed in the Model
+- **Response** → View generates HTML
 
-このシンプルな対応関係が Rails (2004)、Django (2005)、Laravel (2011) などのフレームワークに採用され、Web 開発のデファクトスタンダードとなった。
+This simple correspondence was adopted by frameworks like Rails (2004), Django (2005), and Laravel (2011), making it the de facto standard for web development.
 
-### 2.1 MVC の構造（Ruby on Rails の例）
+### 2.1 MVC Structure (Ruby on Rails Example)
 
 ```ruby
-# Model — ビジネスロジックとデータアクセス
+# Model — business logic and data access
 # app/models/user.rb
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
@@ -189,7 +189,7 @@ class User < ApplicationRecord
   scope :recent, -> { order(created_at: :desc).limit(10) }
   scope :with_posts, -> { includes(:posts).where.not(posts: { id: nil }) }
 
-  # ビジネスロジックは Model に置く
+  # Business logic belongs in the Model
   def full_name
     "#{first_name} #{last_name}"
   end
@@ -205,7 +205,7 @@ end
 ```
 
 ```ruby
-# Controller — リクエスト処理とレスポンス制御
+# Controller — request handling and response control
 # app/controllers/users_controller.rb
 class UsersController < ApplicationController
   before_action :authenticate_user!
@@ -214,7 +214,7 @@ class UsersController < ApplicationController
   def index
     @users = User.active.recent
     respond_to do |format|
-      format.html                    # View テンプレートを描画
+      format.html                    # Render View template
       format.json { render json: @users }
     end
   end
@@ -227,7 +227,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       UserMailer.welcome(@user).deliver_later
-      redirect_to @user, notice: "ユーザーを作成しました"
+      redirect_to @user, notice: "User created successfully"
     else
       render :new, status: :unprocessable_entity
     end
@@ -235,7 +235,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to @user, notice: "ユーザー情報を更新しました"
+      redirect_to @user, notice: "User updated successfully"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -243,7 +243,7 @@ class UsersController < ApplicationController
 
   def destroy
     @user.deactivate!
-    redirect_to users_path, notice: "ユーザーを無効化しました"
+    redirect_to users_path, notice: "User deactivated"
   end
 
   private
@@ -259,14 +259,14 @@ end
 ```
 
 ```erb
-<!-- View — プレゼンテーション -->
+<!-- View — presentation -->
 <!-- app/views/users/index.html.erb -->
-<h1>ユーザー一覧</h1>
+<h1>User List</h1>
 
 <div class="search-bar">
   <%= form_tag users_path, method: :get do %>
-    <%= text_field_tag :q, params[:q], placeholder: "名前で検索..." %>
-    <%= submit_tag "検索" %>
+    <%= text_field_tag :q, params[:q], placeholder: "Search by name..." %>
+    <%= submit_tag "Search" %>
   <% end %>
 </div>
 
@@ -276,22 +276,22 @@ end
       <div class="user-card">
         <h2><%= user.full_name %></h2>
         <p class="email"><%= user.email %></p>
-        <p class="stats">投稿数: <%= user.posts.count %></p>
-        <%= link_to "詳細", user_path(user), class: "btn" %>
+        <p class="stats">Posts: <%= user.posts.count %></p>
+        <%= link_to "Details", user_path(user), class: "btn" %>
       </div>
     <% end %>
   </div>
   <%= paginate @users %>
 <% else %>
-  <p class="empty-state">ユーザーが見つかりませんでした</p>
+  <p class="empty-state">No users found</p>
 <% end %>
 ```
 
-### 2.2 MVC（Express + TypeScript）
+### 2.2 MVC (Express + TypeScript)
 
 ```typescript
 // ============================================================
-// Model — ビジネスロジックとデータアクセス
+// Model — business logic and data access
 // ============================================================
 interface User {
   id: string;
@@ -390,7 +390,7 @@ class UserModel {
 }
 
 // ============================================================
-// Controller — リクエスト処理とレスポンス制御
+// Controller — request handling and response control
 // ============================================================
 class UserController {
   constructor(private model: UserModel) {}
@@ -410,7 +410,7 @@ class UserController {
   async show(req: Request, res: Response): Promise<void> {
     const user = await this.model.findById(req.params.id);
     if (!user) {
-      res.status(404).render("errors/404", { message: "ユーザーが見つかりません" });
+      res.status(404).render("errors/404", { message: "User not found" });
       return;
     }
     res.render("users/show", { user });
@@ -418,20 +418,20 @@ class UserController {
 
   async create(req: Request, res: Response): Promise<void> {
     try {
-      // バリデーション
+      // Validation
       const { name, email, role } = req.body;
       if (!name || !email) {
         res.status(422).render("users/new", {
-          errors: ["名前とメールアドレスは必須です"],
+          errors: ["Name and email are required"],
         });
         return;
       }
 
-      // 重複チェック
+      // Duplicate check
       const existing = await this.model.findByEmail(email);
       if (existing) {
         res.status(422).render("users/new", {
-          errors: ["このメールアドレスは既に登録されています"],
+          errors: ["This email address is already registered"],
         });
         return;
       }
@@ -440,14 +440,14 @@ class UserController {
       res.redirect(`/users/${user.id}`);
     } catch (error) {
       res.status(500).render("errors/500", {
-        message: "ユーザー作成に失敗しました",
+        message: "Failed to create user",
       });
     }
   }
 }
 
 // ============================================================
-// Router (ルーティング定義)
+// Router (routing definition)
 // ============================================================
 const userModel = new UserModel(database);
 const userController = new UserController(userModel);
@@ -457,7 +457,7 @@ router.get("/users/:id", (req, res) => userController.show(req, res));
 router.post("/users", (req, res) => userController.create(req, res));
 ```
 
-### 2.3 MVC（Django / Python）
+### 2.3 MVC (Django / Python)
 
 ```python
 # ============================================================
@@ -468,12 +468,12 @@ from django.db import models
 from django.core.validators import MinValueValidator
 
 class User(models.Model):
-    """ユーザーモデル — ビジネスロジックをモデルに集約"""
+    """User model — consolidate business logic in the model"""
 
     class Role(models.TextChoices):
-        ADMIN = "admin", "管理者"
-        USER = "user", "一般ユーザー"
-        MODERATOR = "moderator", "モデレーター"
+        ADMIN = "admin", "Administrator"
+        USER = "user", "General User"
+        MODERATOR = "moderator", "Moderator"
 
     name = models.CharField(max_length=100)
     email = models.EmailField(unique=True)
@@ -492,20 +492,20 @@ class User(models.Model):
         return self.role == self.Role.ADMIN
 
     def deactivate(self):
-        """ユーザーを無効化（ソフトデリート）"""
+        """Deactivate user (soft delete)"""
         self.active = False
         self.save(update_fields=["active"])
 
 
 # ============================================================
-# View (Django では View が Controller の役割)
+# View (in Django, the View acts as the Controller)
 # ============================================================
 # views.py
 from django.views.generic import ListView, DetailView, CreateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 class UserListView(LoginRequiredMixin, ListView):
-    """ユーザー一覧表示"""
+    """Display user list"""
     model = User
     template_name = "users/list.html"
     context_object_name = "users"
@@ -520,7 +520,7 @@ class UserListView(LoginRequiredMixin, ListView):
 
 
 class UserDetailView(LoginRequiredMixin, DetailView):
-    """ユーザー詳細表示"""
+    """Display user detail"""
     model = User
     template_name = "users/detail.html"
     context_object_name = "user"
@@ -532,37 +532,37 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 
 
 class UserCreateView(LoginRequiredMixin, CreateView):
-    """ユーザー作成"""
+    """Create user"""
     model = User
     template_name = "users/form.html"
     fields = ["name", "email", "role"]
     success_url = "/users/"
 
     def form_valid(self, form):
-        # 追加のビジネスロジック
+        # Additional business logic
         response = super().form_valid(form)
-        send_welcome_email.delay(self.object.id)  # 非同期タスク
+        send_welcome_email.delay(self.object.id)  # Async task
         return response
 ```
 
 ---
 
-## 3. MVP の実装
+## 3. Implementing MVP
 
-### WHY: なぜ MVP は MVC の改良版として生まれたか
+### WHY: Why Was MVP Born as an Improvement Over MVC?
 
-MVC の問題点は View が Model を直接参照できることにあった。これにより:
-1. View と Model の結合度が高くなる
-2. View のテストに Model のモックが必要
-3. プレゼンテーションロジックの置き場が曖昧
+The problem with MVC was that the View could directly reference the Model. This led to:
+1. High coupling between View and Model
+2. Mocking the Model is required to test the View
+3. Ambiguity about where to place presentation logic
 
-MVP は Presenter を「View と Model の唯一の仲介者」として配置し、これらの問題を解決した。
+MVP addressed these issues by placing the Presenter as the sole intermediary between View and Model.
 
-### 3.1 MVP（Android Kotlin — 従来の View システム）
+### 3.1 MVP (Android Kotlin — Traditional View System)
 
 ```kotlin
 // ============================================================
-// Contract — View と Presenter のインターフェースを定義
+// Contract — defines interfaces for View and Presenter
 // ============================================================
 interface UserListContract {
     interface View {
@@ -582,7 +582,7 @@ interface UserListContract {
 }
 
 // ============================================================
-// Model — データアクセスとビジネスロジック
+// Model — data access and business logic
 // ============================================================
 data class User(
     val id: String,
@@ -604,7 +604,7 @@ interface UserRepository {
 }
 
 // ============================================================
-// Presenter — ロジックの中心
+// Presenter — the core of the logic
 // ============================================================
 class UserListPresenter(
     private val view: UserListContract.View,
@@ -625,7 +625,7 @@ class UserListPresenter(
                 }
                 .onFailure { error ->
                     view.hideLoading()
-                    view.showError("ユーザーの読み込みに失敗しました: ${error.message}")
+                    view.showError("Failed to load users: ${error.message}")
                 }
         }
     }
@@ -656,7 +656,7 @@ class UserListPresenter(
 }
 
 // ============================================================
-// View (Activity) — 描画のみ
+// View (Activity) — rendering only
 // ============================================================
 class UserListActivity : AppCompatActivity(), UserListContract.View {
 
@@ -706,11 +706,11 @@ class UserListActivity : AppCompatActivity(), UserListContract.View {
 }
 ```
 
-### 3.2 MVP のテスト（Presenter のユニットテスト）
+### 3.2 MVP Testing (Presenter Unit Tests)
 
 ```kotlin
 // ============================================================
-// Presenter のテスト — View のモック
+// Presenter tests — mocking the View
 // ============================================================
 class UserListPresenterTest {
 
@@ -722,12 +722,12 @@ class UserListPresenterTest {
     fun setup() {
         view = mock()
         repository = mock()
-        // テスト用ディスパッチャーで同期実行
+        // Run synchronously with a test dispatcher
         presenter = UserListPresenter(view, repository, Dispatchers.Unconfined)
     }
 
     @Test
-    fun `loadUsers - 成功時にユーザーリストを表示する`() = runTest {
+    fun `loadUsers - shows user list on success`() = runTest {
         // Arrange
         val users = listOf(
             User("1", "Alice", "alice@example.com", true),
@@ -746,7 +746,7 @@ class UserListPresenterTest {
     }
 
     @Test
-    fun `loadUsers - 失敗時にエラーメッセージを表示する`() = runTest {
+    fun `loadUsers - shows error message on failure`() = runTest {
         // Arrange
         whenever(repository.getUsers()).thenReturn(
             Result.failure(IOException("Network error"))
@@ -758,12 +758,12 @@ class UserListPresenterTest {
         // Assert
         verify(view).showLoading()
         verify(view).hideLoading()
-        verify(view).showError(contains("ユーザーの読み込みに失敗しました"))
+        verify(view).showError(contains("Failed to load users"))
         verify(view, never()).showUsers(any())
     }
 
     @Test
-    fun `onUserClicked - 詳細画面に遷移する`() {
+    fun `onUserClicked - navigates to detail screen`() {
         // Act
         presenter.onUserClicked("user-123")
 
@@ -775,48 +775,48 @@ class UserListPresenterTest {
 
 ---
 
-## 4. MVVM の実装
+## 4. Implementing MVVM
 
-### WHY: なぜ MVVM が現代 UI のデファクトになったか
+### WHY: Why Did MVVM Become the Standard for Modern UI?
 
-MVP の問題点:
-1. Presenter が View の参照を持つため、ライフサイクル管理が複雑（Activity 再生成問題）
-2. View のメソッドを1つずつ呼ぶ手続き的なコードが冗長
-3. UI の状態が Presenter と View に分散する
+Problems with MVP:
+1. Presenter holds a reference to the View, making lifecycle management complex (Activity recreation problem)
+2. Procedural code calling View methods one by one is verbose
+3. UI state is split between Presenter and View
 
-MVVM はこれらを解決する:
-1. **ViewModel は View を知らない** — ライフサイクル問題なし
-2. **データバインディング** — 状態変更が自動的に UI に反映
-3. **状態の一元管理** — ViewModel が唯一の信頼できる状態源
+MVVM solves these:
+1. **ViewModel does not know the View** — no lifecycle issues
+2. **Data binding** — state changes are automatically reflected in the UI
+3. **Single source of truth** — ViewModel is the sole authoritative state source
 
-### 4.1 MVVM の構造（React + hooks）
+### 4.1 MVVM Structure (React + hooks)
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│  React での MVVM マッピング                           │
+│  MVVM Mapping in React                               │
 │                                                      │
-│  Model      = API クライアント + ドメインロジック     │
+│  Model      = API client + domain logic              │
 │  ViewModel  = Custom Hooks (useState, useEffect)     │
-│  View       = JSX コンポーネント                      │
+│  View       = JSX components                         │
 │                                                      │
 │  ┌────────────┐    ┌──────────────┐    ┌──────────┐  │
 │  │ JSX (View) │←──→│ useUsers()   │───→│ API /    │  │
 │  │            │    │ (ViewModel)  │    │ Domain   │  │
-│  │ データ表示  │    │ 状態管理     │    │ (Model)  │  │
-│  │ イベント発火│    │ ロジック     │    │          │  │
+│  │ Render data│    │ State mgmt   │    │ (Model)  │  │
+│  │ Emit events│    │ Logic        │    │          │  │
 │  └────────────┘    └──────────────┘    └──────────┘  │
 │                                                      │
-│  なぜ Custom Hook = ViewModel なのか:                │
-│  1. UI とは独立したロジックの集約                     │
-│  2. 状態（state）とその操作（actions）を公開          │
-│  3. View を知らない（JSX への依存なし）               │
-│  4. テスト可能（renderHook でテスト）                 │
+│  Why Custom Hook = ViewModel:                        │
+│  1. Centralizes logic independent of UI              │
+│  2. Exposes state and actions                        │
+│  3. Does not know View (no JSX dependency)           │
+│  4. Testable (via renderHook)                        │
 └──────────────────────────────────────────────────────┘
 ```
 
 ```typescript
 // ============================================================
-// Model — API クライアントとドメインロジック
+// Model — API client and domain logic
 // ============================================================
 interface User {
   id: string;
@@ -831,7 +831,7 @@ interface CreateUserInput {
   email: string;
 }
 
-// API クライアント（Model 層）
+// API client (Model layer)
 class UserApiClient {
   private baseUrl: string;
 
@@ -880,7 +880,7 @@ class ApiError extends Error {
   }
 }
 
-// ドメインロジック（Model 層）
+// Domain logic (Model layer)
 function sortUsers(users: User[], sortBy: "name" | "createdAt"): User[] {
   return [...users].sort((a, b) => {
     if (sortBy === "name") return a.name.localeCompare(b.name);
@@ -921,7 +921,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
     page: 1,
   });
 
-  // データ取得
+  // Fetch data
   const loadUsers = useCallback(async () => {
     setState((prev) => ({ ...prev, loading: true, error: null }));
     try {
@@ -943,7 +943,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
     loadUsers();
   }, [loadUsers]);
 
-  // アクション
+  // Actions
   const setSearchQuery = useCallback((query: string) => {
     setState((prev) => ({ ...prev, searchQuery: query, page: 1 }));
   }, []);
@@ -980,7 +980,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
     [apiClient]
   );
 
-  // 算出プロパティ（ViewModel のロジック）
+  // Computed properties (ViewModel logic)
   const sortedUsers = useMemo(
     () => sortUsers(state.users, state.sortBy),
     [state.users, state.sortBy]
@@ -990,7 +990,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
   const hasPrevPage = state.page > 1;
 
   return {
-    // 状態
+    // State
     users: sortedUsers,
     total: state.total,
     loading: state.loading,
@@ -1000,7 +1000,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
     page: state.page,
     hasNextPage,
     hasPrevPage,
-    // アクション
+    // Actions
     setSearchQuery,
     setSortBy,
     setPage,
@@ -1011,7 +1011,7 @@ function useUserList(apiClient: UserApiClient = new UserApiClient()) {
 }
 
 // ============================================================
-// View — 純粋な表示コンポーネント
+// View — pure display component
 // ============================================================
 function UserListPage() {
   const {
@@ -1035,26 +1035,26 @@ function UserListPage() {
 
   return (
     <div className="user-list-page">
-      <h1>ユーザー一覧</h1>
+      <h1>User List</h1>
 
-      {/* 検索 + ソート */}
+      {/* Search + Sort */}
       <div className="controls">
         <SearchInput
           value={searchQuery}
           onChange={setSearchQuery}
-          placeholder="名前 or メールで検索"
+          placeholder="Search by name or email"
         />
         <SortSelect
           value={sortBy}
           onChange={setSortBy}
           options={[
-            { value: "createdAt", label: "登録日順" },
-            { value: "name", label: "名前順" },
+            { value: "createdAt", label: "Date registered" },
+            { value: "name", label: "Name" },
           ]}
         />
       </div>
 
-      {/* ユーザーリスト */}
+      {/* User list */}
       <ul className="user-list">
         {users.map((user) => (
           <UserCard
@@ -1065,7 +1065,7 @@ function UserListPage() {
         ))}
       </ul>
 
-      {/* ページネーション */}
+      {/* Pagination */}
       <Pagination
         page={page}
         onPrev={() => setPage(page - 1)}
@@ -1078,14 +1078,14 @@ function UserListPage() {
 }
 ```
 
-### 4.2 MVVM（SwiftUI）
+### 4.2 MVVM (SwiftUI)
 
 ```swift
 import SwiftUI
 import Combine
 
 // ============================================================
-// Model — データ構造とビジネスロジック
+// Model — data structures and business logic
 // ============================================================
 struct User: Identifiable, Codable, Equatable {
     let id: UUID
@@ -1101,7 +1101,7 @@ struct User: Identifiable, Codable, Equatable {
     var isAdmin: Bool { role == .admin }
 }
 
-// API クライアント（Model 層）
+// API client (Model layer)
 protocol UserServiceProtocol {
     func fetchUsers() async throws -> [User]
     func createUser(name: String, email: String) async throws -> User
@@ -1155,18 +1155,18 @@ enum APIError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .invalidResponse: return "サーバーからの応答が不正です"
+        case .invalidResponse: return "Invalid response from server"
         case .networkError(let error): return error.localizedDescription
         }
     }
 }
 
 // ============================================================
-// ViewModel — UIの状態とロジック
+// ViewModel — UI state and logic
 // ============================================================
 @MainActor
 class UserListViewModel: ObservableObject {
-    // Published = データバインディング対象
+    // Published = data binding targets
     @Published var users: [User] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
@@ -1179,7 +1179,7 @@ class UserListViewModel: ObservableObject {
         self.service = service
     }
 
-    // 算出プロパティ — View が参照する表示用データ
+    // Computed properties — display data referenced by the View
     var filteredUsers: [User] {
         guard !searchText.isEmpty else { return users }
         return users.filter {
@@ -1190,12 +1190,12 @@ class UserListViewModel: ObservableObject {
 
     var userCount: String {
         let count = filteredUsers.count
-        return "\(count)件のユーザー"
+        return "\(count) user(s)"
     }
 
     var hasUsers: Bool { !filteredUsers.isEmpty }
 
-    // アクション
+    // Actions
     func loadUsers() async {
         isLoading = true
         errorMessage = nil
@@ -1212,7 +1212,7 @@ class UserListViewModel: ObservableObject {
             let newUser = try await service.createUser(name: name, email: email)
             users.insert(newUser, at: 0)
         } catch {
-            errorMessage = "ユーザーの追加に失敗しました: \(error.localizedDescription)"
+            errorMessage = "Failed to add user: \(error.localizedDescription)"
         }
     }
 
@@ -1223,14 +1223,14 @@ class UserListViewModel: ObservableObject {
                 try await service.deleteUser(id: user.id)
                 users.removeAll { $0.id == user.id }
             } catch {
-                errorMessage = "削除に失敗しました"
+                errorMessage = "Failed to delete user"
             }
         }
     }
 }
 
 // ============================================================
-// View — 宣言的 UI
+// View — declarative UI
 // ============================================================
 struct UserListView: View {
     @StateObject private var viewModel = UserListViewModel()
@@ -1239,10 +1239,10 @@ struct UserListView: View {
         NavigationStack {
             Group {
                 if viewModel.isLoading {
-                    ProgressView("読み込み中...")
+                    ProgressView("Loading...")
                 } else if let error = viewModel.errorMessage {
                     ContentUnavailableView(
-                        "エラー",
+                        "Error",
                         systemImage: "exclamationmark.triangle",
                         description: Text(error)
                     )
@@ -1252,11 +1252,11 @@ struct UserListView: View {
                     ContentUnavailableView.search
                 }
             }
-            .navigationTitle("ユーザー一覧")
-            .searchable(text: $viewModel.searchText, prompt: "名前 or メールで検索")
+            .navigationTitle("User List")
+            .searchable(text: $viewModel.searchText, prompt: "Search by name or email")
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
-                    Button("追加") { viewModel.showingAddSheet = true }
+                    Button("Add") { viewModel.showingAddSheet = true }
                 }
                 ToolbarItem(placement: .status) {
                     Text(viewModel.userCount)
@@ -1314,11 +1314,11 @@ struct UserRow: View {
 }
 ```
 
-### 4.3 MVVM（Vue 3 Composition API）
+### 4.3 MVVM (Vue 3 Composition API)
 
 ```typescript
 // ============================================================
-// Model — API クライアント
+// Model — API client
 // ============================================================
 // api/userApi.ts
 import type { User, CreateUserInput } from '@/types'
@@ -1356,7 +1356,7 @@ import { userApi } from '@/api/userApi'
 import type { User } from '@/types'
 
 export function useUserList() {
-  // リアクティブ状態
+  // Reactive state
   const users = ref<User[]>([])
   const total = ref(0)
   const loading = ref(false)
@@ -1364,7 +1364,7 @@ export function useUserList() {
   const searchQuery = ref('')
   const sortBy = ref<'name' | 'createdAt'>('createdAt')
 
-  // 算出プロパティ（リアクティブに自動更新）
+  // Computed properties (auto-updated reactively)
   const sortedUsers = computed(() => {
     return [...users.value].sort((a, b) => {
       if (sortBy.value === 'name') return a.name.localeCompare(b.name)
@@ -1374,7 +1374,7 @@ export function useUserList() {
 
   const isEmpty = computed(() => users.value.length === 0 && !loading.value)
 
-  // アクション
+  // Actions
   async function loadUsers() {
     loading.value = true
     error.value = null
@@ -1395,12 +1395,12 @@ export function useUserList() {
     total.value++
   }
 
-  // searchQuery の変更を監視して自動検索
+  // Watch searchQuery changes and auto-search
   watch(searchQuery, () => {
     loadUsers()
   }, { debounce: 300 } as any)
 
-  // 初期ロード
+  // Initial load
   loadUsers()
 
   return {
@@ -1417,7 +1417,7 @@ export function useUserList() {
 }
 
 // ============================================================
-// View — テンプレート
+// View — template
 // ============================================================
 // components/UserListPage.vue
 // <script setup lang="ts">
@@ -1430,15 +1430,15 @@ export function useUserList() {
 //
 // <template>
 //   <div class="user-list-page">
-//     <h1>ユーザー一覧</h1>
-//     <input v-model="searchQuery" placeholder="検索..." />
+//     <h1>User List</h1>
+//     <input v-model="searchQuery" placeholder="Search..." />
 //     <select v-model="sortBy">
-//       <option value="createdAt">登録日順</option>
-//       <option value="name">名前順</option>
+//       <option value="createdAt">Date registered</option>
+//       <option value="name">Name</option>
 //     </select>
-//     <div v-if="loading">読み込み中...</div>
+//     <div v-if="loading">Loading...</div>
 //     <div v-else-if="error">{{ error }}</div>
-//     <div v-else-if="isEmpty">ユーザーが見つかりません</div>
+//     <div v-else-if="isEmpty">No users found</div>
 //     <ul v-else>
 //       <li v-for="user in users" :key="user.id">
 //         {{ user.name }} ({{ user.email }})
@@ -1448,11 +1448,11 @@ export function useUserList() {
 // </template>
 ```
 
-### 4.4 MVVM のテスト（React Custom Hook のテスト）
+### 4.4 MVVM Testing (React Custom Hook Tests)
 
 ```typescript
 // ============================================================
-// ViewModel (Custom Hook) のテスト
+// ViewModel (Custom Hook) tests
 // ============================================================
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useUserList } from "./useUserList";
@@ -1469,7 +1469,7 @@ describe("useUserList (ViewModel)", () => {
     jest.clearAllMocks();
   });
 
-  test("初期ロードでユーザー一覧を取得する", async () => {
+  test("fetches user list on initial load", async () => {
     const mockUsers = [
       { id: "1", name: "Alice", email: "alice@example.com", role: "user", createdAt: "2024-01-01" },
       { id: "2", name: "Bob", email: "bob@example.com", role: "admin", createdAt: "2024-01-02" },
@@ -1481,21 +1481,21 @@ describe("useUserList (ViewModel)", () => {
 
     const { result } = renderHook(() => useUserList(mockApiClient));
 
-    // 初期状態: ローディング中
+    // Initial state: loading
     expect(result.current.loading).toBe(true);
 
-    // データ取得完了を待つ
+    // Wait for data fetch to complete
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    // 検証
+    // Assertions
     expect(result.current.users).toHaveLength(2);
     expect(result.current.total).toBe(2);
     expect(result.current.error).toBeNull();
   });
 
-  test("検索クエリを変更するとページがリセットされる", async () => {
+  test("resets page when search query changes", async () => {
     (mockApiClient.fetchAll as jest.Mock).mockResolvedValue({
       users: [],
       total: 0,
@@ -1507,13 +1507,13 @@ describe("useUserList (ViewModel)", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    // ページを2に設定
+    // Set page to 2
     act(() => {
       result.current.setPage(2);
     });
     expect(result.current.page).toBe(2);
 
-    // 検索すると page が 1 にリセットされる
+    // Searching resets page to 1
     act(() => {
       result.current.setSearchQuery("Alice");
     });
@@ -1521,7 +1521,7 @@ describe("useUserList (ViewModel)", () => {
     expect(result.current.searchQuery).toBe("Alice");
   });
 
-  test("ユーザー追加で楽観的更新される", async () => {
+  test("optimistically updates when a user is added", async () => {
     const initialUsers = [
       { id: "1", name: "Alice", email: "alice@example.com", role: "user", createdAt: "2024-01-01" },
     ];
@@ -1545,17 +1545,17 @@ describe("useUserList (ViewModel)", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    // ユーザー追加
+    // Add user
     await act(async () => {
       await result.current.addUser({ name: "Bob", email: "bob@example.com" });
     });
 
-    // 楽観的更新の検証
+    // Verify optimistic update
     expect(result.current.users).toHaveLength(2);
     expect(result.current.total).toBe(2);
   });
 
-  test("API エラー時にエラーメッセージが設定される", async () => {
+  test("sets error message on API error", async () => {
     (mockApiClient.fetchAll as jest.Mock).mockRejectedValue(
       new Error("Network error")
     );
@@ -1574,124 +1574,124 @@ describe("useUserList (ViewModel)", () => {
 
 ---
 
-## 5. パターンの選択基準
+## 5. Pattern Selection Criteria
 
-### 5.1 プラットフォーム / フレームワーク別の推奨
+### 5.1 Recommendations by Platform / Framework
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│          フレームワーク → パターン マッピング                  │
+│          Framework → Pattern Mapping                         │
 │                                                              │
-│  Web (サーバーサイド):                                       │
-│    Rails / Django / Laravel   → MVC (フレームワーク組み込み)  │
-│    Express / Fastify / Hono   → MVC (手動構成、薄い Controller)│
-│    Spring Boot                → MVC (@Controller, @Service)   │
-│    Go (net/http, Gin, Echo)   → MVC (ハンドラ + サービス)     │
+│  Web (Server-Side):                                          │
+│    Rails / Django / Laravel   → MVC (built into framework)   │
+│    Express / Fastify / Hono   → MVC (manual, thin Controller)│
+│    Spring Boot                → MVC (@Controller, @Service)  │
+│    Go (net/http, Gin, Echo)   → MVC (handler + service)      │
 │                                                              │
-│  Web (クライアントサイド):                                   │
+│  Web (Client-Side):                                          │
 │    React                      → MVVM (Custom Hooks = VM)     │
 │    Vue.js 3                   → MVVM (Composition API = VM)  │
 │    Angular                    → MVVM (Component + Service)   │
 │    Svelte                     → MVVM (Store = VM)            │
 │    Solid.js                   → MVVM (createSignal = VM)     │
 │                                                              │
-│  モバイル:                                                   │
+│  Mobile:                                                     │
 │    SwiftUI (iOS)              → MVVM (ObservableObject)      │
-│    UIKit (iOS, レガシー)       → MVC → MVP                    │
+│    UIKit (iOS, legacy)        → MVC → MVP                    │
 │    Jetpack Compose (Android)  → MVVM (StateFlow + ViewModel) │
-│    Android Views (レガシー)    → MVP → MVVM (LiveData)        │
+│    Android Views (legacy)     → MVP → MVVM (LiveData)        │
 │    Flutter                    → MVVM (Provider / Bloc / Riverpod)│
-│    React Native               → MVVM (hooks ベース)           │
+│    React Native               → MVVM (hooks-based)           │
 │                                                              │
-│  デスクトップ:                                               │
-│    WPF / .NET MAUI            → MVVM (発祥、INotifyPropertyChanged)│
+│  Desktop:                                                    │
+│    WPF / .NET MAUI            → MVVM (origin, INotifyPropertyChanged)│
 │    Electron + React           → MVVM                         │
 │    Tauri + Solid/Svelte       → MVVM                         │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-### 5.2 選定フローチャート
+### 5.2 Pattern Selection Flowchart
 
 ```
 ┌────────────────────────────────────────────────────────────┐
-│               パターン選定フローチャート                      │
+│               Pattern Selection Flowchart                  │
 │                                                            │
-│  Q1: サーバーサイド Web アプリ？                             │
-│    Yes → MVC（フレームワークの規約に従う）                   │
-│    No  → Q2 へ                                             │
+│  Q1: Server-side web app?                                  │
+│    Yes → MVC (follow framework conventions)                │
+│    No  → Q2                                                │
 │                                                            │
-│  Q2: リアクティブ UI / SPA / モバイル？                     │
-│    Yes → Q3 へ                                             │
-│    No  → MVC（シンプルなサーバーレンダリング）               │
+│  Q2: Reactive UI / SPA / Mobile?                           │
+│    Yes → Q3                                                │
+│    No  → MVC (simple server rendering)                     │
 │                                                            │
-│  Q3: フレームワークがデータバインディングをサポート？        │
-│    Yes → MVVM（React hooks, SwiftUI, Vue Composition等）   │
-│    No  → Q4 へ                                             │
+│  Q3: Does the framework support data binding?              │
+│    Yes → MVVM (React hooks, SwiftUI, Vue Composition, etc) │
+│    No  → Q4                                                │
 │                                                            │
-│  Q4: View のテスト容易性を最重視？                          │
-│    Yes → MVP（View インターフェース経由でテスト）            │
-│    No  → MVC（カスタム実装）                                │
+│  Q4: Is View testability the top priority?                 │
+│    Yes → MVP (test via View interface)                     │
+│    No  → MVC (custom implementation)                       │
 └────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 6. 比較表
+## 6. Comparison Tables
 
-### 6.1 MVC / MVP / MVVM パターン比較
+### 6.1 MVC / MVP / MVVM Pattern Comparison
 
-| 観点 | MVC | MVP | MVVM |
+| Aspect | MVC | MVP | MVVM |
 |------|-----|-----|------|
-| **View-Logic 結合** | Controller 経由 | Presenter 経由 | DataBinding |
-| **View の知識** | Controller が View を選択 | Presenter が View を更新 | ViewModel は View を知らない |
-| **テスト容易性** | 中（Controller テスト） | 高（Presenter テスト） | 高（ViewModel テスト） |
-| **データフロー** | 三角形（M<->V, C->M, C->V） | 直線（V<->P<->M） | 直線（V<->VM<->M） |
-| **状態管理** | Model に保持 | Presenter に保持 | ViewModel に保持 |
-| **View の役割** | 表示 + 一部ロジック | 表示のみ（Passive View） | 表示 + バインディング |
-| **複雑さ** | 低 | 中 | 中〜高 |
-| **学習コスト** | 低 | 中 | 中（リアクティブ理解必要） |
-| **ボイラープレート** | 少ない | 多い（Contract 定義） | 中（バインディング設定） |
-| **主な用途** | サーバーサイド Web | Android (旧), .NET WinForms | SPA, モバイル, WPF |
-| **代表フレームワーク** | Rails, Django, Laravel | Android Views | React, SwiftUI, WPF |
+| **View-Logic Coupling** | Via Controller | Via Presenter | DataBinding |
+| **View Knowledge** | Controller selects View | Presenter updates View | ViewModel does not know View |
+| **Testability** | Medium (Controller tests) | High (Presenter tests) | High (ViewModel tests) |
+| **Data Flow** | Triangle (M<->V, C->M, C->V) | Linear (V<->P<->M) | Linear (V<->VM<->M) |
+| **State Management** | Held in Model | Held in Presenter | Held in ViewModel |
+| **View Role** | Display + some logic | Display only (Passive View) | Display + binding |
+| **Complexity** | Low | Medium | Medium–High |
+| **Learning Curve** | Low | Medium | Medium (reactive concepts needed) |
+| **Boilerplate** | Low | High (Contract definitions) | Medium (binding setup) |
+| **Primary Use** | Server-side Web | Android (old), .NET WinForms | SPA, Mobile, WPF |
+| **Representative Frameworks** | Rails, Django, Laravel | Android Views | React, SwiftUI, WPF |
 
-### 6.2 フレームワーク実装比較
+### 6.2 Framework Implementation Comparison
 
-| フレームワーク | パターン | Model | ViewModel/Controller | View | バインディング |
+| Framework | Pattern | Model | ViewModel/Controller | View | Binding |
 |--------------|---------|-------|---------------------|------|--------------|
-| **Rails** | MVC | ActiveRecord | Controller | ERB/Slim | なし（テンプレート） |
-| **Django** | MVC (MTV) | ORM Model | View (=Controller) | Template | なし（テンプレート） |
-| **Spring Boot** | MVC | @Entity / @Service | @Controller | Thymeleaf | なし（テンプレート） |
-| **React** | MVVM 風 | API / Store | Custom Hooks | JSX | useState / useEffect |
+| **Rails** | MVC | ActiveRecord | Controller | ERB/Slim | None (template) |
+| **Django** | MVC (MTV) | ORM Model | View (=Controller) | Template | None (template) |
+| **Spring Boot** | MVC | @Entity / @Service | @Controller | Thymeleaf | None (template) |
+| **React** | MVVM-like | API / Store | Custom Hooks | JSX | useState / useEffect |
 | **Vue 3** | MVVM | API / Pinia | Composition API | Template | ref / reactive |
-| **Svelte** | MVVM | API / Store | $state rune | Template | 自動リアクティブ |
+| **Svelte** | MVVM | API / Store | $state rune | Template | Auto-reactive |
 | **Angular** | MVVM | Service / NgRx | Component class | Template | [(ngModel)] / Signal |
-| **SwiftUI** | MVVM | Service 層 | ObservableObject | View struct | @Published / @Binding |
+| **SwiftUI** | MVVM | Service layer | ObservableObject | View struct | @Published / @Binding |
 | **Jetpack Compose** | MVVM | Repository | ViewModel | @Composable | StateFlow / MutableState |
 | **WPF** | MVVM | Data Layer | ViewModel (INotifyPropertyChanged) | XAML | {Binding} |
-| **Flutter** | MVVM 風 | Repository | Provider/Bloc/Riverpod | Widget | ChangeNotifier / Stream |
+| **Flutter** | MVVM-like | Repository | Provider/Bloc/Riverpod | Widget | ChangeNotifier / Stream |
 
-### 6.3 テスト戦略比較
+### 6.3 Testing Strategy Comparison
 
-| パターン | ユニットテスト対象 | モック対象 | テストの書きやすさ | UI テスト必要度 |
+| Pattern | Unit Test Targets | Mock Targets | Ease of Testing | UI Test Necessity |
 |---------|------------------|-----------|-------------------|---------------|
-| **MVC** | Model, Controller | DB, 外部 API | 中 | 高（View ロジックあり） |
-| **MVP** | Model, Presenter | View (Interface), DB | 高 | 低（View はパッシブ） |
-| **MVVM** | Model, ViewModel | API Client | 高 | 低（VM に全ロジック） |
+| **MVC** | Model, Controller | DB, external API | Medium | High (View has logic) |
+| **MVP** | Model, Presenter | View (Interface), DB | High | Low (View is passive) |
+| **MVVM** | Model, ViewModel | API Client | High | Low (all logic in VM) |
 
 ---
 
-## 7. アンチパターン
+## 7. Anti-Patterns
 
-### 7.1 Fat Controller（MVC）
+### 7.1 Fat Controller (MVC)
 
 ```ruby
-# NG: Controller にビジネスロジックを詰め込む
+# BAD: Stuffing business logic into the Controller
 class OrdersController < ApplicationController
   def create
     user = User.find(params[:user_id])
     items = params[:items].map { |i| Product.find(i[:product_id]) }
 
-    # ビジネスロジックが Controller に...
+    # Business logic leaking into Controller...
     total = items.sum(&:price)
     tax = total * 0.10
     discount = user.vip? ? total * 0.05 : 0
@@ -1700,7 +1700,7 @@ class OrdersController < ApplicationController
     order = Order.create!(user: user, total: final_total, tax: tax)
     items.each { |item| order.order_items.create!(product: item) }
 
-    # 通知も Controller で...
+    # Notifications also in Controller...
     OrderMailer.confirmation(order).deliver_later
     SlackNotifier.new_order(order)
 
@@ -1708,7 +1708,7 @@ class OrdersController < ApplicationController
   end
 end
 
-# OK: Service Object に分離
+# GOOD: Extract into a Service Object
 # app/services/create_order_service.rb
 class CreateOrderService
   def initialize(user_id:, items:)
@@ -1749,7 +1749,7 @@ class CreateOrderService
   end
 end
 
-# Controller は薄く
+# Keep the Controller thin
 class OrdersController < ApplicationController
   def create
     result = CreateOrderService.new(
@@ -1766,55 +1766,55 @@ class OrdersController < ApplicationController
 end
 ```
 
-**なぜ NG か**: Controller はリクエストのルーティングとレスポンスの制御のみを担当すべき。ビジネスロジックを含むと、テストが困難になり、ロジックの再利用もできない。
+**Why it's bad**: The Controller should only handle request routing and response control. Including business logic makes it hard to test and prevents logic reuse.
 
-### 7.2 God ViewModel（MVVM）
+### 7.2 God ViewModel (MVVM)
 
 ```typescript
-// NG: 1つの ViewModel に全ロジックを詰め込む
+// BAD: Stuffing all logic into one ViewModel
 function useDashboardGodViewModel() {
-  // ユーザー管理
+  // User management
   const [users, setUsers] = useState([]);
   const [userSearch, setUserSearch] = useState("");
-  // 注文管理
+  // Order management
   const [orders, setOrders] = useState([]);
   const [orderFilter, setOrderFilter] = useState("all");
-  // 通知管理
+  // Notification management
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
-  // 設定管理
+  // Settings management
   const [settings, setSettings] = useState({});
   const [theme, setTheme] = useState("light");
-  // 分析ダッシュボード
+  // Analytics dashboard
   const [analytics, setAnalytics] = useState({});
   const [dateRange, setDateRange] = useState({ from: null, to: null });
-  // ... 200行以上のロジック
+  // ... 200+ lines of logic
 
-  return { /* 50+ のプロパティとメソッド */ };
+  return { /* 50+ properties and methods */ };
 }
 
-// OK: 責務ごとに ViewModel を分割
+// GOOD: Split ViewModel by responsibility
 function useUserList() {
   const [users, setUsers] = useState<User[]>([]);
   const [search, setSearch] = useState("");
-  // ユーザー一覧に関するロジックのみ（30行以内）
+  // Only user list logic (within 30 lines)
   return { users, search, setSearch, loadUsers, addUser };
 }
 
 function useOrderManagement() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [filter, setFilter] = useState<OrderFilter>("all");
-  // 注文管理に関するロジックのみ
+  // Only order management logic
   return { orders, filter, setFilter, loadOrders };
 }
 
 function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  // 通知に関するロジックのみ
+  // Only notification logic
   return { notifications, unreadCount, markAsRead };
 }
 
-// コンポーネントで必要なものだけ組み合わせ
+// Compose only what's needed in the component
 function DashboardPage() {
   const userList = useUserList();
   const orders = useOrderManagement();
@@ -1830,14 +1830,14 @@ function DashboardPage() {
 }
 ```
 
-**なぜ NG か**: ViewModel が肥大化すると、テストが困難になり、変更の影響範囲が読めなくなる。1つの ViewModel の目安は状態3-5個、メソッド5-8個以内。
+**Why it's bad**: A bloated ViewModel is hard to test and makes it impossible to predict the scope of changes. A good rule of thumb: no more than 3–5 state values and 5–8 methods per ViewModel.
 
-### 7.3 View にビジネスロジック（共通）
+### 7.3 Business Logic in the View (Common to All Patterns)
 
 ```typescript
-// NG: View コンポーネント内にビジネスロジック
+// BAD: Business logic inside the View component
 function OrderSummary({ order }: { order: Order }) {
-  // ビジネスロジックが View に混在
+  // Business logic mixed into View
   const subtotal = order.items.reduce((sum, item) => sum + item.price * item.qty, 0);
   const taxRate = order.country === "JP" ? 0.10 : order.country === "US" ? 0.08 : 0.20;
   const tax = subtotal * taxRate;
@@ -1851,16 +1851,16 @@ function OrderSummary({ order }: { order: Order }) {
 
   return (
     <div>
-      <p>小計: {subtotal.toLocaleString()}円</p>
-      <p>税: {tax.toLocaleString()}円</p>
-      <p>割引: -{discount.toLocaleString()}円</p>
-      <p>合計: {total.toLocaleString()}円</p>
-      {freeShipping && <p>送料無料</p>}
+      <p>Subtotal: {subtotal.toLocaleString()}</p>
+      <p>Tax: {tax.toLocaleString()}</p>
+      <p>Discount: -{discount.toLocaleString()}</p>
+      <p>Total: {total.toLocaleString()}</p>
+      {freeShipping && <p>Free shipping</p>}
     </div>
   );
 }
 
-// OK: ViewModel にビジネスロジックを移動
+// GOOD: Move business logic to ViewModel
 function useOrderSummary(order: Order) {
   return useMemo(() => {
     const calculator = new OrderCalculator(order);
@@ -1874,43 +1874,43 @@ function useOrderSummary(order: Order) {
   }, [order]);
 }
 
-// View は表示のみ
+// View handles display only
 function OrderSummary({ order }: { order: Order }) {
   const { subtotal, tax, discount, total, freeShipping } = useOrderSummary(order);
 
   return (
     <div>
-      <p>小計: {subtotal.toLocaleString()}円</p>
-      <p>税: {tax.toLocaleString()}円</p>
-      <p>割引: -{discount.toLocaleString()}円</p>
-      <p>合計: {total.toLocaleString()}円</p>
-      {freeShipping && <p>送料無料</p>}
+      <p>Subtotal: {subtotal.toLocaleString()}</p>
+      <p>Tax: {tax.toLocaleString()}</p>
+      <p>Discount: -{discount.toLocaleString()}</p>
+      <p>Total: {total.toLocaleString()}</p>
+      {freeShipping && <p>Free shipping</p>}
     </div>
   );
 }
 ```
 
-**なぜ NG か**: View にビジネスロジックがあると、(1) 同じ計算を複数の View で重複実装する、(2) ロジックのユニットテストに UI レンダリングが必要になる、(3) デザイナーがレイアウト変更時にロジックを壊すリスクがある。
+**Why it's bad**: Business logic in the View means (1) the same calculation is duplicated across multiple Views, (2) unit testing the logic requires UI rendering, and (3) designers risk breaking logic when changing layout.
 
-### 7.4 ViewModel から View の直接操作（MVVM 違反）
+### 7.4 Direct View Manipulation from ViewModel (MVVM Violation)
 
 ```typescript
-// NG: ViewModel が DOM を直接操作
+// BAD: ViewModel directly manipulates the DOM
 function useScrollToTop() {
   const scrollToTop = () => {
-    // ViewModel が View (DOM) を知っている！
+    // ViewModel knows about the View (DOM)!
     document.getElementById("scroll-container")?.scrollTo(0, 0);
-    document.title = "ページトップ";
+    document.title = "Page Top";
   };
   return { scrollToTop };
 }
 
-// OK: ViewModel は状態のみを公開し、View が副作用を実行
+// GOOD: ViewModel only exposes state; View handles side effects
 function useListViewModel() {
   const [shouldScrollToTop, setShouldScrollToTop] = useState(false);
 
   const resetList = () => {
-    // 状態のみを変更
+    // Change state only
     setShouldScrollToTop(true);
     setPage(1);
   };
@@ -1918,7 +1918,7 @@ function useListViewModel() {
   return { shouldScrollToTop, setShouldScrollToTop, resetList };
 }
 
-// View が副作用を実行
+// View executes side effects
 function ListView() {
   const { shouldScrollToTop, setShouldScrollToTop, resetList } = useListViewModel();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -1934,24 +1934,24 @@ function ListView() {
 }
 ```
 
-**なぜ NG か**: MVVM の核心は「ViewModel が View を知らない」こと。ViewModel が DOM を操作すると、(1) ViewModel がブラウザ環境でしかテストできない、(2) React Native などへの移植ができない、(3) SSR でエラーになる。
+**Why it's bad**: The core of MVVM is that the ViewModel does not know the View. When the ViewModel manipulates the DOM, (1) the ViewModel can only be tested in a browser environment, (2) porting to React Native or similar is impossible, and (3) it causes errors in SSR.
 
 ---
 
-## 8. 実践演習
+## 8. Practice Exercises
 
-### 演習 1（基礎）: MVC の責務分離
+### Exercise 1 (Beginner): Separation of Concerns in MVC
 
-以下の「Fat Controller」を、適切に Model / Controller に責務を分離してリファクタリングせよ。
+Refactor the following "Fat Controller" to properly separate responsibilities between Model and Controller.
 
 ```typescript
-// リファクタリング対象
+// Target for refactoring
 class ProductController {
   async search(req: Request, res: Response) {
     const { query, minPrice, maxPrice, category } = req.query;
     const products = await db.query("SELECT * FROM products");
 
-    // フィルタリング（ビジネスロジック）
+    // Filtering (business logic)
     let filtered = products;
     if (query) {
       filtered = filtered.filter(p =>
@@ -1968,10 +1968,10 @@ class ProductController {
       filtered = filtered.filter(p => p.category === category);
     }
 
-    // ソート（ビジネスロジック）
+    // Sorting (business logic)
     filtered.sort((a, b) => b.salesCount - a.salesCount);
 
-    // ページネーション
+    // Pagination
     const page = Number(req.query.page) || 1;
     const perPage = 20;
     const start = (page - 1) * perPage;
@@ -1982,63 +1982,63 @@ class ProductController {
 }
 ```
 
-**期待する出力構造**:
-- `ProductModel` クラス: `search(criteria)`, `sortByPopularity()`, `paginate(page, perPage)` メソッド
-- `ProductController` クラス: 薄いリクエスト処理のみ（10行以内）
+**Expected output structure**:
+- `ProductModel` class: `search(criteria)`, `sortByPopularity()`, `paginate(page, perPage)` methods
+- `ProductController` class: thin request handling only (within 10 lines)
 
 ---
 
-### 演習 2（応用）: MVVM のテスト可能な設計
+### Exercise 2 (Intermediate): Testable MVVM Design
 
-TODO リストアプリの ViewModel を設計せよ。以下の要件を満たすこと:
+Design a ViewModel for a TODO list app that meets the following requirements:
 
-**要件**:
-1. TODO の追加・完了トグル・削除
-2. フィルタリング: All / Active / Completed
-3. 残りの未完了タスク数の表示
-4. 全完了トグル（全てのタスクを一括完了/未完了）
+**Requirements**:
+1. Add, toggle completion, and delete TODOs
+2. Filtering: All / Active / Completed
+3. Display the count of remaining incomplete tasks
+4. Toggle all (mark all tasks as complete/incomplete at once)
 
-**テスト**: 以下のテストケースが全てパスする ViewModel を実装せよ:
+**Tests**: Implement a ViewModel that passes all of the following test cases:
 
 ```typescript
 describe("useTodoList", () => {
-  test("TODO を追加できる", () => {
-    // addTodo("Buy milk") → todos の length が 1 増える
+  test("can add a TODO", () => {
+    // addTodo("Buy milk") → length of todos increases by 1
   });
 
-  test("空文字の TODO は追加できない", () => {
-    // addTodo("") → todos の length は変わらない
+  test("cannot add an empty TODO", () => {
+    // addTodo("") → length of todos does not change
   });
 
-  test("TODO の完了状態をトグルできる", () => {
-    // toggleTodo(id) → completed が反転
+  test("can toggle the completion state of a TODO", () => {
+    // toggleTodo(id) → completed is inverted
   });
 
-  test("フィルターで Active のみ表示できる", () => {
-    // filter = "active" → completed: false のみ
+  test("can display only Active items with filter", () => {
+    // filter = "active" → only completed: false
   });
 
-  test("残りの未完了タスク数が正しい", () => {
-    // 3個中1個完了 → remainingCount = 2
+  test("remaining incomplete task count is correct", () => {
+    // 1 of 3 completed → remainingCount = 2
   });
 
-  test("全完了トグルが動作する", () => {
-    // toggleAll() → 全て completed: true
-    // もう一度 toggleAll() → 全て completed: false
+  test("toggle all works correctly", () => {
+    // toggleAll() → all completed: true
+    // toggleAll() again → all completed: false
   });
 });
 ```
 
-**期待する出力**: `useTodoList()` Custom Hook の完全な実装とテストコード
+**Expected output**: Complete implementation of the `useTodoList()` Custom Hook and test code
 
 ---
 
-### 演習 3（発展）: パターン間の移行
+### Exercise 3 (Advanced): Migration Between Patterns
 
-既存の MVP 実装（Android Kotlin）を MVVM（Jetpack Compose）に移行せよ。以下の MVP コードを起点として:
+Migrate the following existing MVP implementation (Android Kotlin) to MVVM (Jetpack Compose), starting from this MVP code:
 
 ```kotlin
-// 既存 MVP コード
+// Existing MVP code
 interface WeatherContract {
     interface View {
         fun showTemperature(temp: String)
@@ -2054,56 +2054,56 @@ interface WeatherContract {
 }
 ```
 
-**移行要件**:
-1. `WeatherViewModel` (extends `ViewModel()`) として再設計
-2. `StateFlow` を使用した UI 状態管理
-3. `sealed class WeatherUiState` で状態を型安全に表現
-4. Compose UI の `@Composable` 関数として View を実装
-5. `FakeWeatherRepository` を使ったユニットテスト
+**Migration requirements**:
+1. Redesign as `WeatherViewModel` (extends `ViewModel()`)
+2. UI state management using `StateFlow`
+3. Type-safe state representation with `sealed class WeatherUiState`
+4. Implement the View as a `@Composable` function for Compose UI
+5. Unit tests using `FakeWeatherRepository`
 
-**期待する出力**:
+**Expected output**:
 - `WeatherUiState` sealed class
-- `WeatherViewModel` クラス
+- `WeatherViewModel` class
 - `WeatherScreen` Composable
-- `WeatherViewModelTest` テストクラス
+- `WeatherViewModelTest` test class
 
 ---
 
 ## 9. FAQ
 
-### Q1. React は MVC？ MVVM？
+### Q1. Is React MVC or MVVM?
 
-**A.** React 自体は「View ライブラリ」であり、特定のパターンを強制しない。ただし実際の運用では:
+**A.** React itself is a "View library" and does not enforce a specific pattern. However, in practice:
 
-- **Custom Hooks** = ViewModel（状態管理、ビジネスロジック）
-- **API クライアント / Store** = Model（データアクセス、ドメインロジック）
-- **JSX コンポーネント** = View（UI 描画）
+- **Custom Hooks** = ViewModel (state management, business logic)
+- **API client / Store** = Model (data access, domain logic)
+- **JSX components** = View (UI rendering)
 
-この構造は **MVVM に近い**。Facebook は当初「Flux（単方向データフロー）」を提唱したが、Hooks 登場後の開発スタイルは MVVM のデータバインディングに極めて近い。`useState` と `useEffect` の組み合わせが暗黙のバインディング機構として機能している。
+This structure is **close to MVVM**. Facebook initially advocated "Flux (unidirectional data flow)", but the development style after Hooks was introduced is very close to MVVM's data binding. The combination of `useState` and `useEffect` functions as an implicit binding mechanism.
 
-ただし注意点として、React の「状態更新 → 再レンダリング」は **単方向** であり、WPF のような **双方向** バインディングとは異なる。厳密には「単方向データバインディングの MVVM 変種」と言える。
+However, note that React's "state update → re-render" is **unidirectional**, unlike the **two-way** binding in WPF. Strictly speaking, it can be called a "unidirectional data binding MVVM variant."
 
-### Q2. サーバーサイドとクライアントサイドの MVC は同じもの？
+### Q2. Are server-side and client-side MVC the same thing?
 
-**A.** 名前は同じだが動作モデルが根本的に異なる:
+**A.** The name is the same, but the operating model is fundamentally different:
 
-| 比較軸 | サーバーサイド MVC | クライアントサイド MVC |
+| Aspect | Server-Side MVC | Client-Side MVC |
 |--------|-------------------|---------------------|
-| **ライフサイクル** | リクエスト/レスポンス単位（ステートレス） | アプリ起動〜終了（ステートフル） |
-| **状態の保持** | DB + セッション | メモリ内（リアクティブ） |
-| **View の更新** | HTML 全体を再生成 | DOM の差分更新 |
-| **ユーザー操作** | HTTP リクエスト | イベントハンドラ |
-| **Controller の寿命** | リクエスト処理中のみ | アプリ全体 |
+| **Lifecycle** | Per request/response (stateless) | App launch to close (stateful) |
+| **State persistence** | DB + session | In-memory (reactive) |
+| **View update** | Regenerates entire HTML | Partial DOM updates |
+| **User interaction** | HTTP requests | Event handlers |
+| **Controller lifetime** | Only during request processing | Entire app lifetime |
 
-サーバーサイドの Controller は「1リクエスト = 1インスタンス」で使い捨てだが、クライアントサイドの Controller/ViewModel は継続的に生存する。この違いにより、クライアントサイドでは MVC より **MVVM のほうが自然に適合する**。
+A server-side Controller is disposable — "1 request = 1 instance" — but a client-side Controller/ViewModel lives continuously. Due to this difference, **MVVM fits more naturally** than MVC on the client side.
 
-### Q3. MVVM の ViewModel が肥大化したらどうする？
+### Q3. What should I do when a MVVM ViewModel becomes too large?
 
-**A.** 3 つのアプローチがある:
+**A.** There are three approaches:
 
-1. **ViewModel の分割** — 画面の論理的なセクションごとに ViewModel を分ける
+1. **Split the ViewModel** — separate ViewModels for each logical section of the screen
    ```typescript
-   // 1つの画面に複数の ViewModel
+   // Multiple ViewModels for one screen
    function Dashboard() {
      const header = useHeaderViewModel();
      const userList = useUserListViewModel();
@@ -2111,64 +2111,64 @@ interface WeatherContract {
    }
    ```
 
-2. **UseCase / Interactor 層の導入** — ビジネスロジックを ViewModel から抽出
+2. **Introduce a UseCase / Interactor layer** — extract business logic out of the ViewModel
    ```typescript
-   // ViewModel は UseCase を呼ぶだけ
+   // ViewModel only calls UseCases
    function useOrderViewModel(createOrder: CreateOrderUseCase) {
      const submit = async (data) => {
        const result = await createOrder.execute(data);
-       // ViewModel はプレゼンテーションロジックのみ
+       // ViewModel handles presentation logic only
      };
    }
    ```
 
-3. **Composable ViewModel** — 小さな ViewModel を組み合わせて大きな画面を構成
+3. **Composable ViewModels** — compose small ViewModels to build large screens
    ```typescript
-   function usePagination() { /* ページネーションロジック */ }
-   function useSearch() { /* 検索ロジック */ }
-   function useSort() { /* ソートロジック */ }
+   function usePagination() { /* pagination logic */ }
+   function useSearch() { /* search logic */ }
+   function useSort() { /* sort logic */ }
 
-   // 合成
+   // Compose
    function useUserList() {
      const pagination = usePagination();
      const search = useSearch();
      const sort = useSort();
-     // 組み合わせて返す
+     // Combine and return
    }
    ```
 
-**目安**: ViewModel の状態が 5 個以上、メソッドが 8 個以上になったら分割を検討する。
+**Rule of thumb**: Consider splitting when a ViewModel has 5+ state values or 8+ methods.
 
-### Q4. MVC から MVVM に移行すべきタイミングは？
+### Q4. When should I migrate from MVC to MVVM?
 
-**A.** 以下の兆候が見られたら移行を検討する:
+**A.** Consider migrating when you see these signs:
 
-1. **Controller が肥大化** — 1つの Controller が 300行以上
-2. **テストが書けない** — UI をモックしないとテストできないロジックが増えた
-3. **リアクティブ要件** — リアルタイム更新、複雑な UI 状態遷移が必要
-4. **クロスプラットフォーム** — Web とモバイルでロジックを共有したい
+1. **Controller bloat** — a single Controller exceeds 300 lines
+2. **Untestable code** — more logic requires mocking the UI to test
+3. **Reactive requirements** — real-time updates or complex UI state transitions are needed
+4. **Cross-platform** — you want to share logic between web and mobile
 
-ただし「動いているサーバーサイド MVC」を無理に MVVM に移行する必要はない。フレームワークの規約に従うのが最善。
+That said, there is no need to forcibly migrate a "working server-side MVC." Following the framework's conventions is the best approach.
 
-### Q5. MVP と MVVM のどちらを選ぶべきか？
+### Q5. Should I choose MVP or MVVM?
 
-**A.** 現在（2024年以降）では、ほぼ全てのケースで **MVVM を選ぶべき**。理由:
+**A.** As of today (2024 and beyond), you should **choose MVVM in almost every case**. Reasons:
 
-1. 主要フレームワーク（React, SwiftUI, Compose, Vue, Angular）が全て MVVM 向け
-2. リアクティブプログラミングが主流になり、データバインディングが自然
-3. MVP の「View インターフェース + Presenter」は MVVM の「ViewModel + バインディング」より冗長
+1. All major frameworks (React, SwiftUI, Compose, Vue, Angular) are designed for MVVM
+2. Reactive programming has become mainstream, making data binding feel natural
+3. MVP's "View interface + Presenter" is more verbose than MVVM's "ViewModel + binding"
 
-**例外**: フレームワークなしで UI を構築する場合（カスタム描画エンジン等）は MVP が有効。
+**Exception**: MVP is valid when building a UI without a framework (e.g., custom rendering engines).
 
-### Q6. Clean Architecture と MVC/MVVM の関係は？
+### Q6. What is the relationship between Clean Architecture and MVC/MVVM?
 
-**A.** 直交する概念であり、組み合わせて使う:
+**A.** They are orthogonal concepts and are used together:
 
 ```
 ┌──────────────────────────────────────────────────┐
-│  Clean Architecture の層構造                      │
+│  Clean Architecture Layer Structure              │
 │                                                  │
-│  Presentation Layer ← ここに MVC/MVVM を適用     │
+│  Presentation Layer ← apply MVC/MVVM here        │
 │    ├── View (JSX / Template)                     │
 │    └── ViewModel / Controller                    │
 │                                                  │
@@ -2185,58 +2185,58 @@ interface WeatherContract {
 └──────────────────────────────────────────────────┘
 ```
 
-MVC/MVVM は **Presentation Layer のパターン**であり、Clean Architecture は **全レイヤーの依存関係ルール**を定義する。両者は補完関係にある。
+MVC/MVVM is a **Presentation Layer pattern**, while Clean Architecture defines **dependency rules across all layers**. The two are complementary.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining hands-on experience is the most important thing. Understanding deepens not just through theory, but by actually writing code and verifying how it works.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the basics and jumping straight to advanced topics. We recommend fully understanding the core concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world work?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is applied frequently in day-to-day development. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## 10. まとめ
+## 10. Summary
 
-| 項目 | ポイント |
+| Item | Key Points |
 |------|---------|
-| **MVC** | サーバーサイド Web のデファクト。HTTP のリクエスト/レスポンスモデルと自然に対応。Controller は薄く保つ |
-| **MVP** | View と Presenter の明確な分離。テスト容易性が高いが、ボイラープレートが多い。レガシー Android で使用 |
-| **MVVM** | データバインディングによる宣言的 UI。SPA とモバイルのデファクト。ViewModel は View を知らない |
-| **選定基準** | フレームワークの推奨パターンに従うのが最善。迷ったら MVVM |
-| **共通原則** | 関心の分離、薄い Controller/ViewModel、テスト可能な設計 |
-| **テスト** | MVC: Controller テスト、MVP: Presenter テスト、MVVM: ViewModel テスト。いずれも View なしでテスト可能にする |
-| **進化の方向** | MVC(1979) → MVP(1990s) → MVVM(2005) → 宣言的UI(2019+)。View の受動化が一貫したトレンド |
-| **アンチパターン** | Fat Controller、God ViewModel、View にビジネスロジック、ViewModel の View 直接操作 |
+| **MVC** | De facto standard for server-side web. Maps naturally to HTTP request/response. Keep the Controller thin. |
+| **MVP** | Clear separation between View and Presenter. High testability but lots of boilerplate. Used in legacy Android. |
+| **MVVM** | Declarative UI via data binding. De facto for SPA and mobile. ViewModel does not know the View. |
+| **Selection criteria** | Follow the framework's recommended pattern. When in doubt, choose MVVM. |
+| **Common principles** | Separation of concerns, thin Controller/ViewModel, testable design. |
+| **Testing** | MVC: Controller tests. MVP: Presenter tests. MVVM: ViewModel tests. Make all testable without the View. |
+| **Direction of evolution** | MVC(1979) → MVP(1990s) → MVVM(2005) → Declarative UI(2019+). Passivation of the View is a consistent trend. |
+| **Anti-patterns** | Fat Controller, God ViewModel, business logic in View, ViewModel directly manipulating the View. |
 
 ---
 
-## 次に読むべきガイド
+## What to Read Next
 
-- [01-repository-pattern.md](./01-repository-pattern.md) — データアクセス層の抽象化（MVVM の Model 層設計）
-- [02-event-sourcing-cqrs.md](./02-event-sourcing-cqrs.md) — イベント駆動アーキテクチャ（CQRS の Command/Query 分離）
-- [../02-behavioral/](../02-behavioral/) — Observer パターン（MVVM のデータバインディングの基盤）
-- ../../clean-code-principles/ — 関心の分離、SOLID 原則
-- ../../system-design-guide/ — アーキテクチャ設計の全体像
+- [01-repository-pattern.md](./01-repository-pattern.md) — Abstracting the data access layer (Model layer design in MVVM)
+- [02-event-sourcing-cqrs.md](./02-event-sourcing-cqrs.md) — Event-driven architecture (Command/Query separation in CQRS)
+- [../02-behavioral/](../02-behavioral/) — Observer pattern (the foundation of MVVM's data binding)
+- ../../clean-code-principles/ — Separation of concerns, SOLID principles
+- ../../system-design-guide/ — Overall picture of architecture design
 
 ---
 
-## 参考文献
+## References
 
 1. **Trygve Reenskaug** — "The original MVC reports" (1979) — https://folk.universitetetioslo.no/trygver/themes/mvc/mvc-index.html
 2. **Martin Fowler** — "GUI Architectures" — https://martinfowler.com/eaaDev/uiArchs.html
 3. **Microsoft** — "The MVVM Pattern" — https://learn.microsoft.com/en-us/dotnet/architecture/maui/mvvm
 4. **Apple Developer Documentation** — "Model-View-ViewModel" — https://developer.apple.com/documentation/swiftui/model-data
 5. **Android Developers** — "Guide to app architecture" — https://developer.android.com/topic/architecture
-6. **Josh W. Comeau** — "The Wave of React" — Custom Hooks as ViewModel パターンの解説
-7. **Robert C. Martin** — "Clean Architecture" (2017) — Presentation Layer パターンと Clean Architecture の関係
+6. **Josh W. Comeau** — "The Wave of React" — Explanation of Custom Hooks as ViewModel pattern
+7. **Robert C. Martin** — "Clean Architecture" (2017) — Relationship between Presentation Layer patterns and Clean Architecture

--- a/03-software-design/design-patterns-guide/docs/04-architectural/01-repository-pattern.md
+++ b/03-software-design/design-patterns-guide/docs/04-architectural/01-repository-pattern.md
@@ -1,57 +1,57 @@
-# Repository パターン — データアクセス抽象化
+# Repository Pattern — Data Access Abstraction
 
-> Repository パターンでデータアクセスロジックをビジネスロジックから完全に分離し、テスト容易性・保守性・データソースの切り替え可能性を実現するための実践ガイド。DDD における集約ルートとの関係、Unit of Work、Specification パターンとの組み合わせ、ORM 別の実装例まで網羅する。
+> A practical guide to completely separating data access logic from business logic using the Repository pattern, achieving testability, maintainability, and the ability to swap data sources. Covers the relationship with aggregate roots in DDD, combining with Unit of Work and Specification patterns, and concrete implementation examples for various ORMs.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| オブジェクト指向プログラミング | 中級（インターフェース、抽象クラス、DI） | [02-programming](../../../../02-programming/) |
-| TypeScript / Python 基礎 | 中級（ジェネリクス、async/await） | [02-programming](../../../../02-programming/) |
-| SQL の基礎 | 基礎（SELECT, INSERT, JOIN） | [06-data-and-security](../../../../06-data-and-security/) |
-| SOLID 原則 | 基礎（依存性逆転原則 DIP） | ../../clean-code-principles/ |
-| MVC / MVVM の基礎 | 基礎 | [00-mvc-mvvm.md](./00-mvc-mvvm.md) |
+| Object-Oriented Programming | Intermediate (interfaces, abstract classes, DI) | [02-programming](../../../../02-programming/) |
+| TypeScript / Python basics | Intermediate (generics, async/await) | [02-programming](../../../../02-programming/) |
+| SQL basics | Foundational (SELECT, INSERT, JOIN) | [06-data-and-security](../../../../06-data-and-security/) |
+| SOLID principles | Foundational (Dependency Inversion Principle DIP) | ../../clean-code-principles/ |
+| MVC / MVVM basics | Foundational | [00-mvc-mvvm.md](./00-mvc-mvvm.md) |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. **Repository パターン** の目的と構造、ドメイン駆動設計（DDD）での位置付け
-2. **インターフェースと実装の分離** — 依存性逆転原則（DIP）に基づくテスト可能な設計
-3. **実装パターン** — Specific Repository、Generic Repository、Specification パターン
-4. **Unit of Work パターン** — 複数 Repository のトランザクション管理
-5. **ORM 別実装** — Prisma、SQLAlchemy、TypeORM、Drizzle での具体的実装
+1. **Repository pattern** — purpose, structure, and its role in Domain-Driven Design (DDD)
+2. **Separating interface from implementation** — testable design based on the Dependency Inversion Principle (DIP)
+3. **Implementation patterns** — Specific Repository, Generic Repository, Specification pattern
+4. **Unit of Work pattern** — transaction management across multiple Repositories
+5. **ORM-specific implementations** — concrete examples with Prisma, SQLAlchemy, TypeORM, and Drizzle
 
 ---
 
-## 1. Repository パターンの全体像
+## 1. Overview of the Repository Pattern
 
-### WHY: なぜ Repository パターンが必要か
+### WHY: Why Do We Need the Repository Pattern?
 
-データアクセスコードがビジネスロジックに混在すると、以下の問題が発生する:
+When data access code is mixed into business logic, the following problems arise:
 
-1. **テスト困難** — ビジネスロジックのテストにデータベース接続が必要
-2. **変更の波及** — DB スキーマ変更や ORM 変更が全てのサービスに影響
-3. **重複コード** — 同じクエリが複数箇所に散在
-4. **関心の分離違反** — 「何のデータが必要か」と「どうやって取得するか」が混在
+1. **Hard to test** — testing business logic requires a database connection
+2. **Cascading changes** — DB schema changes or ORM changes affect all services
+3. **Duplicate code** — the same queries are scattered across multiple places
+4. **Violation of separation of concerns** — "what data is needed" and "how to retrieve it" are intermixed
 
-Repository パターンはこれらを解決する:
+The Repository pattern solves these issues:
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│  Repository なし（NG）                                │
+│  Without Repository (BAD)                             │
 │                                                      │
 │  ┌────────────────────────────────────┐              │
 │  │ UserService                        │              │
 │  │                                    │              │
 │  │ async createUser(data) {           │              │
-│  │   // SQL が直接埋め込まれている     │              │
+│  │   // SQL is embedded directly      │              │
 │  │   await db.query(                  │              │
 │  │     "INSERT INTO users ..."        │              │
 │  │   );                               │              │
-│  │   // ビジネスロジックと DB が混在   │              │
+│  │   // Business logic mixed with DB  │              │
 │  │   if (user.role === "admin") {     │              │
 │  │     await db.query(                │              │
 │  │       "INSERT INTO audit_log ..."  │              │
@@ -59,120 +59,121 @@ Repository パターンはこれらを解決する:
 │  │   }                                │              │
 │  │ }                                  │              │
 │  └────────────────────────────────────┘              │
-│  問題: テスト困難、DB 変更時に全箇所修正              │
+│  Problem: hard to test, must update all places on DB change │
 └──────────────────────────────────────────────────────┘
 
 ┌──────────────────────────────────────────────────────┐
-│  Repository あり（OK）                                │
+│  With Repository (GOOD)                               │
 │                                                      │
 │  ┌──────────────┐     ┌──────────────────┐           │
 │  │ UserService  │ ──→ │ UserRepository   │(Interface)│
-│  │ (ビジネス    │     │  findById()      │           │
-│  │  ロジック)   │     │  save()          │           │
+│  │ (Business    │     │  findById()      │           │
+│  │  Logic)      │     │  save()          │           │
 │  └──────────────┘     │  findByEmail()   │           │
 │                       └────────┬─────────┘           │
-│         テスト時              │         本番時       │
+│        For tests              │      For production  │
 │    ┌──────────────┐  ┌───────▼─────────┐             │
 │    │ InMemory     │  │ PostgresUser    │             │
-│    │ Repository   │  │ Repository      │ (実装)      │
-│    └──────────────┘  │ (SQL はここだけ)  │             │
+│    │ Repository   │  │ Repository      │ (impl)      │
+│    └──────────────┘  │ (SQL only here)  │             │
 │                      └─────────────────┘             │
-│  利点: テスト容易、DB 変更は実装クラスのみ            │
+│  Benefits: easy to test, DB changes only affect impl class │
 └──────────────────────────────────────────────────────┘
 ```
 
-### 1.1 依存性逆転原則（DIP）との関係
+### 1.1 Relationship with the Dependency Inversion Principle (DIP)
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│  依存性逆転原則 (Dependency Inversion Principle)           │
+│  Dependency Inversion Principle (DIP)                     │
 │                                                           │
-│  NG: 上位モジュールが下位モジュールに直接依存               │
+│  BAD: Upper module directly depends on lower module       │
 │                                                           │
-│  UserService ──→ PostgresUserRepository ──→ PostgreSQL     │
-│  (上位)          (下位)                    (詳細)          │
+│  UserService ──→ PostgresUserRepository ──→ PostgreSQL    │
+│  (upper)         (lower)                   (detail)       │
 │                                                           │
-│  問題: PostgreSQL を MongoDB に変えると UserService も変更  │
+│  Problem: changing PostgreSQL to MongoDB also requires    │
+│           changing UserService                            │
 │                                                           │
 │  ─────────────────────────────────────────────────────── │
 │                                                           │
-│  OK: 上位モジュールが抽象（インターフェース）に依存         │
+│  GOOD: Upper module depends on abstraction (interface)    │
 │                                                           │
-│  UserService ──→ UserRepository (Interface)                │
-│  (上位)          (抽象)                                    │
+│  UserService ──→ UserRepository (Interface)               │
+│  (upper)         (abstraction)                            │
 │                       ▲                                   │
-│                       │ 実装                               │
-│                       │                                    │
-│              PostgresUserRepository ──→ PostgreSQL          │
-│              MongoUserRepository   ──→ MongoDB              │
-│              InMemoryUserRepository (テスト用)              │
+│                       │ implements                        │
+│                       │                                   │
+│              PostgresUserRepository ──→ PostgreSQL        │
+│              MongoUserRepository   ──→ MongoDB            │
+│              InMemoryUserRepository (for tests)           │
 │                                                           │
-│  利点: UserService は具体的な DB を知らない                 │
-│        DB 変更時は実装クラスを差し替えるだけ                │
+│  Benefit: UserService does not know the concrete DB       │
+│           Swapping the DB only requires changing the impl │
 └───────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 レイヤーアーキテクチャでの位置付け
+### 1.2 Position in Layered Architecture
 
 ```
 ┌──────────────────────────────────────────────────┐
 │  Presentation Layer (Controller / Handler)         │
-│  → HTTP リクエスト/レスポンスの処理                │
+│  → Handles HTTP requests/responses                │
 ├──────────────────────────────────────────────────┤
 │  Application Layer (Service / UseCase)             │
-│  → ユースケースの調整、トランザクション管理        │
-│  → Repository Interface を利用                    │
+│  → Orchestrates use cases, manages transactions   │
+│  → Uses Repository Interface                      │
 ├──────────────────────────────────────────────────┤
 │  Domain Layer (Entity / Value Object)              │
-│  → ビジネスルール、ドメインロジック                │
+│  → Business rules, domain logic                   │
 │  ┌─────────────────────────────────┐              │
-│  │ Repository Interface            │ ← ここに定義 │
-│  │ (ドメイン層に属する)            │              │
+│  │ Repository Interface            │ ← defined here │
+│  │ (belongs to domain layer)       │              │
 │  └─────────────────────────────────┘              │
 ├──────────────────────────────────────────────────┤
 │  Infrastructure Layer                              │
 │  ┌─────────────────────────────────┐              │
-│  │ Repository Implementation       │ ← ここに実装 │
-│  │ (PostgresUserRepository 等)     │              │
+│  │ Repository Implementation       │ ← implemented here │
+│  │ (PostgresUserRepository, etc.)  │              │
 │  └─────────────────────────────────┘              │
-│  → DB アクセス、外部 API 呼び出し                 │
+│  → DB access, external API calls                  │
 └──────────────────────────────────────────────────┘
 
-重要: Interface はドメイン層、Implementation はインフラ層
-      → 依存の方向が内側（ドメイン）に向かう
+Important: Interface belongs to the domain layer, Implementation to the infrastructure layer
+           → The direction of dependency points inward (toward the domain)
 ```
 
-### 1.3 DDD における集約（Aggregate）と Repository
+### 1.3 Aggregates and Repositories in DDD
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│  DDD の集約ルート (Aggregate Root) と Repository           │
+│  Aggregate Root and Repository in DDD                     │
 │                                                           │
-│  原則: Repository は「集約ルートごと」に1つ                │
+│  Principle: one Repository per Aggregate Root             │
 │                                                           │
-│  ┌─────────── Order 集約 ───────────┐                     │
-│  │  Order (集約ルート) ★              │                     │
-│  │    ├── OrderItem                  │                     │
-│  │    ├── OrderItem                  │                     │
-│  │    └── ShippingAddress            │                     │
-│  └───────────────────────────────────┘                     │
+│  ┌─────────── Order Aggregate ─────────┐                  │
+│  │  Order (Aggregate Root) ★            │                  │
+│  │    ├── OrderItem                    │                  │
+│  │    ├── OrderItem                    │                  │
+│  │    └── ShippingAddress              │                  │
+│  └─────────────────────────────────────┘                  │
 │           │                                               │
 │           ▼                                               │
 │  ┌────────────────────────────┐                           │
-│  │  OrderRepository           │  ← 集約ルート単位          │
+│  │  OrderRepository           │  ← per aggregate root    │
 │  │  findById(id): Order       │  ← Order + Items + Address│
-│  │  save(order): void         │  ← 一括保存               │
+│  │  save(order): void         │  ← saves as a whole      │
 │  └────────────────────────────┘                           │
 │                                                           │
-│  NG: OrderItemRepository は作らない                        │
-│      → OrderItem は Order 集約の一部であり、               │
-│        単独で取得・保存すべきでない                         │
+│  BAD: Do not create an OrderItemRepository                │
+│       → OrderItem is part of the Order aggregate and      │
+│         should not be retrieved or saved independently    │
 │                                                           │
-│  OK: Customer 集約は別の Repository                        │
-│  ┌─────────── Customer 集約 ──────────┐                    │
-│  │  Customer (集約ルート) ★            │                    │
-│  │    └── Address                     │                    │
-│  └────────────────────────────────────┘                    │
+│  GOOD: Customer aggregate has its own Repository          │
+│  ┌─────────── Customer Aggregate ──────┐                  │
+│  │  Customer (Aggregate Root) ★         │                  │
+│  │    └── Address                      │                  │
+│  └─────────────────────────────────────┘                  │
 │           │                                               │
 │           ▼                                               │
 │  ┌────────────────────────────┐                           │
@@ -183,9 +184,9 @@ Repository パターンはこれらを解決する:
 
 ---
 
-## 2. TypeScript での実装
+## 2. Implementation in TypeScript
 
-### 2.1 インターフェースと実装の分離（Prisma）
+### 2.1 Separating Interface from Implementation (Prisma)
 
 ```typescript
 // ============================================================
@@ -217,7 +218,7 @@ export interface PaginatedResult<T> {
   hasPrev: boolean;
 }
 
-// Repository Interface — ドメイン層で定義
+// Repository Interface — defined in the domain layer
 export interface UserRepository {
   findById(id: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;
@@ -233,7 +234,7 @@ export interface UserRepository {
 
 ```typescript
 // ============================================================
-// Infrastructure Layer: PostgreSQL 実装（Prisma）
+// Infrastructure Layer: PostgreSQL implementation (Prisma)
 // infrastructure/repositories/PrismaUserRepository.ts
 // ============================================================
 
@@ -251,7 +252,7 @@ export class PrismaUserRepository implements UserRepository {
   async findById(id: string): Promise<User | null> {
     const row = await this.prisma.user.findUnique({
       where: { id },
-      include: { profile: true },  // 集約の関連エンティティも取得
+      include: { profile: true },  // also fetch related entities in the aggregate
     });
     return row ? this.toDomain(row) : null;
   }
@@ -268,7 +269,7 @@ export class PrismaUserRepository implements UserRepository {
     const perPage = options?.perPage ?? 20;
     const skip = (page - 1) * perPage;
 
-    // フィルター条件の構築
+    // Build filter conditions
     const where: Record<string, unknown> = {};
     if (options?.filter?.active !== undefined) {
       where.active = options.filter.active;
@@ -373,7 +374,7 @@ export class PrismaUserRepository implements UserRepository {
     return this.prisma.user.count({ where });
   }
 
-  // ドメインモデルへの変換
+  // Convert to domain model
   private toDomain(row: PrismaUser): User {
     return new User({
       id: row.id,
@@ -388,11 +389,11 @@ export class PrismaUserRepository implements UserRepository {
 }
 ```
 
-### 2.2 テスト用のインメモリ実装
+### 2.2 In-Memory Implementation for Testing
 
 ```typescript
 // ============================================================
-// Test: In-Memory 実装
+// Test: In-Memory implementation
 // tests/repositories/InMemoryUserRepository.ts
 // ============================================================
 
@@ -412,7 +413,7 @@ export class InMemoryUserRepository implements UserRepository {
   async findAll(options?: FindOptions): Promise<PaginatedResult<User>> {
     let all = [...this.users.values()];
 
-    // フィルタリング
+    // Filtering
     if (options?.filter?.active !== undefined) {
       all = all.filter((u) => u.active === options.filter!.active);
     }
@@ -425,7 +426,7 @@ export class InMemoryUserRepository implements UserRepository {
       );
     }
 
-    // ソート
+    // Sorting
     const sortBy = options?.sortBy ?? "createdAt";
     const sortOrder = options?.sortOrder ?? "desc";
     all.sort((a, b) => {
@@ -435,7 +436,7 @@ export class InMemoryUserRepository implements UserRepository {
       return sortOrder === "desc" ? -cmp : cmp;
     });
 
-    // ページネーション
+    // Pagination
     const page = options?.page ?? 1;
     const perPage = options?.perPage ?? 20;
     const start = (page - 1) * perPage;
@@ -485,7 +486,7 @@ export class InMemoryUserRepository implements UserRepository {
     return all.length;
   }
 
-  // テストヘルパー
+  // Test helpers
   clear(): void {
     this.users.clear();
   }
@@ -500,7 +501,7 @@ export class InMemoryUserRepository implements UserRepository {
 }
 ```
 
-### 2.3 Service 層での使用と DI
+### 2.3 Usage in the Service Layer and DI
 
 ```typescript
 // ============================================================
@@ -510,25 +511,25 @@ export class InMemoryUserRepository implements UserRepository {
 
 export class UserService {
   constructor(
-    private readonly userRepo: UserRepository,   // インターフェースに依存
+    private readonly userRepo: UserRepository,   // depends on the interface
     private readonly emailService: EmailService,
     private readonly eventBus: EventBus,
   ) {}
 
   async registerUser(name: string, email: string): Promise<User> {
-    // ビジネスルールの検証
+    // Validate business rules
     const existing = await this.userRepo.exists(email);
     if (existing) {
       throw new DuplicateEmailError(email);
     }
 
-    // ドメインオブジェクト生成
+    // Create domain object
     const user = User.create(name, email);
 
-    // 永続化
+    // Persist
     const saved = await this.userRepo.save(user);
 
-    // 副作用（ドメインイベント発行）
+    // Side effects (publish domain event)
     await this.eventBus.publish(new UserRegisteredEvent(saved));
     await this.emailService.sendWelcome(saved.email);
 
@@ -553,26 +554,26 @@ export class UserService {
 }
 
 // ============================================================
-// DI Container（tsyringe の例）
+// DI Container (tsyringe example)
 // ============================================================
 import { container } from "tsyringe";
 
-// 本番環境: PostgreSQL 実装を注入
+// Production environment: inject PostgreSQL implementation
 container.register<UserRepository>("UserRepository", {
   useClass: PrismaUserRepository,
 });
 
-// テスト環境: InMemory 実装を注入
+// Test environment: inject InMemory implementation
 container.register<UserRepository>("UserRepository", {
   useClass: InMemoryUserRepository,
 });
 ```
 
-### 2.4 Service のテスト
+### 2.4 Testing the Service
 
 ```typescript
 // ============================================================
-// テスト — InMemory Repository を使用
+// Tests — using InMemory Repository
 // ============================================================
 
 describe("UserService", () => {
@@ -589,40 +590,40 @@ describe("UserService", () => {
   });
 
   describe("registerUser", () => {
-    test("新規ユーザーを登録できる", async () => {
+    test("can register a new user", async () => {
       const user = await service.registerUser("Alice", "alice@example.com");
 
-      // ドメインの検証
+      // Validate domain properties
       expect(user.name).toBe("Alice");
       expect(user.email).toBe("alice@example.com");
       expect(user.active).toBe(true);
 
-      // 永続化の検証
+      // Validate persistence
       const found = await userRepo.findByEmail("alice@example.com");
       expect(found).not.toBeNull();
       expect(found!.id).toBe(user.id);
 
-      // 副作用の検証
+      // Validate side effects
       expect(emailService.sendWelcome).toHaveBeenCalledWith("alice@example.com");
       expect(eventBus.publish).toHaveBeenCalledWith(
         expect.objectContaining({ type: "UserRegistered" })
       );
     });
 
-    test("重複メールアドレスはエラー", async () => {
+    test("throws error for duplicate email address", async () => {
       await service.registerUser("Alice", "alice@example.com");
 
       await expect(
         service.registerUser("Bob", "alice@example.com")
       ).rejects.toThrow(DuplicateEmailError);
 
-      // 副作用が呼ばれないことを検証
+      // Validate that side effects were not called again
       expect(emailService.sendWelcome).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("deactivateUser", () => {
-    test("ユーザーを無効化できる", async () => {
+    test("can deactivate a user", async () => {
       const user = await service.registerUser("Alice", "alice@example.com");
       await service.deactivateUser(user.id);
 
@@ -630,7 +631,7 @@ describe("UserService", () => {
       expect(found!.active).toBe(false);
     });
 
-    test("存在しないユーザーはエラー", async () => {
+    test("throws error for non-existent user", async () => {
       await expect(
         service.deactivateUser("non-existent-id")
       ).rejects.toThrow(UserNotFoundError);
@@ -638,7 +639,7 @@ describe("UserService", () => {
   });
 
   describe("getUserList", () => {
-    test("アクティブユーザーのみ返す", async () => {
+    test("returns only active users", async () => {
       const alice = await service.registerUser("Alice", "alice@example.com");
       await service.registerUser("Bob", "bob@example.com");
       await service.deactivateUser(alice.id);
@@ -653,9 +654,9 @@ describe("UserService", () => {
 
 ---
 
-## 3. Python での実装
+## 3. Implementation in Python
 
-### 3.1 Abstract Base Class による定義
+### 3.1 Definition Using Abstract Base Class
 
 ```python
 # ============================================================
@@ -686,7 +687,7 @@ class PaginatedResult:
 
     @property
     def total_pages(self) -> int:
-        return -(-self.total // self.per_page)  # 切り上げ除算
+        return -(-self.total // self.per_page)  # ceiling division
 
     @property
     def has_next(self) -> bool:
@@ -698,7 +699,7 @@ class PaginatedResult:
 
 
 class UserRepository(ABC):
-    """ユーザーリポジトリインターフェース（ドメイン層で定義）"""
+    """User repository interface (defined in the domain layer)"""
 
     @abstractmethod
     async def find_by_id(self, user_id: str) -> Optional[User]:
@@ -739,7 +740,7 @@ from infrastructure.models import UserModel
 
 
 class SQLAlchemyUserRepository(UserRepository):
-    """SQLAlchemy を使った PostgreSQL 実装"""
+    """PostgreSQL implementation using SQLAlchemy"""
 
     def __init__(self, session: AsyncSession):
         self._session = session
@@ -759,11 +760,11 @@ class SQLAlchemyUserRepository(UserRepository):
     async def find_all(self, options: Optional[FindOptions] = None) -> PaginatedResult:
         opts = options or FindOptions()
 
-        # 基本クエリ
+        # Base query
         stmt = select(UserModel)
         count_stmt = select(func.count()).select_from(UserModel)
 
-        # フィルター
+        # Filters
         if opts.active is not None:
             stmt = stmt.where(UserModel.active == opts.active)
             count_stmt = count_stmt.where(UserModel.active == opts.active)
@@ -771,17 +772,17 @@ class SQLAlchemyUserRepository(UserRepository):
             stmt = stmt.where(UserModel.role == opts.role)
             count_stmt = count_stmt.where(UserModel.role == opts.role)
 
-        # ソート
+        # Sorting
         sort_col = getattr(UserModel, opts.sort_by, UserModel.created_at)
         stmt = stmt.order_by(
             sort_col.desc() if opts.sort_order == "desc" else sort_col.asc()
         )
 
-        # ページネーション
+        # Pagination
         offset = (opts.page - 1) * opts.per_page
         stmt = stmt.offset(offset).limit(opts.per_page)
 
-        # 実行
+        # Execute
         result = await self._session.execute(stmt)
         count_result = await self._session.execute(count_stmt)
         rows = result.scalars().all()
@@ -832,7 +833,7 @@ class SQLAlchemyUserRepository(UserRepository):
 
 ```python
 # ============================================================
-# テスト用 InMemory 実装
+# InMemory implementation for testing
 # tests/repositories/in_memory_user_repository.py
 # ============================================================
 class InMemoryUserRepository(UserRepository):
@@ -851,13 +852,13 @@ class InMemoryUserRepository(UserRepository):
         opts = options or FindOptions()
         users = list(self._users.values())
 
-        # フィルター
+        # Filters
         if opts.active is not None:
             users = [u for u in users if u.active == opts.active]
         if opts.role:
             users = [u for u in users if u.role == opts.role]
 
-        # ページネーション
+        # Pagination
         total = len(users)
         start = (opts.page - 1) * opts.per_page
         data = users[start:start + opts.per_page]
@@ -882,38 +883,38 @@ class InMemoryUserRepository(UserRepository):
 
 ---
 
-## 4. Specification パターン
+## 4. Specification Pattern
 
-### WHY: なぜ Specification パターンが必要か
+### WHY: Why Do We Need the Specification Pattern?
 
-複雑な検索条件を Repository のメソッドとして追加し続けると、インターフェースが肥大化する:
+Continuously adding methods to the Repository for complex search conditions causes the interface to bloat:
 
 ```typescript
-// NG: 検索条件ごとにメソッドが増殖
+// BAD: methods multiply for each search condition
 interface UserRepository {
   findByName(name: string): Promise<User[]>;
   findByRole(role: string): Promise<User[]>;
   findByNameAndRole(name: string, role: string): Promise<User[]>;
   findActiveByRole(role: string): Promise<User[]>;
   findInactiveCreatedBefore(date: Date): Promise<User[]>;
-  // ... 無限に増える
+  // ... grows indefinitely
 }
 
-// OK: Specification パターンで条件をオブジェクト化
+// GOOD: Specification pattern turns conditions into objects
 interface UserRepository {
   findAll(spec?: Specification<User>): Promise<User[]>;
-  // 1つのメソッドで全ての検索条件に対応
+  // a single method handles all search conditions
 }
 ```
 
-### 4.1 Specification の実装
+### 4.1 Implementing the Specification
 
 ```typescript
 // ============================================================
-// Specification パターン
+// Specification Pattern
 // ============================================================
 
-// 基底 Specification
+// Base Specification
 interface Specification<T> {
   isSatisfiedBy(entity: T): boolean;
   toSQL(): { where: string; params: unknown[] };
@@ -992,7 +993,7 @@ class NotSpecification<T> extends BaseSpecification<T> {
   }
 }
 
-// 具体的な Specification
+// Concrete Specifications
 class ActiveUserSpec extends BaseSpecification<User> {
   isSatisfiedBy(user: User): boolean {
     return user.active;
@@ -1031,41 +1032,41 @@ class CreatedAfterSpec extends BaseSpecification<User> {
   }
 }
 
-// 使用例: 条件を組み合わせ
+// Usage example: combining conditions
 const activeAdmins = new ActiveUserSpec().and(new UserWithRoleSpec("admin"));
 const recentOrAdmin = new CreatedAfterSpec(lastMonth).or(new UserWithRoleSpec("admin"));
 
-// Repository での使用
+// Using with Repository
 const users = await userRepo.findAll(activeAdmins);
 ```
 
 ---
 
-## 5. Unit of Work パターンとの組み合わせ
+## 5. Combining with the Unit of Work Pattern
 
-### WHY: なぜ Unit of Work が必要か
+### WHY: Why Do We Need Unit of Work?
 
-複数の Repository にまたがる操作をアトミックに実行したい場合、各 Repository が独立にコミットすると不整合が生じる:
+When you want to execute operations spanning multiple Repositories atomically, having each Repository commit independently can cause inconsistencies:
 
 ```
-NG: 各 Repository が独立してコミット
-  OrderRepository.save(order)    → 成功（コミット済み）
-  UserRepository.updatePoints()  → 失敗（ロールバック）
-  → 注文は作成されたがポイントが付与されていない不整合
+BAD: each Repository commits independently
+  OrderRepository.save(order)    → succeeds (already committed)
+  UserRepository.updatePoints()  → fails (rolled back)
+  → order was created but points were never awarded — inconsistent state
 
-OK: Unit of Work で一括コミット
-  UnitOfWork 開始
-    OrderRepository.save(order)     → トランザクション内
-    UserRepository.updatePoints()   → トランザクション内
-  UnitOfWork.commit()               → 全ての変更を一括コミット
-  失敗時 → UnitOfWork.rollback()    → 全ての変更を一括ロールバック
+GOOD: batch commit with Unit of Work
+  UnitOfWork begins
+    OrderRepository.save(order)     → inside transaction
+    UserRepository.updatePoints()   → inside transaction
+  UnitOfWork.commit()               → commits all changes at once
+  On failure → UnitOfWork.rollback() → rolls back all changes at once
 ```
 
-### 5.1 Unit of Work の構造
+### 5.1 Unit of Work Structure
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│              Unit of Work パターン                     │
+│              Unit of Work Pattern                     │
 │                                                      │
 │  ┌──────────────────────────────────────┐            │
 │  │ UnitOfWork                           │            │
@@ -1078,20 +1079,20 @@ OK: Unit of Work で一括コミット
 │  │  └─────────────────┘                │            │
 │  │  ┌─────────────────┐                │            │
 │  │  │ Transaction     │                │            │
-│  │  │ (共有)          │                │            │
+│  │  │ (shared)        │                │            │
 │  │  └─────────────────┘                │            │
 │  │                                      │            │
-│  │  commit()   ← 全リポジトリの変更を   │            │
-│  │  rollback()   一括コミット/ロールバック│           │
+│  │  commit()   ← commits/rolls back all │            │
+│  │  rollback()   repository changes     │            │
 │  └──────────────────────────────────────┘            │
 └──────────────────────────────────────────────────────┘
 ```
 
-### 5.2 実装例
+### 5.2 Implementation Example
 
 ```typescript
 // ============================================================
-// Unit of Work インターフェース
+// Unit of Work interface
 // ============================================================
 interface UnitOfWork {
   readonly users: UserRepository;
@@ -1102,7 +1103,7 @@ interface UnitOfWork {
 }
 
 // ============================================================
-// Prisma 実装
+// Prisma implementation
 // ============================================================
 class PrismaUnitOfWork implements UnitOfWork {
   readonly users: UserRepository;
@@ -1115,7 +1116,7 @@ class PrismaUnitOfWork implements UnitOfWork {
     this.auditLogs = new PrismaAuditLogRepository(tx);
   }
 
-  // ファクトリメソッド: トランザクション内で実行
+  // Factory method: executes inside a transaction
   static async execute<T>(
     prisma: PrismaClient,
     fn: (uow: UnitOfWork) => Promise<T>
@@ -1127,17 +1128,17 @@ class PrismaUnitOfWork implements UnitOfWork {
   }
 
   async commit(): Promise<void> {
-    // Prisma $transaction は自動コミット
+    // Prisma $transaction auto-commits
   }
 
   async rollback(): Promise<void> {
-    // Prisma $transaction は例外時に自動ロールバック
+    // Prisma $transaction auto-rolls back on exception
     throw new Error("Transaction aborted");
   }
 }
 
 // ============================================================
-// Service での使用
+// Usage in Service
 // ============================================================
 class OrderService {
   constructor(
@@ -1147,30 +1148,30 @@ class OrderService {
 
   async placeOrder(userId: string, items: OrderItem[]): Promise<Order> {
     const result = await PrismaUnitOfWork.execute(this.prisma, async (uow) => {
-      // 1. ユーザー取得
+      // 1. Fetch user
       const user = await uow.users.findById(userId);
       if (!user) throw new UserNotFoundError(userId);
 
-      // 2. 注文作成（ドメインロジック）
+      // 2. Create order (domain logic)
       const order = Order.create(user, items);
 
-      // 3. 注文保存
+      // 3. Save order
       await uow.orders.save(order);
 
-      // 4. ユーザーのポイント更新
+      // 4. Update user points
       user.addPoints(order.calculatePoints());
       await uow.users.save(user);
 
-      // 5. 監査ログ記録
+      // 5. Record audit log
       await uow.auditLogs.append(
         AuditLog.create("ORDER_PLACED", userId, { orderId: order.id })
       );
 
       return order;
     });
-    // 全ての変更がトランザクション内で一括コミットされる
+    // All changes are committed together within the transaction
 
-    // トランザクション成功後にイベント発行
+    // Publish event after the transaction succeeds
     await this.eventBus.publish(new OrderPlacedEvent(result));
 
     return result;
@@ -1180,68 +1181,68 @@ class OrderService {
 
 ---
 
-## 6. 比較表
+## 6. Comparison Tables
 
-### 6.1 Repository パターンの実装方式比較
+### 6.1 Comparison of Repository Implementation Approaches
 
-| 方式 | 説明 | メリット | デメリット | 適する場面 |
+| Approach | Description | Pros | Cons | Best For |
 |------|------|---------|----------|----------|
-| **Specific Repository** | エンティティごとに固有メソッド | 明確な API、型安全、ドメイン表現力 | ボイラープレートが多い | DDD、中〜大規模 |
-| **Generic Repository** | 共通 CRUD を基底クラスに | コード量削減、統一的な API | 抽象化が過度になりがち | CRUD 中心、小〜中規模 |
-| **Specification Pattern** | クエリ条件をオブジェクト化 | 柔軟なクエリ構築、条件の再利用 | 学習コスト高、複雑 | 複雑な検索要件 |
-| **CQRS + Repository** | 読み取り/書き込みを分離 | パフォーマンス最適化 | 複雑度が増す | 読み書き比率が偏る |
+| **Specific Repository** | Custom methods per entity | Clear API, type-safe, expressive domain language | More boilerplate | DDD, medium to large scale |
+| **Generic Repository** | Common CRUD in base class | Less code, unified API | Can over-abstract | CRUD-centric, small to medium scale |
+| **Specification Pattern** | Query conditions as objects | Flexible query building, reusable conditions | High learning curve, complex | Complex search requirements |
+| **CQRS + Repository** | Separates reads from writes | Performance optimization | Increased complexity | Skewed read/write ratios |
 
-### 6.2 データアクセスパターン比較
+### 6.2 Comparison of Data Access Patterns
 
-| パターン | 抽象度 | テスト容易性 | 複雑度 | 学習コスト | 適用場面 |
+| Pattern | Abstraction | Testability | Complexity | Learning Curve | Use Case |
 |---------|--------|------------|--------|----------|---------|
-| **直接 SQL** | 低 | 低（DB 必要） | 低 | 低 | 小規模スクリプト |
-| **ORM のみ** | 中 | 中 | 低〜中 | 中 | 中小規模アプリ |
-| **Active Record** | 中 | 中 | 低 | 低 | Rails/Django |
-| **Repository** | 高 | 高 | 中 | 中〜高 | 中〜大規模アプリ |
-| **Repository + UoW** | 高 | 高 | 高 | 高 | 大規模, DDD |
-| **CQRS + ES** | 最高 | 高 | 最高 | 最高 | 複雑ドメイン |
+| **Direct SQL** | Low | Low (needs DB) | Low | Low | Small scripts |
+| **ORM only** | Medium | Medium | Low–Medium | Medium | Small to medium apps |
+| **Active Record** | Medium | Medium | Low | Low | Rails/Django |
+| **Repository** | High | High | Medium | Medium–High | Medium to large apps |
+| **Repository + UoW** | High | High | High | High | Large-scale, DDD |
+| **CQRS + ES** | Highest | High | Highest | Highest | Complex domains |
 
-### 6.3 ORM/ライブラリ別の Repository 実装の特徴
+### 6.3 Repository Implementation Characteristics by ORM/Library
 
-| ORM / Library | 言語 | Repository 実装のしやすさ | UoW サポート | 特記事項 |
+| ORM / Library | Language | Ease of Repository Implementation | UoW Support | Notes |
 |--------------|------|------------------------|-----------|---------|
-| **Prisma** | TypeScript | 高 | $transaction | 型安全、スキーマファースト |
-| **Drizzle** | TypeScript | 高 | transaction() | SQL に近い、軽量 |
-| **TypeORM** | TypeScript | 中 | QueryRunner | Repository パターン組み込み |
-| **SQLAlchemy** | Python | 高 | Session | 最も柔軟、UoW 組み込み |
-| **Django ORM** | Python | 中 | atomic() | Active Record 寄り |
-| **GORM** | Go | 中 | Transaction | シンプルだが型安全性は低い |
-| **Entity Framework** | C# | 高 | DbContext | UoW パターンが標準 |
+| **Prisma** | TypeScript | High | $transaction | Type-safe, schema-first |
+| **Drizzle** | TypeScript | High | transaction() | SQL-close, lightweight |
+| **TypeORM** | TypeScript | Medium | QueryRunner | Built-in Repository pattern |
+| **SQLAlchemy** | Python | High | Session | Most flexible, built-in UoW |
+| **Django ORM** | Python | Medium | atomic() | Leans toward Active Record |
+| **GORM** | Go | Medium | Transaction | Simple but lower type safety |
+| **Entity Framework** | C# | High | DbContext | UoW pattern is standard |
 
 ---
 
-## 7. アンチパターン
+## 7. Anti-Patterns
 
-### 7.1 Repository に ORM の型を漏洩させる
+### 7.1 Leaking ORM Types into the Repository
 
 ```typescript
-// NG: Repository のインターフェースに Prisma の型が漏洩
+// BAD: Prisma types leak into the Repository interface
 interface UserRepository {
   findMany(args: Prisma.UserFindManyArgs): Promise<PrismaUser[]>;
   //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^
-  //       インフラ層の型がドメイン層に漏洩
+  //       infrastructure-layer types leaked into domain layer
 }
 
-// OK: ドメイン層の型のみを使用
+// GOOD: use only domain-layer types
 interface UserRepository {
   findAll(options?: FindOptions): Promise<PaginatedResult<User>>;
   //                ^^^^^^^^^^^                            ^^^^
-  //                ドメイン層で定義した型のみ
+  //                only types defined in the domain layer
 }
 ```
 
-**なぜ NG か**: ORM を切り替える際（Prisma → Drizzle）にインターフェースも変更が必要になり、Repository パターンの「実装の差し替え可能性」が失われる。ドメイン層はインフラストラクチャの詳細を知るべきではない（DIP 違反）。
+**Why it's BAD**: When switching ORMs (e.g., Prisma to Drizzle), the interface itself must also change, destroying the Repository pattern's "swappable implementation" benefit. The domain layer should not know about infrastructure details (violates DIP).
 
-### 7.2 Generic Repository を万能と考える
+### 7.2 Treating the Generic Repository as a Silver Bullet
 
 ```typescript
-// NG: 全てのエンティティに同じ CRUD を提供
+// BAD: provides the same CRUD for all entities
 interface GenericRepository<T> {
   findById(id: string): Promise<T | null>;
   findAll(): Promise<T[]>;
@@ -1249,42 +1250,42 @@ interface GenericRepository<T> {
   delete(id: string): Promise<void>;
 }
 
-// 問題: ドメインルールを表現できない
-// 「ログは削除禁止」「設定は常に1つ」等
+// Problem: cannot express domain rules
+// e.g., "logs cannot be deleted", "settings always have exactly one record"
 
-// OK: ドメインの要件に合わせたインターフェース
+// GOOD: interface tailored to domain requirements
 interface AuditLogRepository {
-  append(log: AuditLog): Promise<void>;  // 追記のみ、削除不可
+  append(log: AuditLog): Promise<void>;  // append-only, no deletion
   findByDateRange(from: Date, to: Date): Promise<AuditLog[]>;
-  // delete() メソッドは意図的に存在しない
+  // delete() method is intentionally absent
 }
 
 interface AppSettingsRepository {
-  get(): Promise<AppSettings>;           // 常に1つ
+  get(): Promise<AppSettings>;           // always exactly one record
   update(settings: AppSettings): Promise<void>;
-  // findAll() や delete() は不要
+  // findAll() or delete() are not needed
 }
 
 interface OrderRepository {
-  findById(id: string): Promise<Order>;  // Order + OrderItems を含む
-  save(order: Order): Promise<void>;     // Order + OrderItems を一括保存
-  // save は集約全体を保存、個別の OrderItem の CRUD は提供しない
+  findById(id: string): Promise<Order>;  // includes Order + OrderItems
+  save(order: Order): Promise<void>;     // saves the entire Order + OrderItems at once
+  // save persists the whole aggregate; individual OrderItem CRUD is not provided
 }
 ```
 
-**なぜ NG か**: Generic Repository は「最小公約数」のインターフェースしか提供できず、ドメインの意図（「ログは不変」「集約は一括保存」等）を表現できない。Repository はドメインの言語（ユビキタス言語）で定義すべき。
+**Why it's BAD**: A Generic Repository can only provide the "least common denominator" interface and cannot express domain intent (e.g., "logs are immutable", "aggregates are saved as a whole"). Repositories should be defined in the language of the domain (ubiquitous language).
 
-### 7.3 Repository 内でビジネスロジックを実行する
+### 7.3 Executing Business Logic Inside the Repository
 
 ```typescript
-// NG: Repository がビジネスルールを知っている
+// BAD: Repository knows about business rules
 class PostgresUserRepository implements UserRepository {
   async save(user: User): Promise<User> {
-    // ビジネスルールの検証が Repository に混在
+    // Business rule validation mixed into the Repository
     if (!user.email.includes("@")) {
       throw new Error("Invalid email");
     }
-    // VIP判定のロジックが Repository に
+    // VIP determination logic inside the Repository
     if (user.purchaseTotal > 100000) {
       user.role = "vip";
     }
@@ -1292,9 +1293,9 @@ class PostgresUserRepository implements UserRepository {
   }
 }
 
-// OK: Repository は永続化のみ、ビジネスロジックはドメイン層
+// GOOD: Repository handles persistence only; business logic belongs in the domain layer
 class User {
-  // ビジネスルールはエンティティに
+  // Business rules belong on the entity
   updateEmail(newEmail: string): void {
     if (!newEmail.includes("@")) {
       throw new InvalidEmailError(newEmail);
@@ -1311,18 +1312,18 @@ class User {
 
 class PostgresUserRepository implements UserRepository {
   async save(user: User): Promise<User> {
-    // 永続化のみ。バリデーションやビジネスロジックは含まない
+    // Persistence only. No validation or business logic.
     return this.prisma.user.upsert(/* ... */);
   }
 }
 ```
 
-**なぜ NG か**: Repository の責務はデータの永続化と取得のみ。ビジネスロジックは Domain Entity や Domain Service に配置する。Repository にロジックがあると、InMemory 実装でテストする際にそのロジックが実行されず、テストの信頼性が下がる。
+**Why it's BAD**: The Repository's responsibility is solely to persist and retrieve data. Business logic belongs in Domain Entities or Domain Services. Logic inside the Repository will not execute when testing with an InMemory implementation, reducing test reliability.
 
-### 7.4 過度な抽象化（YAGNI 違反）
+### 7.4 Over-Abstraction (YAGNI Violation)
 
 ```typescript
-// NG: まだ1種類のDBしか使わないのに抽象化しすぎ
+// BAD: over-abstracted when only one DB type is in use
 interface IRepositoryFactory<T> {
   createRepository(type: "postgres" | "mongo" | "dynamodb"): IRepository<T>;
 }
@@ -1331,8 +1332,8 @@ interface IRepository<T> extends ICrudRepository<T>, ISearchRepository<T>, IAudi
   // ...
 }
 
-// OK: 必要になった時点で抽象化
-// 現時点では Prisma 直接使用で十分なら:
+// GOOD: abstract when the need actually arises
+// If using Prisma directly is sufficient for now:
 class UserRepository {
   constructor(private prisma: PrismaClient) {}
 
@@ -1340,38 +1341,38 @@ class UserRepository {
     // ...
   }
 }
-// テスト時にだけ InMemory に差し替えたい場合に Interface を導入
+// Introduce an Interface only when you need to swap in an InMemory version for tests
 ```
 
-**なぜ NG か**: 将来の「可能性」のために現在の複雑さを増やすのは YAGNI 違反。Repository パターンの導入自体も「テストの必要性」か「データソースの切り替え可能性」が明確になってからで十分。
+**Why it's BAD**: Adding present complexity for future "possibilities" violates YAGNI. Even the introduction of the Repository pattern itself is fine to defer until the need for testability or data source swapping becomes clear.
 
 ---
 
-## 8. 実践演習
+## 8. Practice Exercises
 
-### 演習 1（基礎）: Repository Interface の設計
+### Exercise 1 (Basic): Designing a Repository Interface
 
-ブログサービスの `PostRepository` インターフェースを設計せよ。
+Design a `PostRepository` interface for a blog service.
 
-**要件**:
-- 投稿の CRUD
-- タグによる検索
-- 著者による検索
-- 下書き/公開済みのフィルタリング
-- ページネーション
-- 人気順（いいね数）ソート
+**Requirements**:
+- CRUD for posts
+- Search by tag
+- Search by author
+- Filter by draft/published status
+- Pagination
+- Sort by popularity (number of likes)
 
-**制約**: DDD の集約を意識し、Post は Comment を含む集約とする（CommentRepository は作らない）
+**Constraint**: Be mindful of DDD aggregates; treat Post as an aggregate that includes Comments (do not create a CommentRepository)
 
-**期待する出力**:
-- `PostRepository` インターフェース（TypeScript）
-- 各メソッドの JSDoc コメント付き
+**Expected Output**:
+- `PostRepository` interface (TypeScript)
+- With JSDoc comments for each method
 
 ---
 
-### 演習 2（応用）: InMemory Repository + Service テスト
+### Exercise 2 (Applied): InMemory Repository + Service Tests
 
-以下の `BookingService` のテストを、`InMemoryRoomRepository` と `InMemoryBookingRepository` を実装して書け。
+Write tests for the following `BookingService` by implementing `InMemoryRoomRepository` and `InMemoryBookingRepository`.
 
 ```typescript
 class BookingService {
@@ -1394,100 +1395,100 @@ class BookingService {
 }
 ```
 
-**テストケース**:
-1. 正常予約
-2. 存在しない部屋
-3. 利用不可の部屋
-4. 二重予約
+**Test Cases**:
+1. Successful booking
+2. Room not found
+3. Room unavailable
+4. Double booking
 
-**期待する出力**: `InMemoryRoomRepository`、`InMemoryBookingRepository` の実装と4つのテストケース
+**Expected Output**: Implementation of `InMemoryRoomRepository` and `InMemoryBookingRepository`, plus four test cases
 
 ---
 
-### 演習 3（発展）: Unit of Work + Specification パターン
+### Exercise 3 (Advanced): Unit of Work + Specification Pattern
 
-EC サイトの注文処理を Unit of Work と Specification パターンで実装せよ。
+Implement the order processing for an e-commerce site using Unit of Work and the Specification pattern.
 
-**要件**:
-1. 注文作成時に在庫を減らす（OrderRepository + ProductRepository）
-2. 在庫不足の場合はロールバック
-3. 「在庫5個以下の商品」を Specification で検索
-4. トランザクション内で監査ログも記録
+**Requirements**:
+1. Reduce inventory when an order is created (OrderRepository + ProductRepository)
+2. Roll back if stock is insufficient
+3. Search for "products with 5 or fewer items in stock" using a Specification
+4. Also record an audit log within the transaction
 
-**期待する出力**:
+**Expected Output**:
 - `LowStockSpec` Specification
-- `PlaceOrderUseCase` (Unit of Work 使用)
-- テストコード
+- `PlaceOrderUseCase` (using Unit of Work)
+- Test code
 
 ---
 
 ## 9. FAQ
 
-### Q1. 小規模プロジェクトでも Repository パターンは必要？
+### Q1. Is the Repository pattern necessary even for small projects?
 
-**A.** 小規模（CRUD 中心、テーブル 5 個以下）では不要な場合が多い。ORM を直接使う方がシンプル。以下の条件に **2つ以上** 当てはまる場合に導入を検討:
+**A.** For small projects (CRUD-centric, 5 or fewer tables), it is often unnecessary. Using the ORM directly is simpler. Consider introducing it when **2 or more** of the following conditions apply:
 
-1. ユニットテストでデータベースを使いたくない
-2. 将来的に DB の変更可能性がある（PostgreSQL → DynamoDB 等）
-3. ドメインロジックが複雑でサービス層のテストが重要
-4. 複数のデータソースを組み合わせる（DB + 外部 API + キャッシュ）
-5. チームが大きく、データアクセス層の統一的なインターフェースが必要
+1. You do not want to use a database in unit tests
+2. There is a possibility of changing the DB in the future (e.g., PostgreSQL to DynamoDB)
+3. Domain logic is complex and testing the service layer is important
+4. Combining multiple data sources (DB + external API + cache)
+5. The team is large and a unified interface for the data access layer is needed
 
-スタートアップの初期段階では ORM 直接使用で始め、テストの必要性が出てきた時点で Repository を導入するのが現実的。
+In the early stages of a startup, it is practical to start by using the ORM directly and introduce the Repository once the need for testing becomes apparent.
 
-### Q2. Repository はテーブルごと？集約（Aggregate）ごと？
+### Q2. Should Repositories be per table or per aggregate?
 
-**A.** DDD を採用している場合は **「集約ルートごと」が正解**。例えば `Order` と `OrderItem` は別テーブルでも、`OrderRepository` で一括管理する。DDD でなければテーブルごとで問題ない。
+**A.** If you are following DDD, **"one per aggregate root" is the right answer**. For example, `Order` and `OrderItem` are in separate tables, but they are managed together through a single `OrderRepository`. Without DDD, per-table is fine.
 
 ```typescript
-// DDD: 集約ルート単位
+// DDD: per aggregate root
 interface OrderRepository {
   findById(id: string): Promise<Order>;
-  // ↑ Order + OrderItems + ShippingAddress を含む集約全体を返す
+  // ↑ returns the entire aggregate including Order + OrderItems + ShippingAddress
   save(order: Order): Promise<void>;
-  // ↑ Order + OrderItems + ShippingAddress を一括保存
+  // ↑ saves Order + OrderItems + ShippingAddress all at once
 }
 
-// 非DDD: テーブル単位
+// Non-DDD: per table
 interface OrderRepository {
-  findById(id: string): Promise<Order>;  // Order のみ
+  findById(id: string): Promise<Order>;  // Order only
 }
 interface OrderItemRepository {
   findByOrderId(orderId: string): Promise<OrderItem[]>;
 }
 ```
 
-集約単位の Repository のメリットは、ビジネスルール（「OrderItem の合計金額は Order の total と一致する」等）を集約内で一貫して保証できること。
+The benefit of aggregate-level Repositories is that business rules (e.g., "the sum of OrderItem amounts must match the Order total") can be enforced consistently within the aggregate.
 
-### Q3. Repository をテストする場合、DB を使うべき？モックすべき？
+### Q3. When testing the Repository, should I use a real DB or mocks?
 
-**A.** 両方必要。テストの種類に応じて使い分ける:
+**A.** Both are needed. Use them based on the type of test:
 
 ```
-テストピラミッド:
+Test Pyramid:
   ┌─────────────────┐
-  │    E2E テスト     │  ← 少数、本番相当の DB
+  │    E2E Tests     │  ← few tests, production-equivalent DB
   ├─────────────────┤
-  │   統合テスト      │  ← Repository 実装のテスト（TestContainers）
+  │ Integration Tests│  ← tests for Repository implementation (TestContainers)
   ├─────────────────┤
-  │ ユニットテスト    │  ← Service のテスト（InMemory Repository）
+  │   Unit Tests     │  ← tests for Services (InMemory Repository)
   └─────────────────┘
 ```
 
-| テスト種類 | Repository | 目的 |
+| Test Type | Repository | Purpose |
 |-----------|-----------|------|
-| **ユニットテスト** | InMemory 実装 | Service のビジネスロジック検証 |
-| **統合テスト** | 本物の DB（TestContainers） | SQL / ORM の正しさを検証 |
-| **E2E テスト** | 本物の DB | システム全体の動作検証 |
+| **Unit Tests** | InMemory implementation | Validate Service business logic |
+| **Integration Tests** | Real DB (TestContainers) | Validate SQL / ORM correctness |
+| **E2E Tests** | Real DB | Validate overall system behavior |
 
 ```typescript
-// 統合テスト: TestContainers で PostgreSQL を起動
+// Integration test: start PostgreSQL with TestContainers
 describe("PrismaUserRepository (Integration)", () => {
   let prisma: PrismaClient;
   let repo: PrismaUserRepository;
 
   beforeAll(async () => {
-    // Docker で PostgreSQL コンテナを起動
+    // Start a PostgreSQL container with Docker
     const container = await new PostgreSqlContainer().start();
     prisma = new PrismaClient({
       datasources: { db: { url: container.getConnectionUri() } },
@@ -1507,55 +1508,55 @@ describe("PrismaUserRepository (Integration)", () => {
 });
 ```
 
-### Q4. Active Record と Repository、どちらを使うべき？
+### Q4. Should I use Active Record or Repository?
 
-**A.** プロジェクトの規模とフレームワークによる:
+**A.** It depends on the project's scale and framework:
 
-| 基準 | Active Record | Repository |
+| Criteria | Active Record | Repository |
 |------|---------------|-----------|
-| **フレームワーク** | Rails, Django, Laravel | Express, Spring, 自前 |
-| **プロジェクト規模** | 小〜中 | 中〜大 |
-| **テスト要件** | 統合テスト中心 | ユニットテスト重視 |
-| **ドメインの複雑さ** | 低〜中 | 高 |
-| **チーム規模** | 小（1-5人） | 中〜大（5人以上） |
+| **Framework** | Rails, Django, Laravel | Express, Spring, custom |
+| **Project Scale** | Small to medium | Medium to large |
+| **Testing Requirements** | Integration test-centric | Unit test-focused |
+| **Domain Complexity** | Low to medium | High |
+| **Team Size** | Small (1–5 people) | Medium to large (5+ people) |
 
-Active Record（Rails の `User.find_by(email: ...)` 等）はフレームワークの規約に従うなら最もシンプル。Repository は DDD やクリーンアーキテクチャを採用する場合に適する。
+Active Record (e.g., Rails' `User.find_by(email: ...)`) is the simplest approach when following framework conventions. Repository is appropriate when adopting DDD or Clean Architecture.
 
-### Q5. Repository の返り値はドメインエンティティ？DTO？
+### Q5. Should Repository return domain entities or DTOs?
 
-**A.** **ドメインエンティティ** を返すのが正解。Repository はドメイン層のインターフェースであり、ドメインの言語（Entity, Value Object）で結果を返す。DTO（Data Transfer Object）への変換は Presentation 層（Controller / Serializer）の責務。
+**A.** Returning **domain entities** is correct. The Repository is a domain-layer interface and returns results in the domain's language (Entity, Value Object). Converting to DTOs (Data Transfer Objects) is the responsibility of the Presentation layer (Controller / Serializer).
 
 ```typescript
-// OK: ドメインエンティティを返す
+// GOOD: return domain entity
 interface UserRepository {
-  findById(id: string): Promise<User>;  // ← User はドメインエンティティ
+  findById(id: string): Promise<User>;  // ← User is a domain entity
 }
 
-// NG: DTO を返す
+// BAD: return DTO
 interface UserRepository {
-  findById(id: string): Promise<UserResponseDTO>;  // ← これは Controller の仕事
+  findById(id: string): Promise<UserResponseDTO>;  // ← this is the Controller's job
 }
 ```
 
-### Q6. Repository にキャッシュを組み込むべき？
+### Q6. Should you incorporate caching into the Repository?
 
-**A.** Repository をデコレーターパターンでラップするのが推奨。Repository インターフェースを変更せずにキャッシュ層を追加できる:
+**A.** It is recommended to wrap the Repository using the Decorator pattern. This allows you to add a cache layer without changing the Repository interface:
 
 ```typescript
-// キャッシュ付き Repository（Decorator パターン）
+// Repository with caching (Decorator pattern)
 class CachedUserRepository implements UserRepository {
   constructor(
-    private inner: UserRepository,  // 実際の DB Repository
-    private cache: CacheClient,     // Redis 等
-    private ttl: number = 300,      // 5分
+    private inner: UserRepository,  // the actual DB Repository
+    private cache: CacheClient,     // Redis, etc.
+    private ttl: number = 300,      // 5 minutes
   ) {}
 
   async findById(id: string): Promise<User | null> {
-    // 1. キャッシュ確認
+    // 1. Check cache
     const cached = await this.cache.get(`user:${id}`);
     if (cached) return JSON.parse(cached);
 
-    // 2. DB から取得
+    // 2. Fetch from DB
     const user = await this.inner.findById(id);
     if (user) {
       await this.cache.set(`user:${id}`, JSON.stringify(user), this.ttl);
@@ -1565,15 +1566,15 @@ class CachedUserRepository implements UserRepository {
 
   async save(user: User): Promise<User> {
     const saved = await this.inner.save(user);
-    // キャッシュ無効化
+    // Invalidate cache
     await this.cache.del(`user:${saved.id}`);
     return saved;
   }
 
-  // ... 他のメソッドも同様
+  // ... same for other methods
 }
 
-// DI 設定
+// DI setup
 const dbRepo = new PrismaUserRepository(prisma);
 const cachedRepo = new CachedUserRepository(dbRepo, redis);
 container.register<UserRepository>("UserRepository", { useValue: cachedRepo });
@@ -1584,51 +1585,51 @@ container.register<UserRepository>("UserRepository", { useValue: cachedRepo });
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not only through theory but by actually writing code and confirming behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the fundamentals and jumping to advanced topics. It is recommended to thoroughly understand the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work. It becomes especially important during code reviews and architecture design.
 
 ---
 
-## 10. まとめ
+## 10. Summary
 
-| 項目 | ポイント |
+| Item | Key Point |
 |------|---------|
-| **Repository** | データアクセスの抽象化。ドメイン層にインターフェースを定義し、インフラ層で実装する |
-| **DIP** | 上位モジュール（Service）はインターフェース（Repository）に依存。具体実装は注入 |
-| **DDD の集約** | Repository は集約ルートごとに1つ。集約内のエンティティは Repository を通じてのみアクセス |
-| **テスト** | InMemory 実装でサービス層をユニットテスト。DB 実装は統合テスト（TestContainers） |
-| **Unit of Work** | 複数 Repository の変更を1トランザクションで管理。データの一貫性を保証 |
-| **Specification** | 検索条件をオブジェクト化。条件の組み合わせ（AND, OR, NOT）を型安全に表現 |
-| **注意点** | 過度な抽象化を避け、ドメインの要件に合ったインターフェースを設計。YAGNI を意識する |
-| **キャッシュ** | Decorator パターンで Repository をラップ。インターフェースを変更せずにキャッシュを追加 |
+| **Repository** | Abstracts data access. Define the interface in the domain layer and implement it in the infrastructure layer. |
+| **DIP** | Upper modules (Service) depend on interfaces (Repository). Concrete implementations are injected. |
+| **DDD Aggregates** | One Repository per aggregate root. Entities within an aggregate are accessed only through the Repository. |
+| **Testing** | Unit-test the service layer using an InMemory implementation. Test the DB implementation with integration tests (TestContainers). |
+| **Unit of Work** | Manages changes across multiple Repositories within a single transaction. Guarantees data consistency. |
+| **Specification** | Turns search conditions into objects. Combines conditions (AND, OR, NOT) in a type-safe manner. |
+| **Caution** | Avoid over-abstraction; design interfaces suited to domain requirements. Be mindful of YAGNI. |
+| **Caching** | Wrap the Repository with the Decorator pattern. Add caching without changing the interface. |
 
 ---
 
-## 次に読むべきガイド
+## Recommended Next Reads
 
-- [00-mvc-mvvm.md](./00-mvc-mvvm.md) — UI 層のアーキテクチャパターン（Repository を使う側の設計）
-- [02-event-sourcing-cqrs.md](./02-event-sourcing-cqrs.md) — イベント駆動とコマンド/クエリ分離（CQRS での Repository）
-- ../../clean-code-principles/ — SOLID 原則、依存性逆転原則の詳細
-- [../02-behavioral/](../02-behavioral/) — Strategy パターン（Repository の実装切り替え）
-- ../../system-design-guide/ — データベーススケーリングとキャッシュ戦略
+- [00-mvc-mvvm.md](./00-mvc-mvvm.md) — UI layer architecture patterns (design on the side that uses Repository)
+- [02-event-sourcing-cqrs.md](./02-event-sourcing-cqrs.md) — Event-driven design and command/query separation (Repository in CQRS)
+- ../../clean-code-principles/ — SOLID principles, details on the Dependency Inversion Principle
+- [../02-behavioral/](../02-behavioral/) — Strategy pattern (swapping Repository implementations)
+- ../../system-design-guide/ — Database scaling and cache strategies
 
 ---
 
-## 参考文献
+## References
 
-1. **Martin Fowler** — "Patterns of Enterprise Application Architecture" — Repository パターンの原典 — https://martinfowler.com/eaaCatalog/repository.html
+1. **Martin Fowler** — "Patterns of Enterprise Application Architecture" — The original source for the Repository pattern — https://martinfowler.com/eaaCatalog/repository.html
 2. **Martin Fowler** — "Unit of Work" — https://martinfowler.com/eaaCatalog/unitOfWork.html
 3. **Eric Evans** — "Domain-Driven Design: Tackling Complexity in the Heart of Software" — Addison-Wesley, 2003
 4. **Microsoft** — "Implementing the Repository and Unit of Work Patterns" — https://learn.microsoft.com/en-us/aspnet/mvc/overview/older-versions/getting-started-with-ef-5-using-mvc-4/implementing-the-repository-and-unit-of-work-patterns-in-an-asp-net-mvc-application
-5. **Robert C. Martin** — "Clean Architecture" (2017) — 依存性逆転原則と Repository の位置付け
+5. **Robert C. Martin** — "Clean Architecture" (2017) — Dependency Inversion Principle and the role of Repository
 6. **Prisma Documentation** — "Repository pattern with Prisma" — https://www.prisma.io/docs/guides
-7. **Vaughn Vernon** — "Implementing Domain-Driven Design" (2013) — 集約と Repository の関係
+7. **Vaughn Vernon** — "Implementing Domain-Driven Design" (2013) — Relationship between aggregates and Repository

--- a/03-software-design/design-patterns-guide/docs/04-architectural/02-event-sourcing-cqrs.md
+++ b/03-software-design/design-patterns-guide/docs/04-architectural/02-event-sourcing-cqrs.md
@@ -1,68 +1,69 @@
-# Event Sourcing / CQRS — イベント駆動設計
+# Event Sourcing / CQRS — Event-Driven Design
 
-> Event Sourcing で状態の変化を不変のイベントログとして記録し、CQRS で読み取りと書き込みを分離することで、監査可能性・スケーラビリティ・ドメインの表現力を最大化するための実践ガイド。イベントストア設計、プロジェクション、スナップショット最適化、段階的導入戦略まで網羅する。
+> A practical guide to recording state changes as an immutable event log with Event Sourcing, and separating reads from writes with CQRS to maximize auditability, scalability, and domain expressiveness. Covers event store design, projections, snapshot optimization, and incremental adoption strategies.
 
 ---
 
-## 前提知識
+## Prerequisites
 
-| トピック | 必要レベル | 参照先 |
+| Topic | Required Level | Reference |
 |---------|-----------|--------|
-| TypeScript / JavaScript | 中級（ジェネリクス、async/await、discriminated union） | [02-programming](../../../../02-programming/) |
-| リレーショナルDB の基礎 | 基礎（INSERT, SELECT, トランザクション） | [06-data-and-security](../../../../06-data-and-security/) |
-| Repository パターン | 基礎 | [01-repository-pattern.md](./01-repository-pattern.md) |
-| DDD の基礎概念 | 基礎（集約、ドメインイベント） | ../../clean-code-principles/ |
-| メッセージキューの基礎 | 基礎（Pub/Sub モデル） | ../../system-design-guide/ |
+| TypeScript / JavaScript | Intermediate (generics, async/await, discriminated union) | [02-programming](../../../../02-programming/) |
+| Relational DB basics | Basics (INSERT, SELECT, transactions) | [06-data-and-security](../../../../06-data-and-security/) |
+| Repository pattern | Basics | [01-repository-pattern.md](./01-repository-pattern.md) |
+| DDD fundamentals | Basics (aggregates, domain events) | ../../clean-code-principles/ |
+| Message queue basics | Basics (Pub/Sub model) | ../../system-design-guide/ |
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn
 
-1. **Event Sourcing** — 状態をイベントの履歴として保存するパターンの設計と実装
-2. **CQRS（Command Query Responsibility Segregation）** — 読み取りと書き込みの責務分離の4段階
-3. **Event Sourcing + CQRS** の組み合わせ — プロジェクション設計と結果整合性の管理
-4. **スナップショット最適化** — イベント再生コストを削減する戦略
-5. **段階的導入** — 既存 CRUD アプリからの移行パスとイベントスキーマのバージョニング
+1. **Event Sourcing** — Design and implementation of the pattern that stores state as a history of events
+2. **CQRS (Command Query Responsibility Segregation)** — Four levels of separating read and write responsibilities
+3. **Event Sourcing + CQRS** combined — Projection design and managing eventual consistency
+4. **Snapshot optimization** — Strategies to reduce event replay costs
+5. **Incremental adoption** — Migration paths from existing CRUD applications and event schema versioning
 
 ---
 
-## 1. 従来の CRUD vs Event Sourcing
+## 1. Traditional CRUD vs Event Sourcing
 
-### WHY: なぜ Event Sourcing が必要か
+### WHY: Why Event Sourcing Is Needed
 
-従来の CRUD はデータの「現在の状態」だけを保存する。これにより以下の問題が発生する:
+Traditional CRUD stores only the "current state" of data. This leads to the following problems:
 
-1. **監査証跡の欠如** — 「いつ」「誰が」「なぜ」変更したかが分からない
-2. **時系列分析不可** — 過去の任意時点の状態を再構築できない
-3. **ドメイン知識の損失** — 「価格を変更した」のか「割引を適用した」のか区別できない
-4. **同時更新の競合** — UPDATE は上書きのため、最後の書き込みが勝つ（Lost Update）
+1. **Lack of audit trail** — You cannot tell "when", "who", or "why" a change was made
+2. **No time-series analysis** — You cannot reconstruct the state at any arbitrary point in the past
+3. **Loss of domain knowledge** — You cannot distinguish between "the price was changed" and "a discount was applied"
+4. **Concurrent update conflicts** — UPDATE overwrites, so the last write wins (Lost Update)
 
-Event Sourcing はこれらを根本的に解決する。
+Event Sourcing fundamentally resolves all of these.
 
-### 1.1 根本的な違い
+### 1.1 The Fundamental Difference
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│  従来の CRUD（状態保存）                              │
+│  Traditional CRUD (state storage)                    │
 │                                                      │
-│  orders テーブル:                                    │
+│  orders table:                                       │
 │  ┌──────┬────────┬────────┬───────────┐              │
 │  │ id   │ status │ total  │ updated_at│              │
 │  ├──────┼────────┼────────┼───────────┤              │
-│  │ O-01 │ shipped│ 15,000 │ 02-10     │ ← 現在の状態│
-│  └──────┴────────┴────────┴───────────┘   のみ保存  │
-│                                                      │
-│  問題: 「いつ」「なぜ」注文が変更されたか分からない   │
-│        注文が 12,000円 → 15,000円 に変わった理由は？  │
-│        ・商品追加？ ・価格変更？ ・送料追加？          │
+│  │ O-01 │ shipped│ 15,000 │ 02-10     │ ← Only the  │
+│  └──────┴────────┴────────┴───────────┘   current   │
+│                                            state     │
+│  Problem: Cannot tell "when" or "why" the order     │
+│           changed. Why did it go from 12,000 to      │
+│           15,000?                                    │
+│           ・Item added? ・Price change? ・Shipping?  │
 └──────────────────────────────────────────────────────┘
 
 ┌──────────────────────────────────────────────────────┐
-│  Event Sourcing（イベント保存）                       │
+│  Event Sourcing (event storage)                      │
 │                                                      │
-│  events テーブル:                                    │
+│  events table:                                       │
 │  ┌────┬──────┬────────────────┬──────────┬───────┐   │
-│  │ #  │ 集約 │ イベント型      │ データ    │ 日時  │   │
+│  │ #  │ Agg  │ Event Type     │ Data     │ Time  │   │
 │  ├────┼──────┼────────────────┼──────────┼───────┤   │
 │  │ 1  │ O-01 │ OrderCreated   │ {items}  │ 02-08 │   │
 │  │ 2  │ O-01 │ ItemAdded      │ {item}   │ 02-08 │   │
@@ -70,15 +71,16 @@ Event Sourcing はこれらを根本的に解決する。
 │  │ 4  │ O-01 │ OrderShipped   │ {carrier}│ 02-10 │   │
 │  └────┴──────┴────────────────┴──────────┴───────┘   │
 │                                                      │
-│  利点: 全ての変更履歴が残る、任意時点の状態を再構築   │
-│        「なぜ 15,000円か」= Event 1+2 の合計           │
+│  Benefit: Full change history is preserved;          │
+│           reconstruct state at any point in time.    │
+│           "Why 15,000?" = sum of Event 1+2           │
 └──────────────────────────────────────────────────────┘
 ```
 
-### 1.2 Event Sourcing の状態復元
+### 1.2 State Reconstruction via Event Sourcing
 
 ```
-イベントの再生 (Replay) による状態復元:
+State reconstruction through event replay (Replay):
 
   Event 1: OrderCreated      → Order { status: "created", items: [], total: 0 }
       │
@@ -97,37 +99,38 @@ Event Sourcing はこれらを根本的に解決する。
       ▼
   Event 6: OrderShipped       → Order { status: "shipped", items: [A,B], total: 15000 }
 
-  ※ 2月9日時点の状態が必要 → Event 1-5 を再生すれば OK
-  ※ 「なぜ15,000円？」→ Event 2(5000) + Event 3(7000) + Event 4(3000)
+  * Need state as of Feb 9 → replay Events 1-5
+  * "Why 15,000?" → Event 2(5000) + Event 3(7000) + Event 4(3000)
 ```
 
-### 1.3 Event Sourcing の核心概念
+### 1.3 Core Concepts of Event Sourcing
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│  Event Sourcing の3つの核心                                │
+│  Three core principles of Event Sourcing                  │
 │                                                           │
-│  1. イベントは不変 (Immutable)                             │
+│  1. Events are Immutable                                  │
 │     ────────────────────────                               │
-│     一度記録されたイベントは決して変更・削除しない          │
-│     → 監査証跡の信頼性を保証                               │
+│     Events, once recorded, are never modified or deleted  │
+│     → Guarantees reliability of the audit trail           │
 │                                                           │
-│  2. イベントは追記のみ (Append-Only)                       │
+│  2. Events are Append-Only                                │
 │     ────────────────────────────                           │
-│     新しいイベントを末尾に追加するだけ                     │
-│     → ロック競合が少なく、書き込み性能が高い               │
+│     New events are simply appended to the end             │
+│     → Fewer lock conflicts, higher write performance      │
 │                                                           │
-│  3. 現在の状態はイベントの導出値 (Derived State)           │
+│  3. Current State is Derived State                        │
 │     ──────────────────────────────────                     │
-│     状態 = fold(初期状態, 全イベント, apply関数)           │
-│     → 同じイベント列からは常に同じ状態が再構築される       │
-│     → 関数型プログラミングの reduce と同じ概念             │
+│     state = fold(initialState, allEvents, applyFunction)  │
+│     → The same sequence of events always yields the       │
+│       same reconstructed state                            │
+│     → Same concept as reduce in functional programming    │
 └───────────────────────────────────────────────────────────┘
 
-数学的表現:
+Mathematical expression:
   state(t) = reduce(apply, initialState, events[0..t])
 
-TypeScript 風:
+In TypeScript:
   const currentState = events.reduce(
     (state, event) => applyEvent(state, event),
     initialState
@@ -136,16 +139,16 @@ TypeScript 風:
 
 ---
 
-## 2. Event Sourcing の実装
+## 2. Implementing Event Sourcing
 
-### 2.1 イベント定義（TypeScript）
+### 2.1 Event Definitions (TypeScript)
 
 ```typescript
 // ============================================================
-// Domain Events — 型安全なイベント定義
+// Domain Events — type-safe event definitions
 // ============================================================
 
-// 基底イベント型
+// Base event type
 interface DomainEvent {
   readonly eventId: string;
   readonly aggregateId: string;
@@ -155,13 +158,13 @@ interface DomainEvent {
   readonly metadata: Readonly<{
     timestamp: Date;
     version: number;
-    userId?: string;          // 誰がこの変更を行ったか
-    correlationId?: string;   // 関連する操作のID（分散トレーシング）
-    causationId?: string;     // このイベントの原因となったイベントID
+    userId?: string;          // Who made this change
+    correlationId?: string;   // ID of the related operation (distributed tracing)
+    causationId?: string;     // ID of the event that caused this event
   }>;
 }
 
-// 注文ドメインのイベント（Discriminated Union で型安全に）
+// Order domain events (type-safe with Discriminated Union)
 type OrderEvent =
   | OrderCreated
   | ItemAdded
@@ -245,11 +248,11 @@ interface OrderCancelled extends DomainEvent {
 }
 ```
 
-### 2.2 集約（Aggregate）の実装
+### 2.2 Aggregate Implementation
 
 ```typescript
 // ============================================================
-// Order Aggregate — イベントソーシング対応
+// Order Aggregate — Event Sourcing compatible
 // ============================================================
 
 interface OrderItem {
@@ -272,7 +275,7 @@ class Order {
   private _uncommittedEvents: OrderEvent[] = [];
 
   // ============================================
-  // クエリ（読み取り）
+  // Queries (reads)
   // ============================================
   get id(): string { return this._id; }
   get status(): OrderStatus { return this._status; }
@@ -282,12 +285,12 @@ class Order {
   get version(): number { return this._version; }
 
   // ============================================
-  // ファクトリ: イベントから状態を復元
+  // Factory: restore state from events
   // ============================================
   static fromEvents(events: OrderEvent[]): Order {
     const order = new Order();
     for (const event of events) {
-      order.applyEvent(event, false);  // 既存イベントは uncommitted に追加しない
+      order.applyEvent(event, false);  // Existing events are not added to uncommitted
     }
     return order;
   }
@@ -302,7 +305,7 @@ class Order {
     order._discountAmount = snapshot.discountAmount;
     order._version = snapshot.version;
 
-    // スナップショット以降のイベントを再生
+    // Replay events after the snapshot
     for (const event of newEvents) {
       order.applyEvent(event, false);
     }
@@ -310,7 +313,7 @@ class Order {
   }
 
   // ============================================
-  // コマンド（書き込み） — ビジネスルールの検証 + イベント発行
+  // Commands (writes) — business rule validation + event emission
   // ============================================
   static create(
     orderId: string,
@@ -319,12 +322,12 @@ class Order {
     shippingAddress: { street: string; city: string; postalCode: string },
     userId: string
   ): Order {
-    // ビジネスルールの検証
+    // Business rule validation
     if (items.length === 0) {
-      throw new DomainError("注文には1つ以上の商品が必要です");
+      throw new DomainError("An order must have at least one item");
     }
     if (items.some((i) => i.quantity <= 0)) {
-      throw new DomainError("商品数量は正の整数でなければなりません");
+      throw new DomainError("Item quantity must be a positive integer");
     }
 
     const order = new Order();
@@ -345,14 +348,14 @@ class Order {
   }
 
   addItem(item: OrderItem, userId: string): void {
-    // ビジネスルール: 支払い済みの注文には商品を追加できない
+    // Business rule: cannot add items to a paid order
     if (this._status !== "created") {
       throw new DomainError(
-        `状態 "${this._status}" の注文に商品を追加できません`
+        `Cannot add items to an order with status "${this._status}"`
       );
     }
     if (item.quantity <= 0) {
-      throw new DomainError("商品数量は正の整数でなければなりません");
+      throw new DomainError("Item quantity must be a positive integer");
     }
 
     this.raiseEvent({
@@ -369,14 +372,14 @@ class Order {
 
   removeItem(productId: string, quantity: number, reason: string, userId: string): void {
     if (this._status !== "created") {
-      throw new DomainError("支払い済みの注文から商品を削除できません");
+      throw new DomainError("Cannot remove items from a paid order");
     }
     const existingItem = this._items.find((i) => i.productId === productId);
     if (!existingItem) {
-      throw new DomainError(`商品 ${productId} は注文に含まれていません`);
+      throw new DomainError(`Item ${productId} is not in the order`);
     }
     if (existingItem.quantity < quantity) {
-      throw new DomainError("削除数量が注文数量を超えています");
+      throw new DomainError("Removal quantity exceeds ordered quantity");
     }
 
     this.raiseEvent({
@@ -388,10 +391,10 @@ class Order {
 
   applyDiscount(type: "percentage" | "fixed", value: number, reason: string, couponCode?: string, userId?: string): void {
     if (this._status !== "created") {
-      throw new DomainError("支払い済みの注文に割引を適用できません");
+      throw new DomainError("Cannot apply a discount to a paid order");
     }
     if (type === "percentage" && (value < 0 || value > 100)) {
-      throw new DomainError("割引率は 0-100% の範囲でなければなりません");
+      throw new DomainError("Discount percentage must be in the range 0-100%");
     }
 
     this.raiseEvent({
@@ -403,11 +406,11 @@ class Order {
 
   receivePayment(amount: number, method: PaymentReceived["data"]["paymentMethod"], txId: string, userId: string): void {
     if (this._status !== "created") {
-      throw new DomainError("この注文はすでに支払い済みです");
+      throw new DomainError("This order has already been paid");
     }
     if (amount < this.netAmount) {
       throw new DomainError(
-        `支払い金額 ${amount} が不足しています（必要額: ${this.netAmount}）`
+        `Payment amount ${amount} is insufficient (required: ${this.netAmount})`
       );
     }
 
@@ -420,7 +423,7 @@ class Order {
 
   ship(carrier: string, trackingNumber: string, estimatedDelivery: string, userId: string): void {
     if (this._status !== "paid") {
-      throw new DomainError("支払い済みの注文のみ発送できます");
+      throw new DomainError("Only paid orders can be shipped");
     }
 
     this.raiseEvent({
@@ -432,10 +435,10 @@ class Order {
 
   cancel(reason: string, userId: string): void {
     if (this._status === "shipped" || this._status === "delivered") {
-      throw new DomainError("発送済みの注文はキャンセルできません");
+      throw new DomainError("Shipped orders cannot be cancelled");
     }
     if (this._status === "cancelled") {
-      throw new DomainError("既にキャンセル済みです");
+      throw new DomainError("Order is already cancelled");
     }
 
     const refundAmount = this._status === "paid" ? this.netAmount : 0;
@@ -447,7 +450,7 @@ class Order {
   }
 
   // ============================================
-  // イベント適用（状態変更ロジック）— 純粋関数
+  // Event application (state mutation logic) — pure function
   // ============================================
   private applyEvent(event: OrderEvent, isNew: boolean = true): void {
     switch (event.eventType) {
@@ -518,7 +521,7 @@ class Order {
   }
 
   // ============================================
-  // イベント発行ヘルパー
+  // Event emission helper
   // ============================================
   private raiseEvent(
     eventData: Pick<OrderEvent, "eventType" | "aggregateId" | "data">,
@@ -576,11 +579,11 @@ class DomainError extends Error {
 }
 ```
 
-### 2.3 Event Store の実装
+### 2.3 Implementing the Event Store
 
 ```typescript
 // ============================================================
-// Event Store Interface（ドメイン層）
+// Event Store Interface (domain layer)
 // ============================================================
 interface EventStore {
   append(
@@ -601,7 +604,7 @@ interface EventStore {
 }
 
 // ============================================================
-// PostgreSQL 実装
+// PostgreSQL implementation
 // ============================================================
 class PostgresEventStore implements EventStore {
   constructor(private pool: Pool) {}
@@ -615,11 +618,11 @@ class PostgresEventStore implements EventStore {
     try {
       await client.query("BEGIN");
 
-      // 楽観的ロック: 現在のバージョンを確認
+      // Optimistic lock: check the current version
       const { rows } = await client.query(
         `SELECT COALESCE(MAX(version), 0) as current_version
          FROM events WHERE aggregate_id = $1
-         FOR UPDATE`,  // SELECT FOR UPDATE で排他ロック
+         FOR UPDATE`,  // SELECT FOR UPDATE for exclusive lock
         [aggregateId]
       );
       const currentVersion = rows[0].current_version;
@@ -631,7 +634,7 @@ class PostgresEventStore implements EventStore {
         );
       }
 
-      // イベントを追記（バッチ INSERT）
+      // Append events (batch INSERT)
       const values: unknown[] = [];
       const placeholders: string[] = [];
       let paramIndex = 1;
@@ -744,44 +747,44 @@ class ConcurrencyError extends Error {
 }
 ```
 
-### 2.4 Event Store のスキーマ
+### 2.4 Event Store Schema
 
 ```sql
 -- ============================================================
--- PostgreSQL: Event Store テーブル定義
+-- PostgreSQL: Event Store table definition
 -- ============================================================
 
 CREATE TABLE events (
-    -- 主キー
+    -- Primary key
     id              BIGSERIAL PRIMARY KEY,
 
-    -- イベント識別
+    -- Event identification
     event_id        UUID NOT NULL UNIQUE,
     aggregate_id    UUID NOT NULL,
     aggregate_type  VARCHAR(100) NOT NULL,
     event_type      VARCHAR(100) NOT NULL,
 
-    -- イベントデータ
+    -- Event data
     data            JSONB NOT NULL,
     metadata        JSONB NOT NULL,
 
-    -- バージョニング（楽観的ロック用）
+    -- Versioning (for optimistic locking)
     version         INTEGER NOT NULL,
 
-    -- タイムスタンプ
+    -- Timestamp
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
-    -- 集約ごとのバージョンはユニーク
+    -- Version is unique per aggregate
     CONSTRAINT unique_aggregate_version
         UNIQUE (aggregate_id, version)
 );
 
--- インデックス
+-- Indexes
 CREATE INDEX idx_events_aggregate_id ON events (aggregate_id, version);
 CREATE INDEX idx_events_event_type ON events (event_type);
 CREATE INDEX idx_events_created_at ON events (created_at);
 
--- スナップショットテーブル
+-- Snapshots table
 CREATE TABLE snapshots (
     aggregate_id    UUID PRIMARY KEY,
     aggregate_type  VARCHAR(100) NOT NULL,
@@ -793,90 +796,90 @@ CREATE TABLE snapshots (
 
 ---
 
-## 3. CQRS の設計
+## 3. CQRS Design
 
-### WHY: なぜ CQRS が必要か
+### WHY: Why CQRS Is Needed
 
-読み取りと書き込みは根本的に異なる要件を持つ:
+Reads and writes have fundamentally different requirements:
 
 ```
 ┌───────────────────────────────────────────────────────┐
-│  読み取りと書き込みの非対称性                           │
+│  Asymmetry between reads and writes                   │
 │                                                       │
-│  書き込み (Command):                                  │
-│  ・ドメインモデルの一貫性が重要                        │
-│  ・ビジネスルールの検証が必要                          │
-│  ・トランザクション整合性                              │
-│  ・通常は1つの集約を操作                              │
-│  ・トラフィックの 10-20%                              │
+│  Write (Command):                                     │
+│  · Domain model consistency is critical               │
+│  · Business rule validation is required               │
+│  · Transactional consistency                          │
+│  · Usually operates on a single aggregate             │
+│  · 10-20% of traffic                                  │
 │                                                       │
-│  読み取り (Query):                                    │
-│  ・表示に最適化されたデータ形式が重要                  │
-│  ・複数の集約をJOINした情報が必要                      │
-│  ・キャッシュが効果的                                  │
-│  ・結果整合性で十分なことが多い                        │
-│  ・トラフィックの 80-90%                              │
+│  Read (Query):                                        │
+│  · Data format optimized for display is important     │
+│  · Requires JOINed data from multiple aggregates      │
+│  · Caching is effective                               │
+│  · Eventual consistency is often sufficient           │
+│  · 80-90% of traffic                                  │
 │                                                       │
-│  → 同じモデルで両方を最適化するのは困難                │
-│  → 分離すればそれぞれに最適な設計ができる              │
+│  → It is difficult to optimize both with one model    │
+│  → Separating them allows optimal design for each     │
 └───────────────────────────────────────────────────────┘
 ```
 
-### 3.1 CQRS の4段階
+### 3.1 Four Levels of CQRS
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│  CQRS の段階的導入                                         │
+│  Incremental CQRS adoption                                │
 │                                                           │
-│  Level 0: 従来型（分離なし）                               │
+│  Level 0: Traditional (no separation)                     │
 │  ┌──────────────┐                                         │
-│  │ 同一 Model   │ ← 読み書き両方に同じモデル               │
+│  │ Same Model   │ ← Same model for both reads and writes  │
 │  │ (User Entity)│                                         │
 │  └──────┬───────┘                                         │
 │         │                                                 │
 │  ┌──────▼───────┐                                         │
-│  │   同一 DB    │                                         │
+│  │   Same DB    │                                         │
 │  └──────────────┘                                         │
 │                                                           │
-│  Level 1: モデル分離（同一 DB）                             │
+│  Level 1: Model separation (same DB)                      │
 │  ┌──────────┐  ┌──────────┐                               │
-│  │ Write    │  │ Read     │ ← 異なるモデル                 │
+│  │ Write    │  │ Read     │ ← Different models             │
 │  │ Model    │  │ Model    │    (DTO / View Model)          │
 │  └────┬─────┘  └────┬─────┘                               │
 │       └──────┬──────┘                                     │
 │       ┌──────▼───────┐                                    │
-│       │   同一 DB    │                                    │
+│       │   Same DB    │                                    │
 │       └──────────────┘                                    │
 │                                                           │
-│  Level 2: DB 分離（同期更新）                              │
+│  Level 2: DB separation (synchronous update)              │
 │  ┌──────────┐           ┌──────────┐                      │
 │  │ Write    │           │ Read     │                      │
 │  │ Model    │           │ Model    │                      │
 │  └────┬─────┘           └────┬─────┘                      │
-│  ┌────▼─────┐  同期    ┌────▼─────┐                      │
+│  ┌────▼─────┐  sync    ┌────▼─────┐                      │
 │  │ Write DB │ ───────→ │ Read DB  │                      │
 │  └──────────┘          └──────────┘                      │
 │                                                           │
-│  Level 3: Event Sourcing + 非同期プロジェクション          │
+│  Level 3: Event Sourcing + async projections              │
 │  ┌──────────┐           ┌──────────┐                      │
 │  │ Command  │           │ Query    │                      │
 │  │ Handler  │           │ Handler  │                      │
 │  └────┬─────┘           └────┬─────┘                      │
 │  ┌────▼──────┐  Event  ┌────▼─────┐                      │
-│  │ Event     │ ──────→ │ Read DB  │ ← 非同期で最適化      │
-│  │ Store     │ Stream  │(Projection)│  された形に投影      │
-│  └───────────┘         └──────────┘                      │
+│  │ Event     │ ──────→ │ Read DB  │ ← Asynchronously      │
+│  │ Store     │ Stream  │(Projection)│  projected into an  │
+│  └───────────┘         └──────────┘  optimized format    │
 └───────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 Command と Query の分離
+### 3.2 Separating Commands and Queries
 
 ```typescript
 // ============================================================
-// Command Side（書き込み）
+// Command Side (writes)
 // ============================================================
 
-// Command 定義
+// Command definitions
 type OrderCommand =
   | CreateOrderCommand
   | AddItemCommand
@@ -917,12 +920,12 @@ class OrderCommandHandler {
         return this.handleCreateOrder(command);
       case "ShipOrder":
         return this.handleShipOrder(command);
-      // ... 他のコマンド
+      // ... other commands
     }
   }
 
   private async handleCreateOrder(cmd: CreateOrderCommand): Promise<void> {
-    // 新しい集約を作成
+    // Create a new aggregate
     const order = Order.create(
       cmd.orderId,
       cmd.customerId,
@@ -936,22 +939,22 @@ class OrderCommandHandler {
       cmd.userId
     );
 
-    // イベントを永続化
+    // Persist events
     const events = order.getUncommittedEvents();
     await this.eventStore.append(cmd.orderId, [...events], 0);
     order.clearUncommittedEvents();
 
-    // イベントを発行（プロジェクション更新のため）
+    // Publish events (to update projections)
     for (const event of events) {
       await this.eventBus.publish(event);
     }
   }
 
   private async handleShipOrder(cmd: ShipOrderCommand): Promise<void> {
-    // 集約を復元
+    // Restore the aggregate
     const order = await this.loadOrder(cmd.orderId);
 
-    // コマンド実行（ビジネスルール検証 + イベント発行）
+    // Execute the command (business rule validation + event emission)
     order.ship(
       cmd.carrier,
       cmd.trackingNumber,
@@ -959,7 +962,7 @@ class OrderCommandHandler {
       cmd.userId
     );
 
-    // イベントを永続化
+    // Persist events
     const newEvents = order.getUncommittedEvents();
     await this.eventStore.append(
       cmd.orderId,
@@ -968,14 +971,14 @@ class OrderCommandHandler {
     );
     order.clearUncommittedEvents();
 
-    // イベントを発行
+    // Publish events
     for (const event of newEvents) {
       await this.eventBus.publish(event);
     }
   }
 
   private async loadOrder(orderId: string): Promise<Order> {
-    // スナップショットがあれば使用
+    // Use snapshot if available
     const snapshot = await this.snapshotRepo.load(orderId);
     if (snapshot) {
       const newEvents = await this.eventStore.getEventsAfterVersion(
@@ -985,7 +988,7 @@ class OrderCommandHandler {
       return Order.fromSnapshot(snapshot.state as OrderSnapshot, newEvents as OrderEvent[]);
     }
 
-    // なければ全イベントから復元
+    // Otherwise, restore from all events
     const events = await this.eventStore.getEvents(orderId);
     if (events.length === 0) {
       throw new Error(`Order ${orderId} not found`);
@@ -997,16 +1000,16 @@ class OrderCommandHandler {
 
 ```typescript
 // ============================================================
-// Query Side（読み取り）
+// Query Side (reads)
 // ============================================================
 
-// Read Model (Projection) — 表示に最適化されたデータ構造
+// Read Model (Projection) — data structure optimized for display
 interface OrderSummaryView {
   orderId: string;
   customerName: string;
   customerEmail: string;
   status: string;
-  statusLabel: string;  // 表示用ラベル（「発送済み」等）
+  statusLabel: string;  // Display label (e.g. "Shipped")
   itemCount: number;
   totalAmount: number;
   discountAmount: number;
@@ -1034,7 +1037,7 @@ interface OrderDetailView extends OrderSummaryView {
   }>;
 }
 
-// Projector: イベントから Read Model を構築
+// Projector: builds the Read Model from events
 class OrderProjector {
   constructor(
     private readDb: ReadDatabase,
@@ -1062,7 +1065,7 @@ class OrderProjector {
   }
 
   private async onOrderCreated(event: OrderCreated): Promise<void> {
-    // 顧客情報を取得（Read Model は非正規化してOK）
+    // Fetch customer information (denormalization is fine in Read Model)
     const customer = await this.customerService.getById(event.data.customerId);
     const items = event.data.items;
     const totalAmount = items.reduce(
@@ -1074,7 +1077,7 @@ class OrderProjector {
       customerName: customer.name,
       customerEmail: customer.email,
       status: "created",
-      statusLabel: "注文受付",
+      statusLabel: "Order Received",
       itemCount: items.length,
       totalAmount,
       discountAmount: 0,
@@ -1102,7 +1105,7 @@ class OrderProjector {
   private async onPaymentReceived(event: PaymentReceived): Promise<void> {
     await this.readDb.update("order_summaries", event.aggregateId, {
       status: "paid",
-      statusLabel: "支払い完了",
+      statusLabel: "Payment Complete",
       lastUpdated: event.metadata.timestamp,
     });
   }
@@ -1110,7 +1113,7 @@ class OrderProjector {
   private async onOrderShipped(event: OrderShipped): Promise<void> {
     await this.readDb.update("order_summaries", event.aggregateId, {
       status: "shipped",
-      statusLabel: "発送済み",
+      statusLabel: "Shipped",
       trackingUrl: `https://tracking.example.com/${event.data.trackingNumber}`,
       lastUpdated: event.metadata.timestamp,
     });
@@ -1119,13 +1122,13 @@ class OrderProjector {
   private async onOrderCancelled(event: OrderCancelled): Promise<void> {
     await this.readDb.update("order_summaries", event.aggregateId, {
       status: "cancelled",
-      statusLabel: "キャンセル",
+      statusLabel: "Cancelled",
       lastUpdated: event.metadata.timestamp,
     });
   }
 }
 
-// Query Handler — Read Model に対する検索
+// Query Handler — queries against the Read Model
 class OrderQueryHandler {
   constructor(private readDb: ReadDatabase) {}
 
@@ -1175,40 +1178,40 @@ class OrderQueryHandler {
 
 ---
 
-## 4. スナップショット最適化
+## 4. Snapshot Optimization
 
-### 4.1 スナップショットの仕組み
+### 4.1 How Snapshots Work
 
 ```
-イベント数が増大すると再生コストが増加:
+As the number of events grows, replay cost increases:
 
   Without Snapshot:
   Event 1 → Event 2 → ... → Event 999 → Event 1000
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  全1000イベントを再生（遅い）
+  Replay all 1000 events (slow)
 
-  With Snapshot (100イベントごと):
+  With Snapshot (every 100 events):
   [Snapshot @ Event 900] → Event 901 → ... → Event 1000
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                           100イベントのみ再生（速い）
+                           Only replay 100 events (fast)
 
   ┌──────────────────────────────────────────────────┐
-  │  スナップショット戦略                             │
+  │  Snapshot strategies                             │
   │                                                  │
-  │  保存タイミング:                                  │
-  │  - N イベントごと (例: 100件ごと)                 │
-  │  - 時間ベース (例: 1時間ごと)                     │
-  │  - 手動 (負荷が高い集約のみ)                      │
-  │  - イベント再生時間が閾値超過時                    │
+  │  When to save:                                   │
+  │  - Every N events (e.g. every 100)               │
+  │  - Time-based (e.g. every hour)                  │
+  │  - Manual (only for high-load aggregates)        │
+  │  - When event replay time exceeds a threshold    │
   │                                                  │
-  │  保存先:                                          │
-  │  - 同じ Event Store の別テーブル                   │
-  │  - Redis / Memcached (高速アクセス)               │
-  │  - S3 (大量データ、低頻度アクセス)                │
+  │  Where to save:                                  │
+  │  - Separate table in the same Event Store        │
+  │  - Redis / Memcached (fast access)               │
+  │  - S3 (large data, infrequent access)            │
   └──────────────────────────────────────────────────┘
 ```
 
-### 4.2 スナップショット実装
+### 4.2 Snapshot Implementation
 
 ```typescript
 // ============================================================
@@ -1256,7 +1259,7 @@ class PostgresSnapshotRepository implements SnapshotRepository {
 }
 
 // ============================================================
-// スナップショット対応の Order Repository
+// Snapshot-aware Order Repository
 // ============================================================
 class EventSourcedOrderRepository {
   constructor(
@@ -1291,7 +1294,7 @@ class EventSourcedOrderRepository {
     await this.eventStore.append(order.id, [...events], baseVersion);
     order.clearUncommittedEvents();
 
-    // スナップショット保存判定
+    // Decide whether to save a snapshot
     if (order.version % this.snapshotInterval === 0) {
       await this.snapshotRepo.save({
         aggregateId: order.id,
@@ -1306,18 +1309,18 @@ class EventSourcedOrderRepository {
 
 ---
 
-## 5. イベントスキーマのバージョニング
+## 5. Event Schema Versioning
 
-### WHY: なぜバージョニングが必要か
+### WHY: Why Versioning Is Needed
 
-イベントは不変（immutable）であるため、スキーマ変更時に既存イベントを書き換えることはできない。代わりに **Upcaster** パターンで古いバージョンのイベントを読み取り時に変換する。
+Because events are immutable, existing events cannot be rewritten when the schema changes. Instead, use the **Upcaster** pattern to transform old-version events at read time.
 
 ```typescript
 // ============================================================
-// イベントバージョニングと Upcaster
+// Event versioning and Upcaster
 // ============================================================
 
-// v1: 初期バージョン
+// v1: initial version
 interface OrderCreatedV1 {
   eventType: "OrderCreated";
   schemaVersion: 1;
@@ -1327,7 +1330,7 @@ interface OrderCreatedV1 {
   };
 }
 
-// v2: 通貨フィールドを追加
+// v2: added currency field
 interface OrderCreatedV2 {
   eventType: "OrderCreated";
   schemaVersion: 2;
@@ -1337,13 +1340,13 @@ interface OrderCreatedV2 {
       productId: string;
       quantity: number;
       price: number;
-      currency: string;  // 新規追加
+      currency: string;  // newly added
     }>;
-    currency: string;  // 新規追加
+    currency: string;  // newly added
   };
 }
 
-// v3: 配送先を追加
+// v3: added shipping address
 interface OrderCreatedV3 {
   eventType: "OrderCreated";
   schemaVersion: 3;
@@ -1356,7 +1359,7 @@ interface OrderCreatedV3 {
       currency: string;
     }>;
     currency: string;
-    shippingAddress: {  // 新規追加
+    shippingAddress: {  // newly added
       street: string;
       city: string;
       postalCode: string;
@@ -1393,16 +1396,16 @@ class EventUpcaster {
   }
 }
 
-// Upcaster の登録
+// Registering upcasters
 const upcaster = new EventUpcaster();
 
-// v1 → v2: currency フィールドを追加
+// v1 → v2: add currency field
 upcaster.register("OrderCreated", 1, (event: OrderCreatedV1): OrderCreatedV2 => ({
   ...event,
   schemaVersion: 2,
   data: {
     ...event.data,
-    currency: "JPY",  // デフォルト値
+    currency: "JPY",  // default value
     items: event.data.items.map((i) => ({
       ...i,
       currency: "JPY",
@@ -1410,15 +1413,15 @@ upcaster.register("OrderCreated", 1, (event: OrderCreatedV1): OrderCreatedV2 => 
   },
 }));
 
-// v2 → v3: shippingAddress を追加
+// v2 → v3: add shippingAddress
 upcaster.register("OrderCreated", 2, (event: OrderCreatedV2): OrderCreatedV3 => ({
   ...event,
   schemaVersion: 3,
   data: {
     ...event.data,
     shippingAddress: {
-      street: "不明",
-      city: "不明",
+      street: "Unknown",
+      city: "Unknown",
       postalCode: "000-0000",
       country: "JP",
     },
@@ -1428,107 +1431,107 @@ upcaster.register("OrderCreated", 2, (event: OrderCreatedV2): OrderCreatedV3 => 
 
 ---
 
-## 6. 比較表
+## 6. Comparison Tables
 
 ### 6.1 CRUD vs Event Sourcing
 
-| 観点 | 従来の CRUD | Event Sourcing |
+| Aspect | Traditional CRUD | Event Sourcing |
 |------|-----------|----------------|
-| **データモデル** | 現在の状態のみ | イベントの履歴（不変） |
-| **変更履歴** | 手動で監査テーブル作成 | 自動的に全履歴保持 |
-| **任意時点の復元** | 不可能（別途実装必要） | イベント再生で可能 |
-| **データ容量** | 少ない（現在の状態のみ） | 大きい（全イベント保存） |
-| **読み取り性能** | 高い（直接クエリ） | 低い（再生必要 → プロジェクションで解決） |
-| **書き込み性能** | 中（UPDATE + ロック） | 高い（追記のみ、ロック少ない） |
-| **スキーマ変更** | マイグレーションで対応 | Upcaster で旧バージョンを変換 |
-| **デバッグ** | 現在の状態のみ確認可能 | イベントログで原因追跡容易 |
-| **複雑性** | 低い | 高い |
-| **テスト** | DB モック必要 | イベントの入出力で検証可能 |
+| **Data model** | Current state only | Event history (immutable) |
+| **Change history** | Manual audit table required | Full history preserved automatically |
+| **Point-in-time recovery** | Not possible (requires separate implementation) | Possible via event replay |
+| **Storage volume** | Small (current state only) | Large (all events stored) |
+| **Read performance** | High (direct query) | Low (requires replay → solved with projections) |
+| **Write performance** | Medium (UPDATE + lock) | High (append-only, fewer locks) |
+| **Schema changes** | Handled via migration | Old versions converted with Upcaster |
+| **Debugging** | Only current state is visible | Event log makes root cause tracing easy |
+| **Complexity** | Low | High |
+| **Testing** | DB mock required | Verifiable with event input/output |
 
-### 6.2 CQRS 導入パターン比較
+### 6.2 CQRS Adoption Pattern Comparison
 
-| パターン | 説明 | 整合性 | 複雑度 | スケーラビリティ | ユースケース |
+| Pattern | Description | Consistency | Complexity | Scalability | Use Case |
 |---------|------|--------|--------|----------------|------------|
-| **Level 0: 分離なし** | 同一モデル、同一 DB | 即時整合 | 低 | 低 | 小規模 CRUD |
-| **Level 1: モデル分離** | 異なるモデル、同一 DB | 即時整合 | 低〜中 | 中 | 読み書きの最適化 |
-| **Level 2: DB 分離 + 同期** | Write DB → Read DB を同期更新 | ほぼ即時 | 中 | 中〜高 | 整合性重視 |
-| **Level 3: ES + 非同期** | Event Store + 非同期プロジェクション | 結果整合 | 高 | 最高 | 高スケーラビリティ |
+| **Level 0: No separation** | Same model, same DB | Immediate | Low | Low | Small-scale CRUD |
+| **Level 1: Model separation** | Different models, same DB | Immediate | Low–Medium | Medium | Read/write optimization |
+| **Level 2: DB separation + sync** | Write DB → Read DB sync update | Near-immediate | Medium | Medium–High | Consistency-focused |
+| **Level 3: ES + async** | Event Store + async projections | Eventual | High | Highest | High scalability |
 
-### 6.3 Event Store 実装の選択肢
+### 6.3 Event Store Implementation Options
 
-| 実装 | 特徴 | 適する規模 | 運用コスト |
+| Implementation | Characteristics | Suitable Scale | Operational Cost |
 |------|------|-----------|----------|
-| **PostgreSQL + JSONB** | 汎用的、既存インフラ活用 | 小〜中（〜数千万イベント） | 低 |
-| **EventStoreDB** | ES 専用、プロジェクションエンジン内蔵 | 中〜大 | 中 |
-| **Apache Kafka** | ストリーム処理、高スループット | 大（数十億イベント） | 高 |
-| **DynamoDB Streams** | AWS ネイティブ、サーバーレス | 中〜大 | 中（従量課金） |
-| **MongoDB + Change Streams** | ドキュメント指向、柔軟なスキーマ | 中 | 中 |
+| **PostgreSQL + JSONB** | General-purpose, leverages existing infrastructure | Small–Medium (~tens of millions of events) | Low |
+| **EventStoreDB** | ES-dedicated, built-in projection engine | Medium–Large | Medium |
+| **Apache Kafka** | Stream processing, high throughput | Large (billions of events) | High |
+| **DynamoDB Streams** | AWS-native, serverless | Medium–Large | Medium (pay-per-use) |
+| **MongoDB + Change Streams** | Document-oriented, flexible schema | Medium | Medium |
 
 ---
 
-## 7. アンチパターン
+## 7. Anti-Patterns
 
-### 7.1 全てのドメインに Event Sourcing を適用
+### 7.1 Applying Event Sourcing to All Domains
 
 ```
-NG: マスタデータ（商品カテゴリ、設定値）にも Event Sourcing
-    → 過度な複雑性、CRUD で十分な領域
+NG: Applying Event Sourcing to master data (product categories, configuration values)
+    → Excessive complexity; CRUD is sufficient for these areas
 
-OK: Event Sourcing の適用基準
+OK: Criteria for applying Event Sourcing
     ┌───────────────────────────────────────┐
-    │ Event Sourcing が適する:              │
-    │ ✓ 注文処理、金融取引                  │
-    │ ✓ 監査証跡が法的に必要               │
-    │ ✓ ビジネスイベントの分析が重要       │
-    │ ✓ 複雑な状態遷移がある               │
-    │ ✓ 取り消し/補償トランザクションが必要 │
+    │ Event Sourcing is appropriate for:   │
+    │ ✓ Order processing, financial txns   │
+    │ ✓ Audit trail legally required       │
+    │ ✓ Business event analysis is critical│
+    │ ✓ Complex state transitions exist    │
+    │ ✓ Undo/compensating txns needed      │
     │                                       │
-    │ CRUD で十分:                          │
-    │ ✗ ユーザープロフィール               │
-    │ ✗ マスタデータ管理                   │
-    │ ✗ 設定値管理                         │
-    │ ✗ CRUD が中心の管理画面              │
-    │ ✗ 単純な参照データ                   │
+    │ CRUD is sufficient for:              │
+    │ ✗ User profiles                      │
+    │ ✗ Master data management             │
+    │ ✗ Configuration management           │
+    │ ✗ Admin screens centered on CRUD     │
+    │ ✗ Simple reference data              │
     └───────────────────────────────────────┘
 ```
 
-**なぜ NG か**: Event Sourcing はイベント設計、Projector 実装、結果整合性の管理など大きなコストがかかる。ビジネス上の価値がないドメインに適用すると、複雑さだけが増す。
+**Why it's NG**: Event Sourcing carries significant costs — event design, Projector implementation, managing eventual consistency. Applying it to domains with no business value only adds complexity.
 
-### 7.2 イベントスキーマを頻繁に変更する
+### 7.2 Frequently Changing Event Schemas
 
 ```typescript
-// NG: 既存イベントの構造を直接変更
-// v1 のデータ: { amount: 1000 }
-// v2 のデータ: { amount: 1000, currency: "JPY" }
-// → 既存の v1 イベントを読み込むとクラッシュ
+// NG: Directly modifying the structure of existing events
+// v1 data: { amount: 1000 }
+// v2 data: { amount: 1000, currency: "JPY" }
+// → Reading v1 events will crash
 
-// OK: Upcaster でバージョン移行
+// OK: Migrate versions using an Upcaster
 function upcastOrderCreatedV1toV2(event: OrderCreatedV1): OrderCreatedV2 {
   return {
     ...event,
     schemaVersion: 2,
     data: {
       ...event.data,
-      currency: "JPY",  // デフォルト値を付与
+      currency: "JPY",  // assign default value
     },
   };
 }
 ```
 
-**なぜ NG か**: イベントは不変であり、既に保存されたデータの構造を変えることはできない。Upcaster を使って読み取り時に変換するのが正しいアプローチ。
+**Why it's NG**: Events are immutable — the structure of already-stored data cannot be changed. The correct approach is to use an Upcaster to transform them at read time.
 
-### 7.3 イベントにドメインの意図を含めない
+### 7.3 Not Encoding Domain Intent in Events
 
 ```typescript
-// NG: CRUD 風の汎用イベント
+// NG: Generic CRUD-style event
 interface OrderUpdated {
   eventType: "OrderUpdated";
   data: {
-    fields: Record<string, unknown>;  // 何が変わったか分からない
+    fields: Record<string, unknown>;  // unclear what changed
   };
 }
 
-// OK: ドメインの意図を表現するイベント
+// OK: Events that express domain intent
 interface DiscountApplied {
   eventType: "DiscountApplied";
   data: {
@@ -1538,40 +1541,40 @@ interface DiscountApplied {
     couponCode?: string;
   };
 }
-// 「なぜ金額が変わったか」が明確
+// "Why did the amount change?" is clearly expressed
 ```
 
-**なぜ NG か**: Event Sourcing の価値は「ドメインの歴史を記録すること」。汎用的な "Updated" イベントでは、CRUD と同じく「何が起こったか」しか分からず、「なぜ起こったか」が失われる。
+**Why it's NG**: The value of Event Sourcing is "recording the history of the domain." A generic "Updated" event, just like CRUD, only tells you "what happened" — the "why it happened" is lost.
 
-### 7.4 プロジェクションで副作用を実行する
+### 7.4 Executing Side Effects Inside Projections
 
 ```typescript
-// NG: Projector 内で外部 API を呼ぶ
+// NG: Calling external APIs inside a Projector
 class OrderProjector {
   async handle(event: OrderShipped) {
-    // Read Model の更新
+    // Update the Read Model
     await this.readDb.update(/* ... */);
 
-    // 副作用（NG！）
+    // Side effects (NG!)
     await this.emailService.sendShipmentNotification(event);
     await this.smsService.sendTrackingLink(event);
-    // → プロジェクションを再構築（Rebuild）するたびに
-    //   メールとSMSが再送信されてしまう！
+    // → Every time the projection is rebuilt (Rebuild),
+    //   emails and SMS will be re-sent!
   }
 }
 
-// OK: 副作用は別のイベントハンドラで
+// OK: Side effects in a separate event handler
 class OrderProjector {
   async handle(event: OrderShipped) {
-    // Read Model の更新のみ
+    // Only update the Read Model
     await this.readDb.update(/* ... */);
   }
 }
 
-// 通知は専用のハンドラで（べき等性を保証）
+// Notifications handled in a dedicated handler (with idempotency guarantee)
 class ShipmentNotificationHandler {
   async handle(event: OrderShipped) {
-    // べき等性チェック
+    // Idempotency check
     const alreadySent = await this.notificationLog.exists(event.eventId);
     if (alreadySent) return;
 
@@ -1581,93 +1584,93 @@ class ShipmentNotificationHandler {
 }
 ```
 
-**なぜ NG か**: プロジェクションは再構築（Rebuild）される可能性がある。副作用がプロジェクション内にあると、Rebuild のたびに副作用が再実行される。通知やメール送信は別のイベントハンドラに分離し、べき等性を保証する。
+**Why it's NG**: Projections may be rebuilt (Rebuild). If side effects are inside the projection, they will re-execute every time it is rebuilt. Notifications and emails should be separated into dedicated event handlers with idempotency guarantees.
 
 ---
 
-## 8. 実践演習
+## 8. Practical Exercises
 
-### 演習 1（基礎）: イベント定義と集約
+### Exercise 1 (Basic): Event Definition and Aggregate
 
-銀行口座（BankAccount）の集約を Event Sourcing で設計せよ。
+Design a BankAccount aggregate using Event Sourcing.
 
-**イベント**:
-- AccountOpened（口座開設）
-- MoneyDeposited（入金）
-- MoneyWithdrawn（出金）
-- AccountFrozen（口座凍結）
-- AccountClosed（口座解約）
+**Events**:
+- AccountOpened
+- MoneyDeposited
+- MoneyWithdrawn
+- AccountFrozen
+- AccountClosed
 
-**ビジネスルール**:
-- 残高がマイナスになる出金は不可
-- 凍結中の口座は入出金不可
-- 閉鎖済み口座は操作不可
+**Business rules**:
+- Withdrawals that would result in a negative balance are not allowed
+- Frozen accounts cannot perform deposits or withdrawals
+- Closed accounts cannot be operated on
 
-**期待する出力**: `BankAccount` 集約クラス（TypeScript）とテストコード
-
----
-
-### 演習 2（応用）: プロジェクションの設計
-
-演習 1 の銀行口座イベントから、以下の Read Model を構築する Projector を実装せよ。
-
-1. **AccountBalanceView** — 口座残高一覧（口座ID、名前、残高、状態）
-2. **TransactionHistoryView** — 取引履歴（日時、種別、金額、残高）
-3. **DailyReportView** — 日次レポート（日ごとの入金合計、出金合計、純増減）
-
-**期待する出力**: 3つの Projector クラスと Read Model 定義
+**Expected output**: `BankAccount` aggregate class (TypeScript) and test code
 
 ---
 
-### 演習 3（発展）: 段階的 CRUD → ES 移行
+### Exercise 2 (Applied): Projection Design
 
-既存の CRUD ベースの注文システムを、Strangler Fig パターンで段階的に Event Sourcing に移行する計画を立てよ。
+Using the bank account events from Exercise 1, implement Projectors that build the following Read Models.
 
-**現行システム**: orders テーブル（id, status, total, user_id, created_at, updated_at）
+1. **AccountBalanceView** — Account balance list (account ID, name, balance, status)
+2. **TransactionHistoryView** — Transaction history (timestamp, type, amount, balance)
+3. **DailyReportView** — Daily report (total deposits, total withdrawals, net change per day)
 
-**移行計画**:
-1. Phase 1: Dual Write（CRUD + イベント記録を並行）
-2. Phase 2: Read Model 構築（イベントからプロジェクション作成）
-3. Phase 3: 読み取りをプロジェクションに移行
-4. Phase 4: 書き込みを Event Sourcing に移行
-5. Phase 5: 旧テーブルの廃止
+**Expected output**: Three Projector classes and Read Model definitions
 
-**期待する出力**: 各フェーズの具体的なコード例（TypeScript）とリスク分析
+---
+
+### Exercise 3 (Advanced): Incremental CRUD → ES Migration
+
+Plan an incremental migration from an existing CRUD-based order system to Event Sourcing using the Strangler Fig pattern.
+
+**Current system**: orders table (id, status, total, user_id, created_at, updated_at)
+
+**Migration plan**:
+1. Phase 1: Dual Write (run CRUD and event recording in parallel)
+2. Phase 2: Build Read Model (create projections from events)
+3. Phase 3: Migrate reads to projections
+4. Phase 4: Migrate writes to Event Sourcing
+5. Phase 5: Retire the old table
+
+**Expected output**: Concrete code examples (TypeScript) for each phase and a risk analysis
 
 ---
 
 ## 9. FAQ
 
-### Q1. Event Sourcing のイベントが増え続けてストレージが心配
+### Q1. I'm worried about storage as Event Sourcing events keep growing
 
-**A.** 3 つの対策がある:
-1. **スナップショット** — N イベントごとに状態を保存し、古いイベントの再生を省略
-2. **アーカイブ** — 一定期間経過したイベントを S3/Glacier に移動（法的要件に注意）
-3. **パーティショニング** — 月別 / 年別でテーブルを分割し、検索性能を維持
+**A.** Three countermeasures are available:
+1. **Snapshots** — Save state every N events and skip replaying older events
+2. **Archiving** — Move events older than a certain period to S3/Glacier (note legal requirements)
+3. **Partitioning** — Split tables by month/year to maintain query performance
 
-実務では、数千万イベントでも PostgreSQL で問題なく運用できる。パーティショニングを適用すれば数億イベントも対応可能。1イベント平均 1KB として、1億イベント = 約 100GB であり、現代のストレージコストでは許容範囲。
+In practice, tens of millions of events run fine on PostgreSQL. With partitioning, hundreds of millions of events are manageable. At an average of 1KB per event, 100 million events is roughly 100GB — an acceptable range at modern storage costs.
 
-### Q2. CQRS で結果整合性になると UI はどう対応する？
+### Q2. How should the UI handle eventual consistency in CQRS?
 
-**A.** 3 つのパターンがある:
+**A.** Three patterns are available:
 
-1. **楽観的 UI** — コマンド成功後に UI をローカルで即座に更新
-2. **ポーリング** — コマンド後に短い間隔で Read Model を確認
-3. **WebSocket / SSE** — プロジェクション更新完了をリアルタイムに通知
+1. **Optimistic UI** — Immediately update the UI locally after a successful command
+2. **Polling** — Check the Read Model at short intervals after a command
+3. **WebSocket / SSE** — Notify in real-time when a projection update is complete
 
 ```typescript
-// 楽観的 UI の例（React）
+// Example of optimistic UI (React)
 async function submitOrder(orderData: CreateOrderInput) {
-  // 1. コマンド送信
+  // 1. Send command
   await api.post("/commands/create-order", orderData);
 
-  // 2. UI をローカルで即座に更新（Read Model 更新を待たない）
+  // 2. Immediately update the UI locally (without waiting for Read Model update)
   setOrders((prev) => [
     { ...orderData, status: "processing", id: tempId },
     ...prev,
   ]);
 
-  // 3. バックグラウンドで Read Model の反映を確認
+  // 3. Confirm Read Model reflection in the background
   const confirmed = await pollUntil(
     () => api.get(`/orders/${orderData.id}`),
     (res) => res.status !== 404,
@@ -1675,7 +1678,7 @@ async function submitOrder(orderData: CreateOrderInput) {
   );
 
   if (confirmed) {
-    // 楽観的更新を確定データで置換
+    // Replace optimistic update with confirmed data
     setOrders((prev) =>
       prev.map((o) => (o.id === tempId ? confirmed : o))
     );
@@ -1683,43 +1686,43 @@ async function submitOrder(orderData: CreateOrderInput) {
 }
 ```
 
-### Q3. Event Sourcing を既存の CRUD アプリに段階的に導入できる？
+### Q3. Can Event Sourcing be incrementally introduced into an existing CRUD application?
 
-**A.** 可能。Strangler Fig パターンと組み合わせた段階的アプローチが推奨される:
+**A.** Yes. An incremental approach combined with the Strangler Fig pattern is recommended:
 
-1. **Phase 1: Dual Write** — CRUD と並行してイベントテーブルに記録
-2. **Phase 2: Read Model 構築** — イベントからプロジェクションを作成し、読み取りクエリの一部を移行
-3. **Phase 3: 読み取り移行完了** — 全読み取りをプロジェクションに切り替え
-4. **Phase 4: 書き込み移行** — 集約単位で書き込みを Event Sourcing に移行
-5. **Phase 5: 旧テーブル廃止** — CRUD テーブルを削除
+1. **Phase 1: Dual Write** — Record events in parallel alongside CRUD
+2. **Phase 2: Build Read Model** — Create projections from events and migrate some read queries
+3. **Phase 3: Complete read migration** — Switch all reads to projections
+4. **Phase 4: Migrate writes** — Migrate writes to Event Sourcing per aggregate
+5. **Phase 5: Retire old tables** — Drop the CRUD tables
 
-各フェーズ間でシステムが正常動作することを確認し、問題があればロールバック可能な状態を維持する。全フェーズの完了には通常 3-6 ヶ月かかる。
+Verify that the system operates normally between each phase and maintain a rollback-capable state if issues arise. Completing all phases typically takes 3–6 months.
 
-### Q4. Event Sourcing のテストはどう書く？
+### Q4. How do you write tests for Event Sourcing?
 
-**A.** 「Given-When-Then」パターンが最も自然:
+**A.** The "Given-When-Then" pattern is the most natural:
 
 ```typescript
 describe("Order Aggregate", () => {
-  test("支払い済み注文に商品を追加するとエラー", () => {
-    // Given: 支払い済みの注文
+  test("adding an item to a paid order throws an error", () => {
+    // Given: a paid order
     const events: OrderEvent[] = [
       orderCreatedEvent({ items: [item1] }),
       paymentReceivedEvent({ amount: 5000 }),
     ];
     const order = Order.fromEvents(events);
 
-    // When + Then: 商品追加するとエラー
+    // When + Then: adding an item throws an error
     expect(() => {
       order.addItem(item2, "user-1");
-    }).toThrow('状態 "paid" の注文に商品を追加できません');
+    }).toThrow('Cannot add items to an order with status "paid"');
   });
 
-  test("注文作成で OrderCreated イベントが発行される", () => {
-    // When: 注文を作成
+  test("creating an order emits an OrderCreated event", () => {
+    // When: create an order
     const order = Order.create("order-1", "customer-1", [item1], address, "user-1");
 
-    // Then: 発行されたイベントを検証
+    // Then: verify the emitted events
     const events = order.getUncommittedEvents();
     expect(events).toHaveLength(1);
     expect(events[0].eventType).toBe("OrderCreated");
@@ -1728,66 +1731,66 @@ describe("Order Aggregate", () => {
 });
 ```
 
-### Q5. プロジェクションが壊れた場合の復旧方法は？
+### Q5. How do you recover if a projection breaks?
 
-**A.** イベントは不変であるため、プロジェクションはいつでも再構築（Rebuild）可能:
+**A.** Because events are immutable, projections can always be rebuilt (Rebuild):
 
-1. Read Model テーブルを TRUNCATE
-2. 全イベントを最初から再生してプロジェクションを再構築
-3. Read Model のスキーマを変更した場合も、同じ手順で新しい形式のデータを作成可能
+1. TRUNCATE the Read Model table
+2. Replay all events from the beginning to rebuild the projection
+3. When the Read Model schema changes, the same procedure creates data in the new format
 
-これが Event Sourcing の最大の利点の一つ。「データの変換ミス」があっても、Projector を修正して Rebuild すれば正しい状態に復旧できる。
+This is one of the greatest advantages of Event Sourcing. Even if there is a "data transformation mistake," fixing the Projector and running a Rebuild restores the correct state.
 
 ---
 
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is paramount. Understanding deepens not just through theory, but by actually writing code and confirming how it behaves.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the fundamentals and jumping to advanced topics. We recommend thoroughly understanding the core concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in real-world practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
+Knowledge of this topic is frequently applied in day-to-day development work, especially during code reviews and architectural design.
 
 ---
 
-## 10. まとめ
+## 10. Summary
 
-| 項目 | ポイント |
+| Item | Key Points |
 |------|---------|
-| **Event Sourcing** | 状態の変化をイベントとして追記保存。完全な監査証跡、任意時点の復元が可能 |
-| **イベントの3原則** | 不変（Immutable）、追記のみ（Append-Only）、導出値（Derived State） |
-| **CQRS** | 読み取りと書き込みを分離。それぞれを独立にスケール・最適化 |
-| **プロジェクション** | イベントから最適化された Read Model を構築。壊れても再構築可能 |
-| **スナップショット** | イベント再生コストを削減する最適化手法。N イベントごとに状態保存 |
-| **バージョニング** | Upcaster パターンでイベントスキーマの進化に対応。既存イベントは不変 |
-| **適用基準** | 監査要件、複雑な状態遷移、高スケーラビリティが必要な場合に適用。CRUD で十分な領域には不要 |
-| **テスト** | Given-When-Then パターン。イベントの入出力で検証可能。DB 不要 |
+| **Event Sourcing** | Store state changes as append-only events. Full audit trail and point-in-time recovery are possible |
+| **Three principles of events** | Immutable, Append-Only, Derived State |
+| **CQRS** | Separate reads and writes. Scale and optimize each independently |
+| **Projections** | Build optimized Read Models from events. Can be rebuilt if broken |
+| **Snapshots** | Optimization technique to reduce event replay costs. Save state every N events |
+| **Versioning** | Handle event schema evolution with the Upcaster pattern. Existing events remain immutable |
+| **When to apply** | Apply when audit requirements, complex state transitions, or high scalability are needed. Not necessary for CRUD-sufficient areas |
+| **Testing** | Given-When-Then pattern. Verifiable with event input/output. No DB required |
 
 ---
 
-## 次に読むべきガイド
+## What to Read Next
 
-- [00-mvc-mvvm.md](./00-mvc-mvvm.md) — UI レイヤーのアーキテクチャパターン
-- [01-repository-pattern.md](./01-repository-pattern.md) — データアクセスの抽象化
-- ../../system-design-guide/ — メッセージキュー、分散システム設計
-- ../../clean-code-principles/ — DDD、SOLID 原則
-- [../02-behavioral/](../02-behavioral/) — Observer パターン（イベント駆動の基盤）
+- [00-mvc-mvvm.md](./00-mvc-mvvm.md) — UI layer architectural patterns
+- [01-repository-pattern.md](./01-repository-pattern.md) — Data access abstraction
+- ../../system-design-guide/ — Message queues, distributed system design
+- ../../clean-code-principles/ — DDD, SOLID principles
+- [../02-behavioral/](../02-behavioral/) — Observer pattern (foundation of event-driven design)
 
 ---
 
-## 参考文献
+## References
 
 1. **Martin Fowler** — "Event Sourcing" — https://martinfowler.com/eaaDev/EventSourcing.html
 2. **Martin Fowler** — "CQRS" — https://martinfowler.com/bliki/CQRS.html
 3. **Greg Young** — "CQRS and Event Sourcing" — https://cqrs.files.wordpress.com/2010/11/cqrs_documents.pdf
 4. **Microsoft** — "CQRS pattern" — https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs
-5. **Vaughn Vernon** — "Implementing Domain-Driven Design" (2013) — Event Sourcing と DDD の統合
+5. **Vaughn Vernon** — "Implementing Domain-Driven Design" (2013) — Integration of Event Sourcing and DDD
 6. **EventStoreDB Documentation** — https://www.eventstore.com/docs/
 7. **Adam Dymitruk** — "Event Modeling" — https://eventmodeling.org/


### PR DESCRIPTION
## Summary
- Translated all 20 files in `03-software-design/design-patterns-guide/docs/`
- Sections: 00-creational (4), 01-structural (5), 02-behavioral (5), 03-functional (3), 04-architectural (3)

## Files
- 00-creational: singleton, factory, builder, prototype
- 01-structural: adapter, decorator, facade, proxy, composite
- 02-behavioral: observer, strategy, command, state, iterator
- 03-functional: monad, functor-applicative, fp-patterns
- 04-architectural: mvc-mvvm, repository-pattern, event-sourcing-cqrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)