### PR TITLE
translate: browser-and-web-platform remaining 2 files + fix translation-status.js

### DIFF
--- a/04-web-and-network/browser-and-web-platform/docs/03-web-apis/02-intersection-resize-observer.md
+++ b/04-web-and-network/browser-and-web-platform/docs/03-web-apis/02-intersection-resize-observer.md
@@ -1,98 +1,98 @@
 # Observer API
 
-> IntersectionObserver、ResizeObserver、MutationObserver、PerformanceObserverは、要素の可視性・サイズ変更・DOM変更・パフォーマンスイベントを効率的に監視するブラウザネイティブAPI群。従来のscrollイベントやsetIntervalによるポーリングに比べて大幅にパフォーマンスが優れており、遅延読み込み、無限スクロール、レスポンシブコンポーネント、Web Vitals計測など幅広い実務シーンで不可欠な技術である。
+> IntersectionObserver, ResizeObserver, MutationObserver, and PerformanceObserver are a set of browser-native APIs for efficiently monitoring element visibility, size changes, DOM mutations, and performance events. Compared to traditional scroll events or setInterval-based polling, these APIs offer significantly better performance and are indispensable in a wide range of practical scenarios including lazy loading, infinite scroll, responsive components, and Web Vitals measurement.
 
-## 前提知識
+## Prerequisites
 
-この章を理解するために、以下の知識を事前に習得しておくことを推奨する。
+It is recommended to have the following knowledge before studying this chapter.
 
-- **DOM API** ([./00-dom-api.md](./00-dom-api.md)): Observer APIはDOM要素を監視対象とするため、DOM操作の基礎（querySelector、イベントリスナー、要素の参照管理など）を理解していることが前提となる。
-- **レンダリングパイプライン** ([../01-rendering/00-rendering-pipeline.md](../01-rendering/00-rendering-pipeline.md)): IntersectionObserverやResizeObserverがなぜパフォーマンスに優れているかを理解するには、ブラウザのレンダリングプロセス（Layout、Paint、Compositeの各フェーズ）とリフロー（Forced Reflow）の概念を把握しておく必要がある。
-- **スクロールイベントの基本**: 従来のscrollイベントとgetBoundingClientRect()を使った可視性判定の仕組みを知っていると、Observer APIの優位性とユースケースがより明確になる。特にイベントのthrottle/debounceパターンと、そのパフォーマンス上の課題を理解しておくとよい。
+- **DOM API** ([./00-dom-api.md](./00-dom-api.md)): Since the Observer API observes DOM elements, a foundational understanding of DOM manipulation (querySelector, event listeners, element reference management, etc.) is assumed.
+- **Rendering Pipeline** ([../01-rendering/00-rendering-pipeline.md](../01-rendering/00-rendering-pipeline.md)): To understand why IntersectionObserver and ResizeObserver are performant, you need to be familiar with the browser's rendering process (the Layout, Paint, and Composite phases) and the concept of forced reflow.
+- **Scroll Event Basics**: Knowing how traditional scroll events and getBoundingClientRect() work for visibility detection makes the advantages and use cases of the Observer API clearer. In particular, understanding the throttle/debounce pattern for events and its performance drawbacks is helpful.
 
-これらの基礎知識があることで、Observer APIの設計思想と実務での効果的な活用法をより深く理解できる。
+Having this foundational knowledge allows for a deeper understanding of the Observer API's design philosophy and how to use it effectively in practice.
 
 ---
 
-## この章で学ぶこと
+## What You Will Learn in This Chapter
 
-- [ ] IntersectionObserverの仕組みと活用パターンを理解する
-- [ ] ResizeObserverの使い方とコンテナクエリとの比較を把握する
-- [ ] MutationObserverでDOM変更を効率的に監視する方法を学ぶ
-- [ ] PerformanceObserverによるWeb Vitals計測を実装できるようになる
-- [ ] 各Observerのパフォーマンス面での利点とベストプラクティスを理解する
-- [ ] Reactやフレームワークでのカスタムフック化パターンを身につける
+- [ ] Understand how IntersectionObserver works and the patterns for using it
+- [ ] Learn how to use ResizeObserver and how it compares to container queries
+- [ ] Learn how to efficiently monitor DOM changes with MutationObserver
+- [ ] Be able to implement Web Vitals measurement with PerformanceObserver
+- [ ] Understand the performance benefits and best practices of each Observer
+- [ ] Learn how to create custom hook patterns for React and other frameworks
 
 ---
 
 ## 1. IntersectionObserver
 
-### 1.1 基本概念とAPI
+### 1.1 Core Concepts and API
 
-IntersectionObserverは、ターゲット要素がルート要素（デフォルトではビューポート）と交差する状態を非同期的に監視するAPIである。スクロールイベントとgetBoundingClientRect()を使った従来の手法と異なり、ブラウザの内部最適化により、メインスレッドへの負荷を最小限に抑えることができる。
+IntersectionObserver is an API that asynchronously monitors the intersection state of a target element with a root element (the viewport by default). Unlike the traditional approach of using scroll events with getBoundingClientRect(), it leverages browser-internal optimizations to minimize load on the main thread.
 
 ```javascript
-// IntersectionObserverの基本構造
+// Basic structure of IntersectionObserver
 const observer = new IntersectionObserver(
   (entries, observer) => {
-    // entries: IntersectionObserverEntry[] の配列
-    // observer: IntersectionObserver インスタンス自身
+    // entries: array of IntersectionObserverEntry[]
+    // observer: the IntersectionObserver instance itself
     entries.forEach(entry => {
-      // entry のプロパティ
-      console.log('target:', entry.target);           // 監視対象のDOM要素
-      console.log('isIntersecting:', entry.isIntersecting); // 交差しているか
-      console.log('intersectionRatio:', entry.intersectionRatio); // 交差率 (0.0-1.0)
-      console.log('intersectionRect:', entry.intersectionRect); // 交差領域
-      console.log('boundingClientRect:', entry.boundingClientRect); // ターゲットの矩形
-      console.log('rootBounds:', entry.rootBounds);   // ルート要素の矩形
-      console.log('time:', entry.time);               // 交差が記録された時刻
+      // Properties of entry
+      console.log('target:', entry.target);           // The observed DOM element
+      console.log('isIntersecting:', entry.isIntersecting); // Whether it is intersecting
+      console.log('intersectionRatio:', entry.intersectionRatio); // Intersection ratio (0.0-1.0)
+      console.log('intersectionRect:', entry.intersectionRect); // The intersection rectangle
+      console.log('boundingClientRect:', entry.boundingClientRect); // The target's bounding rect
+      console.log('rootBounds:', entry.rootBounds);   // The root element's bounding rect
+      console.log('time:', entry.time);               // Timestamp when the intersection was recorded
     });
   },
   {
-    root: null,             // 監視のルート要素（null=ビューポート）
-    rootMargin: '0px',      // ルート要素のマージン（CSS形式: "10px 20px 30px 40px"）
-    threshold: [0, 0.5, 1], // コールバック発火の交差率しきい値
+    root: null,             // Root element for observation (null = viewport)
+    rootMargin: '0px',      // Margin around the root element (CSS format: "10px 20px 30px 40px")
+    threshold: [0, 0.5, 1], // Intersection ratio thresholds that trigger the callback
   }
 );
 
-// 要素の監視開始
+// Start observing an element
 const targetElement = document.getElementById('target');
 observer.observe(targetElement);
 
-// 特定の要素の監視停止
+// Stop observing a specific element
 observer.unobserve(targetElement);
 
-// 全ての監視を停止
+// Stop all observation
 observer.disconnect();
 
-// 現在監視中のエントリを取得（非同期的に保留中のものも含む）
+// Get currently pending entries (including asynchronously buffered ones)
 const pendingEntries = observer.takeRecords();
 ```
 
-### 1.2 thresholdの詳細
+### 1.2 threshold in Detail
 
 ```javascript
-// threshold: 単一値
+// threshold: single value
 const observer1 = new IntersectionObserver(callback, {
-  threshold: 0,    // 1pxでも交差したらコールバック
+  threshold: 0,    // Callback fires when even 1px is intersecting
 });
 
 const observer2 = new IntersectionObserver(callback, {
-  threshold: 1.0,  // 要素が完全に見えたらコールバック
+  threshold: 1.0,  // Callback fires when the element is fully visible
 });
 
-// threshold: 配列（複数のしきい値）
+// threshold: array (multiple thresholds)
 const observer3 = new IntersectionObserver(callback, {
   threshold: [0, 0.25, 0.5, 0.75, 1.0],
-  // 0%, 25%, 50%, 75%, 100% の交差率でそれぞれコールバック
+  // Callback fires at 0%, 25%, 50%, 75%, and 100% intersection ratios
 });
 
-// 細かい段階の監視（スクロール連動アニメーション用）
+// Fine-grained thresholds (for scroll-linked animations)
 const thresholds = Array.from({ length: 100 }, (_, i) => i / 100);
 // [0, 0.01, 0.02, ..., 0.99]
 const smoothObserver = new IntersectionObserver((entries) => {
   entries.forEach(entry => {
-    // intersectionRatioをCSSカスタムプロパティに反映
+    // Reflect intersectionRatio to a CSS custom property
     entry.target.style.setProperty(
       '--visibility',
       String(entry.intersectionRatio)
@@ -100,7 +100,7 @@ const smoothObserver = new IntersectionObserver((entries) => {
   });
 }, { threshold: thresholds });
 
-// CSSで利用
+// Usage in CSS
 // .fade-in {
 //   opacity: var(--visibility, 0);
 //   transform: translateY(calc((1 - var(--visibility)) * 20px));
@@ -108,75 +108,75 @@ const smoothObserver = new IntersectionObserver((entries) => {
 // }
 ```
 
-### 1.3 rootMarginの活用
+### 1.3 Using rootMargin
 
 ```javascript
-// rootMargin で監視領域を拡張・縮小する
-// ビューポートの200px手前で検知（プリロードに最適）
+// Expand or shrink the observation area with rootMargin
+// Detect 200px before the viewport (ideal for preloading)
 const preloadObserver = new IntersectionObserver(callback, {
-  rootMargin: '200px 0px', // 上下200px、左右0px
+  rootMargin: '200px 0px', // 200px top/bottom, 0px left/right
 });
 
-// ビューポートの50%内側に入ったら検知
+// Detect when element enters the inner 50% of the viewport
 const innerObserver = new IntersectionObserver(callback, {
-  rootMargin: '-50% 0px', // 上下を50%縮小
+  rootMargin: '-50% 0px', // Shrink top/bottom by 50%
 });
 
-// 非対称なマージン（上方向に多く取る）
+// Asymmetric margin (larger margin on the top)
 const asymmetricObserver = new IntersectionObserver(callback, {
-  rootMargin: '300px 0px 0px 0px', // 上300px、右0px、下0px、左0px
+  rootMargin: '300px 0px 0px 0px', // top 300px, right 0px, bottom 0px, left 0px
 });
 
-// ★ rootMargin の値はCSSのmargin shorthand と同じ形式
-// "10px"          → 全方向 10px
-// "10px 20px"     → 上下10px、左右20px
-// "10px 20px 30px"    → 上10px、左右20px、下30px
-// "10px 20px 30px 40px" → 上10px、右20px、下30px、左40px
+// ★ rootMargin values use the same format as CSS margin shorthand
+// "10px"          → all sides 10px
+// "10px 20px"     → top/bottom 10px, left/right 20px
+// "10px 20px 30px"    → top 10px, left/right 20px, bottom 30px
+// "10px 20px 30px 40px" → top 10px, right 20px, bottom 30px, left 40px
 
-// パーセンテージも使用可能（ルート要素に対する割合）
+// Percentages are also supported (relative to the root element)
 const percentObserver = new IntersectionObserver(callback, {
-  rootMargin: '-25%', // ルート要素を25%縮小して監視
+  rootMargin: '-25%', // Shrink the root element by 25% for observation
 });
 ```
 
-### 1.4 カスタムルート要素
+### 1.4 Custom Root Element
 
 ```javascript
-// スクロールコンテナをルートに指定
+// Specify a scroll container as the root
 const scrollContainer = document.getElementById('scroll-container');
 
 const containerObserver = new IntersectionObserver(
   (entries) => {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
-        console.log('要素がスクロールコンテナ内に表示された');
+        console.log('Element is visible within the scroll container');
       }
     });
   },
   {
-    root: scrollContainer, // ビューポートの代わりにこのコンテナを基準にする
+    root: scrollContainer, // Use this container as the reference instead of the viewport
     rootMargin: '50px',
     threshold: 0,
   }
 );
 
-// スクロールコンテナ内の全アイテムを監視
+// Observe all items within the scroll container
 scrollContainer.querySelectorAll('.list-item').forEach(item => {
   containerObserver.observe(item);
 });
 
-// ★ 注意: rootはターゲット要素の祖先である必要がある
-// ★ root: null はビューポート（暗黙のルート）を意味する
+// ★ Note: root must be an ancestor of the target element
+// ★ root: null means the viewport (implicit root)
 ```
 
 ---
 
-## 2. IntersectionObserver の実務パターン
+## 2. Practical Patterns for IntersectionObserver
 
-### 2.1 画像の遅延読み込み（Lazy Loading）
+### 2.1 Lazy Loading Images
 
 ```javascript
-// バニラJSでの画像遅延読み込み
+// Lazy loading images with vanilla JS
 class LazyImageLoader {
   constructor(options = {}) {
     this.observer = new IntersectionObserver(
@@ -199,7 +199,7 @@ class LazyImageLoader {
       } else if (element.tagName === 'VIDEO') {
         this.loadVideo(element);
       } else {
-        // 背景画像の遅延読み込み
+        // Lazy loading background images
         this.loadBackground(element);
       }
 
@@ -208,15 +208,15 @@ class LazyImageLoader {
   }
 
   loadImage(img) {
-    // srcsetの処理
+    // Handle srcset
     if (img.dataset.srcset) {
       img.srcset = img.dataset.srcset;
     }
-    // sizesの処理
+    // Handle sizes
     if (img.dataset.sizes) {
       img.sizes = img.dataset.sizes;
     }
-    // src の処理
+    // Handle src
     if (img.dataset.src) {
       img.src = img.dataset.src;
     }
@@ -228,7 +228,7 @@ class LazyImageLoader {
   }
 
   loadVideo(video) {
-    // source要素のdata-srcを処理
+    // Process data-src on source elements
     video.querySelectorAll('source').forEach(source => {
       if (source.dataset.src) {
         source.src = source.dataset.src;
@@ -258,11 +258,11 @@ class LazyImageLoader {
   }
 }
 
-// 使用例
+// Usage
 const lazyLoader = new LazyImageLoader({ rootMargin: '300px 0px' });
 lazyLoader.observeAll('[data-src], [data-bg]');
 
-// HTML側
+// HTML side
 // <img data-src="large-image.jpg"
 //      data-srcset="small.jpg 480w, medium.jpg 800w, large.jpg 1200w"
 //      data-sizes="(max-width: 600px) 480px, (max-width: 1024px) 800px, 1200px"
@@ -270,15 +270,15 @@ lazyLoader.observeAll('[data-src], [data-bg]');
 //      alt="Description"
 //      class="lazy" />
 
-// ★ 現在は loading="lazy" 属性が推奨（ブラウザネイティブ）
+// ★ The loading="lazy" attribute is now recommended (browser-native)
 // <img src="image.jpg" loading="lazy" alt="Description" />
-// ただし、細かい制御が必要な場合はIntersectionObserverを使用する
+// However, use IntersectionObserver when fine-grained control is needed
 ```
 
-### 2.2 無限スクロール
+### 2.2 Infinite Scroll
 
 ```javascript
-// 高機能な無限スクロール実装
+// Feature-rich infinite scroll implementation
 class InfiniteScroll {
   constructor(options) {
     this.container = options.container;
@@ -287,7 +287,7 @@ class InfiniteScroll {
     this.loading = false;
     this.hasMore = true;
 
-    // 番兵要素の作成
+    // Create a sentinel element
     this.sentinel = document.createElement('div');
     this.sentinel.className = 'infinite-scroll-sentinel';
     this.sentinel.setAttribute('aria-hidden', 'true');
@@ -339,7 +339,7 @@ class InfiniteScroll {
       fragment.appendChild(element);
     });
 
-    // 番兵要素の前に挿入
+    // Insert before the sentinel element
     this.container.insertBefore(fragment, this.sentinel);
   }
 
@@ -381,7 +381,7 @@ class InfiniteScroll {
   }
 }
 
-// 使用例
+// Usage
 let page = 0;
 const infiniteScroll = new InfiniteScroll({
   container: document.getElementById('items-container'),
@@ -397,10 +397,10 @@ const infiniteScroll = new InfiniteScroll({
 });
 ```
 
-### 2.3 スクロール連動アニメーション
+### 2.3 Scroll-Linked Animation
 
 ```javascript
-// フェードインアニメーション
+// Fade-in animation
 class ScrollAnimator {
   constructor(options = {}) {
     this.animations = new Map();
@@ -458,7 +458,7 @@ class ScrollAnimator {
 
   register(element, animationType = 'fade-in') {
     this.animations.set(element, animationType);
-    // 初期状態を設定
+    // Set initial state
     element.style.opacity = '0';
     element.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
     this.observer.observe(element);
@@ -476,7 +476,7 @@ class ScrollAnimator {
   }
 }
 
-// 使用例
+// Usage
 const animator = new ScrollAnimator();
 animator.registerAll('.section-title', 'fade-in');
 animator.registerAll('.card-left', 'slide-left');
@@ -493,14 +493,14 @@ animator.registerAll('.feature-icon', 'scale-up');
 // }
 ```
 
-### 2.4 ビューアビリティ計測と分析
+### 2.4 Viewability Measurement and Analytics
 
 ```javascript
-// 広告やコンテンツのビューアビリティ計測
+// Viewability tracking for ads and content
 class ViewabilityTracker {
   constructor(options = {}) {
     this.minVisibleRatio = options.minVisibleRatio || 0.5;
-    this.minVisibleTime = options.minVisibleTime || 1000; // 1秒
+    this.minVisibleTime = options.minVisibleTime || 1000; // 1 second
     this.timers = new Map();
     this.tracked = new Set();
     this.onViewable = options.onViewable || (() => {});
@@ -521,7 +521,7 @@ class ViewabilityTracker {
       if (this.tracked.has(id)) return;
 
       if (entry.intersectionRatio >= this.minVisibleRatio) {
-        // 表示開始: タイマーを設定
+        // Became visible: set a timer
         if (!this.timers.has(id)) {
           const timer = setTimeout(() => {
             this.tracked.add(id);
@@ -538,7 +538,7 @@ class ViewabilityTracker {
           this.timers.set(id, timer);
         }
       } else {
-        // 非表示: タイマーをクリア
+        // Became hidden: clear the timer
         const timer = this.timers.get(id);
         if (timer) {
           clearTimeout(timer);
@@ -562,13 +562,13 @@ class ViewabilityTracker {
   }
 }
 
-// 使用例
+// Usage
 const tracker = new ViewabilityTracker({
   minVisibleRatio: 0.5,
-  minVisibleTime: 2000, // 2秒以上50%以上表示でビューアブル
+  minVisibleTime: 2000, // Viewable when 50%+ visible for 2+ seconds
   onViewable({ id, element }) {
     console.log(`Element ${id} is viewable`);
-    // アナリティクスに送信
+    // Send to analytics
     fetch('/api/analytics/viewability', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -585,10 +585,10 @@ const tracker = new ViewabilityTracker({
 document.querySelectorAll('[data-track]').forEach(el => tracker.track(el));
 ```
 
-### 2.5 セクションナビゲーション（アクティブセクション検出）
+### 2.5 Section Navigation (Active Section Detection)
 
 ```javascript
-// スクロール位置に応じたナビゲーションのアクティブ状態更新
+// Update navigation active state based on scroll position
 class SectionNavigator {
   constructor(options = {}) {
     this.sections = new Map();
@@ -598,7 +598,7 @@ class SectionNavigator {
     this.observer = new IntersectionObserver(
       this.handleIntersection.bind(this),
       {
-        rootMargin: '-20% 0px -70% 0px', // ビューポート上部20-30%で検知
+        rootMargin: '-20% 0px -70% 0px', // Detect in the top 20-30% of the viewport
         threshold: 0,
       }
     );
@@ -619,7 +619,7 @@ class SectionNavigator {
   }
 
   updateNavigation(activeSectionId) {
-    // ナビゲーションリンクのアクティブ状態を更新
+    // Update the active state of navigation links
     document.querySelectorAll('.nav-link').forEach(link => {
       const isActive = link.getAttribute('href') === `#${activeSectionId}`;
       link.classList.toggle('active', isActive);
@@ -646,10 +646,10 @@ class SectionNavigator {
   }
 }
 
-// 使用例
+// Usage
 const sectionNav = new SectionNavigator({
   onSectionChange(sectionId) {
-    // URLハッシュの更新（pushStateで履歴に追加しない）
+    // Update the URL hash (without adding to history with pushState)
     history.replaceState(null, '', `#${sectionId}`);
   },
 });
@@ -660,33 +660,33 @@ sectionNav.registerAll('section[id]');
 
 ## 3. ResizeObserver
 
-### 3.1 基本概念とAPI
+### 3.1 Core Concepts and API
 
-ResizeObserverは要素のサイズ変更を効率的に監視するAPIである。ウィンドウのリサイズだけでなく、CSSアニメーション、DOM操作、フレックスボックス/グリッドのレイアウト変更など、あらゆる原因によるサイズ変更を検出できる。
+ResizeObserver is an API for efficiently monitoring size changes of elements. It can detect size changes caused by any source — not just window resizing, but also CSS animations, DOM manipulation, flexbox/grid layout changes, and more.
 
 ```javascript
-// ResizeObserverの基本構造
+// Basic structure of ResizeObserver
 const observer = new ResizeObserver((entries) => {
   for (const entry of entries) {
-    // contentRect: コンテンツ領域のサイズ（paddingを除く）
+    // contentRect: size of the content area (excluding padding)
     const { width, height, top, left } = entry.contentRect;
     console.log(`Content size: ${width}x${height}`);
     console.log(`Content position: (${left}, ${top})`);
 
-    // contentBoxSize: コンテンツボックスのサイズ（新しいAPI）
+    // contentBoxSize: size of the content box (newer API)
     if (entry.contentBoxSize) {
-      // 配列で返される（将来のフラグメンテーション対応）
+      // Returned as an array (for future fragmentation support)
       const contentBox = entry.contentBoxSize[0];
       console.log(`Content box: ${contentBox.inlineSize}x${contentBox.blockSize}`);
     }
 
-    // borderBoxSize: ボーダーボックスのサイズ（padding + border含む）
+    // borderBoxSize: size of the border box (includes padding + border)
     if (entry.borderBoxSize) {
       const borderBox = entry.borderBoxSize[0];
       console.log(`Border box: ${borderBox.inlineSize}x${borderBox.blockSize}`);
     }
 
-    // devicePixelContentBoxSize: デバイスピクセル単位
+    // devicePixelContentBoxSize: size in device pixels
     if (entry.devicePixelContentBoxSize) {
       const devicePixelBox = entry.devicePixelContentBoxSize[0];
       console.log(`Device pixel: ${devicePixelBox.inlineSize}x${devicePixelBox.blockSize}`);
@@ -696,38 +696,38 @@ const observer = new ResizeObserver((entries) => {
   }
 });
 
-// 要素の監視
+// Observe an element
 observer.observe(element);
 
-// 特定のboxモデルで監視
-observer.observe(element, { box: 'border-box' });   // ボーダーボックス
-observer.observe(element, { box: 'content-box' });   // コンテンツボックス（デフォルト）
-observer.observe(element, { box: 'device-pixel-content-box' }); // デバイスピクセル
+// Observe with a specific box model
+observer.observe(element, { box: 'border-box' });   // border box
+observer.observe(element, { box: 'content-box' });   // content box (default)
+observer.observe(element, { box: 'device-pixel-content-box' }); // device pixels
 
-// 監視停止
+// Stop observing
 observer.unobserve(element);
 observer.disconnect();
 ```
 
-### 3.2 inlineSize / blockSize について
+### 3.2 About inlineSize / blockSize
 
 ```javascript
-// ★ inlineSizeとblockSizeは論理的なサイズ
-// 横書き（writing-mode: horizontal-tb）の場合:
-//   inlineSize = width（横方向）
-//   blockSize = height（縦方向）
+// ★ inlineSize and blockSize are logical sizes
+// For horizontal writing (writing-mode: horizontal-tb):
+//   inlineSize = width (horizontal direction)
+//   blockSize = height (vertical direction)
 //
-// 縦書き（writing-mode: vertical-rl）の場合:
-//   inlineSize = height（縦方向）
-//   blockSize = width（横方向）
+// For vertical writing (writing-mode: vertical-rl):
+//   inlineSize = height (vertical direction)
+//   blockSize = width (horizontal direction)
 
-// 多言語対応のレイアウト処理
+// Layout processing for multilingual support
 const observer = new ResizeObserver((entries) => {
   for (const entry of entries) {
     const { inlineSize, blockSize } = entry.contentBoxSize[0];
 
-    // 論理的なサイズに基づいてレイアウトを調整
-    // writing-modeに関係なく正しく動作する
+    // Adjust layout based on logical size
+    // Works correctly regardless of writing-mode
     if (inlineSize < 400) {
       entry.target.classList.add('compact-layout');
     } else {
@@ -737,10 +737,10 @@ const observer = new ResizeObserver((entries) => {
 });
 ```
 
-### 3.3 コンテナクエリの代替
+### 3.3 Container Query Alternative
 
 ```javascript
-// ResizeObserverによるコンテナクエリの実装
+// Implementing container queries with ResizeObserver
 class ContainerQuery {
   constructor() {
     this.queries = new Map();
@@ -776,7 +776,7 @@ class ContainerQuery {
   }
 }
 
-// 使用例
+// Usage
 const cq = new ContainerQuery();
 cq.register(document.querySelector('.card-container'), [
   { className: 'cq-small', condition: { maxWidth: 400 } },
@@ -784,17 +784,17 @@ cq.register(document.querySelector('.card-container'), [
   { className: 'cq-large', condition: { minWidth: 801 } },
 ]);
 
-// ★ 現在はCSSネイティブのコンテナクエリが推奨
+// ★ Native CSS container queries are now recommended
 // @container (min-width: 400px) {
 //   .card { grid-template-columns: 1fr 1fr; }
 // }
-// ただし、JavaScript連携が必要な場合はResizeObserverを使用する
+// However, use ResizeObserver when JavaScript integration is needed
 ```
 
-### 3.4 チャートの自動リサイズ
+### 3.4 Auto-Resizing Charts
 
 ```javascript
-// D3.js / Chart.js / ECharts などのチャートライブラリ連携
+// Integration with chart libraries such as D3.js / Chart.js / ECharts
 class ResponsiveChart {
   constructor(container, chartLib) {
     this.container = container;
@@ -803,7 +803,7 @@ class ResponsiveChart {
     this.resizeTimeout = null;
 
     this.observer = new ResizeObserver((entries) => {
-      // デバウンス処理（頻繁なリサイズを抑制）
+      // Debounce to suppress frequent resizes
       if (this.resizeTimeout) {
         cancelAnimationFrame(this.resizeTimeout);
       }
@@ -824,13 +824,13 @@ class ResponsiveChart {
 
   resize(width, height) {
     if (this.chart) {
-      // Chart.js の場合
+      // For Chart.js
       this.chart.resize(width, height);
 
-      // ECharts の場合
+      // For ECharts
       // this.chart.resize({ width, height });
 
-      // D3.js の場合
+      // For D3.js
       // d3.select(this.container).select('svg')
       //   .attr('width', width)
       //   .attr('height', height);
@@ -845,7 +845,7 @@ class ResponsiveChart {
   }
 }
 
-// Canvas要素のデバイスピクセル比対応
+// Pixel-perfect Canvas resizing with device pixel ratio support
 class ResponsiveCanvas {
   constructor(container) {
     this.container = container;
@@ -855,7 +855,7 @@ class ResponsiveCanvas {
 
     this.observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        // devicePixelContentBoxSizeでピクセルパーフェクトなリサイズ
+        // Use devicePixelContentBoxSize for pixel-perfect resizing
         if (entry.devicePixelContentBoxSize) {
           const { inlineSize, blockSize } = entry.devicePixelContentBoxSize[0];
           this.canvas.width = inlineSize;
@@ -877,7 +877,7 @@ class ResponsiveCanvas {
   render() {
     const { width, height } = this.canvas;
     this.ctx.clearRect(0, 0, width, height);
-    // 描画処理...
+    // Drawing logic...
   }
 
   destroy() {
@@ -887,10 +887,10 @@ class ResponsiveCanvas {
 }
 ```
 
-### 3.5 テキストの自動縮小（FitText）
+### 3.5 Auto-Shrink Text (FitText)
 
 ```javascript
-// テキストを要素幅に合わせて自動縮小
+// Automatically shrink text to fit the element width
 class AutoFitText {
   constructor(options = {}) {
     this.minFontSize = options.minFontSize || 10;
@@ -912,7 +912,7 @@ class AutoFitText {
     let fontSize = config.maxFontSize || this.maxFontSize;
     const minSize = config.minFontSize || this.minFontSize;
 
-    // バイナリサーチで最適なフォントサイズを見つける
+    // Find the optimal font size with binary search
     let low = minSize;
     let high = fontSize;
 
@@ -950,17 +950,17 @@ class AutoFitText {
   }
 }
 
-// 使用例
+// Usage
 const autoFit = new AutoFitText({ minFontSize: 12, maxFontSize: 48 });
 autoFit.observe(document.querySelector('.headline'), {
   maxFontSize: 64,
 });
 ```
 
-### 3.6 仮想スクロールとの連携
+### 3.6 Integration with Virtual Scroll
 
 ```javascript
-// ResizeObserverを使った動的高さの仮想スクロール
+// Virtual scroll with dynamic item heights using ResizeObserver
 class VirtualList {
   constructor(container, options) {
     this.container = container;
@@ -970,7 +970,7 @@ class VirtualList {
     this.defaultHeight = options.estimatedItemHeight || 50;
     this.overscan = options.overscan || 5;
 
-    // スクロールコンテナの設定
+    // Set up the scroll container
     this.viewport = document.createElement('div');
     this.viewport.style.cssText = 'overflow-y: auto; height: 100%;';
     this.spacer = document.createElement('div');
@@ -979,7 +979,7 @@ class VirtualList {
     this.viewport.appendChild(this.content);
     container.appendChild(this.viewport);
 
-    // アイテムの高さを計測
+    // Measure item heights
     this.heightObserver = new ResizeObserver((entries) => {
       let heightChanged = false;
 
@@ -999,7 +999,7 @@ class VirtualList {
       }
     });
 
-    // ビューポートのリサイズ監視
+    // Monitor viewport resize
     this.viewportObserver = new ResizeObserver(() => {
       this.render();
     });
@@ -1037,7 +1037,7 @@ class VirtualList {
     const scrollTop = this.viewport.scrollTop;
     const viewportHeight = this.viewport.clientHeight;
 
-    // 表示範囲のアイテムを計算
+    // Calculate which items are in the visible range
     let startIndex = 0;
     let accumulatedHeight = 0;
 
@@ -1059,7 +1059,7 @@ class VirtualList {
 
     endIndex = Math.min(this.items.length - 1, endIndex + this.overscan);
 
-    // DOMの更新
+    // Update the DOM
     this.content.innerHTML = '';
     const fragment = document.createDocumentFragment();
 
@@ -1090,30 +1090,30 @@ class VirtualList {
 
 ## 4. MutationObserver
 
-### 4.1 基本概念とAPI
+### 4.1 Core Concepts and API
 
-MutationObserverはDOMツリーの変更を監視するAPIである。属性の変更、子ノードの追加・削除、テキストコンテンツの変更などを検出できる。
+MutationObserver is an API for monitoring changes to the DOM tree. It can detect attribute changes, additions and removals of child nodes, and text content changes.
 
 ```javascript
-// MutationObserverの基本構造
+// Basic structure of MutationObserver
 const observer = new MutationObserver((mutations, observer) => {
   for (const mutation of mutations) {
     switch (mutation.type) {
       case 'childList':
-        // 子ノードの追加・削除
+        // Child node additions and removals
         console.log('Added nodes:', mutation.addedNodes);
         console.log('Removed nodes:', mutation.removedNodes);
         break;
 
       case 'attributes':
-        // 属性の変更
+        // Attribute changes
         console.log('Attribute changed:', mutation.attributeName);
         console.log('Old value:', mutation.oldValue);
         console.log('New value:', mutation.target.getAttribute(mutation.attributeName));
         break;
 
       case 'characterData':
-        // テキストノードの変更
+        // Text node changes
         console.log('Text changed:', mutation.target.textContent);
         console.log('Old value:', mutation.oldValue);
         break;
@@ -1121,27 +1121,27 @@ const observer = new MutationObserver((mutations, observer) => {
   }
 });
 
-// 監視オプション
+// Observation options
 observer.observe(targetNode, {
-  childList: true,         // 子ノードの追加・削除を監視
-  attributes: true,        // 属性の変更を監視
-  characterData: true,     // テキストノードの変更を監視
-  subtree: true,           // 子孫ノードも含めて監視
-  attributeOldValue: true, // 変更前の属性値を記録
-  characterDataOldValue: true, // 変更前のテキストを記録
-  attributeFilter: ['class', 'style', 'data-state'], // 監視する属性を限定
+  childList: true,         // Monitor child node additions and removals
+  attributes: true,        // Monitor attribute changes
+  characterData: true,     // Monitor text node changes
+  subtree: true,           // Also monitor descendant nodes
+  attributeOldValue: true, // Record the previous attribute value before changes
+  characterDataOldValue: true, // Record the previous text content before changes
+  attributeFilter: ['class', 'style', 'data-state'], // Limit which attributes to watch
 });
 
-// 保留中の変更を取得して監視を停止
+// Get pending changes and stop observing
 const pendingMutations = observer.takeRecords();
 observer.disconnect();
 ```
 
-### 4.2 DOM変更の監視パターン
+### 4.2 DOM Change Monitoring Patterns
 
 ```javascript
-// パターン1: サードパーティスクリプトのDOM監視
-// 外部スクリプトが意図しないDOM変更を行わないか監視
+// Pattern 1: Monitoring DOM changes from third-party scripts
+// Monitor for unintended DOM changes made by external scripts
 class DOMGuard {
   constructor(protectedElement) {
     this.element = protectedElement;
@@ -1149,17 +1149,17 @@ class DOMGuard {
 
     this.observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
-        // 不正なスクリプトタグの挿入を検出
+        // Detect injection of suspicious script tags
         for (const node of mutation.addedNodes) {
           if (node.nodeType === Node.ELEMENT_NODE) {
             if (node.tagName === 'SCRIPT' || node.tagName === 'IFRAME') {
               console.warn('Suspicious element injected:', node);
-              node.remove(); // 不正な要素を削除
+              node.remove(); // Remove the unauthorized element
             }
           }
         }
 
-        // 重要な属性の変更を検出
+        // Detect changes to important attributes
         if (mutation.type === 'attributes') {
           if (mutation.attributeName === 'style' || mutation.attributeName === 'class') {
             console.warn(
@@ -1184,8 +1184,8 @@ class DOMGuard {
   }
 }
 
-// パターン2: 動的コンテンツの自動初期化
-// SPAやサードパーティウィジェットで動的に追加される要素を自動検出
+// Pattern 2: Auto-initialization of dynamic content
+// Auto-detect elements dynamically added by SPAs or third-party widgets
 class AutoInitializer {
   constructor(config) {
     this.config = config; // { selector: string, init: (element) => void }[]
@@ -1195,7 +1195,7 @@ class AutoInitializer {
         for (const node of mutation.addedNodes) {
           if (node.nodeType === Node.ELEMENT_NODE) {
             this.initElement(node);
-            // 追加されたノードの子要素もチェック
+            // Also check child elements of the added node
             node.querySelectorAll?.('*').forEach(child => {
               this.initElement(child);
             });
@@ -1209,7 +1209,7 @@ class AutoInitializer {
       subtree: true,
     });
 
-    // 既存の要素も初期化
+    // Also initialize existing elements
     this.config.forEach(({ selector, init }) => {
       document.querySelectorAll(selector).forEach(init);
     });
@@ -1229,7 +1229,7 @@ class AutoInitializer {
   }
 }
 
-// 使用例
+// Usage
 const autoInit = new AutoInitializer([
   {
     selector: '[data-tooltip]',
@@ -1245,14 +1245,14 @@ const autoInit = new AutoInitializer([
   },
 ]);
 
-// パターン3: フォームの変更検出
+// Pattern 3: Form change detection
 class FormChangeDetector {
   constructor(form) {
     this.form = form;
     this.isDirty = false;
     this.initialValues = this.captureValues();
 
-    // 属性の変更を監視（value属性はプロパティなので直接監視できない）
+    // Monitor attribute changes (value attribute is a property and cannot be observed directly)
     this.observer = new MutationObserver((mutations) => {
       this.checkDirty();
     });
@@ -1263,7 +1263,7 @@ class FormChangeDetector {
       attributeFilter: ['value', 'checked', 'selected'],
     });
 
-    // inputイベントも監視（valueプロパティの変更はMutationObserverでは検出できない）
+    // Also listen to input events (value property changes cannot be detected by MutationObserver)
     form.addEventListener('input', () => this.checkDirty());
     form.addEventListener('change', () => this.checkDirty());
   }
@@ -1296,47 +1296,48 @@ class FormChangeDetector {
 }
 ```
 
-### 4.3 MutationObserverの注意点
+### 4.3 Caveats for MutationObserver
 
 ```javascript
-// ★ 注意1: コールバックは同期的なDOM変更がすべて完了してから呼ばれる
-// （マイクロタスクとして実行される）
+// ★ Note 1: The callback is called after all synchronous DOM changes have completed
+// (executed as a microtask)
 element.setAttribute('class', 'foo');
 element.setAttribute('class', 'bar');
 element.setAttribute('class', 'baz');
-// → コールバックは1回だけ呼ばれ、3つのmutationが含まれる
+// → The callback is called only once, containing all 3 mutations
 
-// ★ 注意2: 無限ループに注意
-// コールバック内でDOMを変更すると再度コールバックが呼ばれる
+// ★ Note 2: Watch out for infinite loops
+// Modifying the DOM inside the callback will trigger the callback again
 const observer = new MutationObserver((mutations) => {
-  // 危険: 無限ループになる可能性がある
+  // Dangerous: can cause an infinite loop
   // mutations[0].target.textContent = 'updated';
 
-  // 安全: 一時的に監視を停止
+  // Safe: temporarily disconnect before making changes
   observer.disconnect();
   mutations[0].target.textContent = 'updated';
   observer.observe(targetNode, options);
 });
 
-// ★ 注意3: パフォーマンスへの影響
-// subtree: true で広範囲を監視すると負荷が高い
-// 必要最小限の範囲とフィルターで監視する
+// ★ Note 3: Performance impact
+// Monitoring a large area with subtree: true can be costly
+// Use the minimum necessary scope and attribute filters
 
-// ★ 注意4: CSSプロパティの変更はMutationObserverでは検出できない
-// style属性の変更は検出できるが、CSSクラスの結果としてのスタイル変更は検出不可
-// → ResizeObserverやgetComputedStyleを使用する
+// ★ Note 4: CSS property changes cannot be detected by MutationObserver
+// Changes to the style attribute can be detected, but style changes
+// caused by CSS class application cannot
+// → Use ResizeObserver or getComputedStyle instead
 ```
 
 ---
 
 ## 5. PerformanceObserver
 
-### 5.1 基本概念とAPI
+### 5.1 Core Concepts and API
 
-PerformanceObserverはブラウザのパフォーマンスエントリを非同期的に監視するAPIである。Performance Timelineの一部であり、さまざまなパフォーマンスメトリクスをリアルタイムで収集できる。
+PerformanceObserver is an API that asynchronously monitors browser performance entries. It is part of the Performance Timeline and allows real-time collection of various performance metrics.
 
 ```javascript
-// PerformanceObserverの基本構造
+// Basic structure of PerformanceObserver
 const observer = new PerformanceObserver((list, observer) => {
   const entries = list.getEntries();
   for (const entry of entries) {
@@ -1344,23 +1345,23 @@ const observer = new PerformanceObserver((list, observer) => {
   }
 });
 
-// 監視するエントリタイプを指定
+// Specify entry types to observe
 observer.observe({
-  type: 'resource',     // 単一タイプ
-  buffered: true,       // 過去のエントリも含める
+  type: 'resource',     // Single type
+  buffered: true,       // Include past entries
 });
 
-// 複数タイプを同時に監視
+// Observe multiple types simultaneously
 observer.observe({
   entryTypes: ['navigation', 'resource', 'paint'],
-  // ★ entryTypes と type は同時に使えない
-  // ★ entryTypes では buffered オプションは使えない
+  // ★ entryTypes and type cannot be used together
+  // ★ The buffered option is not available with entryTypes
 });
 
-// 監視停止
+// Stop observing
 observer.disconnect();
 
-// サポートされているエントリタイプの確認
+// Check supported entry types
 const supportedTypes = PerformanceObserver.supportedEntryTypes;
 console.log(supportedTypes);
 // ['element', 'event', 'first-input', 'largest-contentful-paint',
@@ -1368,10 +1369,10 @@ console.log(supportedTypes);
 //  'paint', 'resource', 'visibility-state']
 ```
 
-### 5.2 Core Web Vitals の計測
+### 5.2 Measuring Core Web Vitals
 
 ```javascript
-// LCP（Largest Contentful Paint）: 最大のコンテンツが描画される時間
+// LCP (Largest Contentful Paint): time for the largest content to be painted
 function observeLCP(callback) {
   let lcpValue = 0;
 
@@ -1383,19 +1384,19 @@ function observeLCP(callback) {
 
   observer.observe({ type: 'largest-contentful-paint', buffered: true });
 
-  // ユーザーインタラクション時にLCPを確定
-  // （LCPはユーザーインタラクションまで更新され続ける）
+  // Finalize LCP on user interaction
+  // (LCP continues to be updated until user interaction)
   const reportLCP = () => {
     observer.disconnect();
     callback(lcpValue);
   };
 
-  // 各種イベントで確定
+  // Finalize on various events
   ['keydown', 'click', 'scroll'].forEach(type => {
     addEventListener(type, reportLCP, { once: true });
   });
 
-  // ページ遷移時にも報告
+  // Also report on page navigation
   addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
       reportLCP();
@@ -1403,13 +1404,13 @@ function observeLCP(callback) {
   }, { once: true });
 }
 
-// FID（First Input Delay）: 最初のインタラクションの遅延
+// FID (First Input Delay): delay of the first interaction
 function observeFID(callback) {
   const observer = new PerformanceObserver((list) => {
     const entries = list.getEntries();
     const firstInput = entries[0];
 
-    // processingStart - startTime が入力遅延
+    // processingStart - startTime is the input delay
     const delay = firstInput.processingStart - firstInput.startTime;
     callback(delay);
     observer.disconnect();
@@ -1418,14 +1419,14 @@ function observeFID(callback) {
   observer.observe({ type: 'first-input', buffered: true });
 }
 
-// INP（Interaction to Next Paint）: インタラクションからの応答性
+// INP (Interaction to Next Paint): responsiveness from interaction
 function observeINP(callback) {
   const interactions = new Map();
   let longestDuration = 0;
 
   const observer = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
-      // 同じインタラクションのイベントをグループ化
+      // Group events belonging to the same interaction
       const interactionId = entry.interactionId;
       if (!interactionId) continue;
 
@@ -1441,10 +1442,10 @@ function observeINP(callback) {
 
   observer.observe({ type: 'event', buffered: true, durationThreshold: 16 });
 
-  // ページ非表示時に報告
+  // Report when the page is hidden
   addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
-      // 98パーセンタイルを計算
+      // Calculate the 98th percentile
       const sortedDurations = [...interactions.values()].sort((a, b) => a - b);
       const p98Index = Math.floor(sortedDurations.length * 0.98) - 1;
       const inp = sortedDurations[Math.max(p98Index, 0)] || 0;
@@ -1454,7 +1455,7 @@ function observeINP(callback) {
   }, { once: true });
 }
 
-// CLS（Cumulative Layout Shift）: 累積レイアウトシフト
+// CLS (Cumulative Layout Shift): cumulative layout shift score
 function observeCLS(callback) {
   let clsValue = 0;
   let sessionValue = 0;
@@ -1463,15 +1464,15 @@ function observeCLS(callback) {
 
   const observer = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
-      // ユーザー入力に起因するシフトは除外
+      // Exclude shifts caused by user input
       if (entry.hadRecentInput) continue;
 
       const firstSessionEntry = sessionEntries[0];
       const lastSessionEntry = sessionEntries[sessionEntries.length - 1];
 
-      // セッションウィンドウの条件:
-      // 1. 前のエントリから1秒以内
-      // 2. セッション全体が5秒以内
+      // Session window conditions:
+      // 1. Within 1 second of the previous entry
+      // 2. Entire session is within 5 seconds
       if (
         sessionEntries.length > 0 &&
         entry.startTime - lastSessionEntry.startTime < 1000 &&
@@ -1480,7 +1481,7 @@ function observeCLS(callback) {
         sessionValue += entry.value;
         sessionEntries.push(entry);
       } else {
-        // 新しいセッションを開始
+        // Start a new session
         sessionValue = entry.value;
         sessionEntries = [entry];
       }
@@ -1505,7 +1506,7 @@ function observeCLS(callback) {
   }, { once: true });
 }
 
-// 統合的なWeb Vitals計測
+// Integrated Web Vitals collection
 class WebVitalsCollector {
   constructor(reportCallback) {
     this.report = reportCallback;
@@ -1557,11 +1558,11 @@ class WebVitalsCollector {
   }
 }
 
-// 使用例
+// Usage
 const vitals = new WebVitalsCollector((metric) => {
   console.log(`${metric.name}: ${metric.value} (${metric.rating})`);
 
-  // アナリティクスに送信
+  // Send to analytics
   fetch('/api/analytics/web-vitals', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1577,10 +1578,10 @@ const vitals = new WebVitalsCollector((metric) => {
 });
 ```
 
-### 5.3 Long Tasks の監視
+### 5.3 Monitoring Long Tasks
 
 ```javascript
-// 50ms以上のタスクを検出
+// Detect tasks longer than 50ms
 class LongTaskMonitor {
   constructor(options = {}) {
     this.threshold = options.threshold || 50;
@@ -1593,7 +1594,7 @@ class LongTaskMonitor {
           duration: entry.duration,
           startTime: entry.startTime,
           name: entry.name,
-          // attributionで原因を特定
+          // Use attribution to identify the cause
           attribution: entry.attribution?.map(attr => ({
             containerType: attr.containerType,
             containerName: attr.containerName,
@@ -1635,7 +1636,7 @@ class LongTaskMonitor {
   }
 }
 
-// 使用例
+// Usage
 const longTaskMonitor = new LongTaskMonitor({
   onLongTask(task) {
     if (task.duration > 100) {
@@ -1644,7 +1645,7 @@ const longTaskMonitor = new LongTaskMonitor({
   },
 });
 
-// ページ離脱時にレポートを送信
+// Send a report when the page is unloaded
 window.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'hidden') {
     const report = longTaskMonitor.getReport();
@@ -1653,10 +1654,10 @@ window.addEventListener('visibilitychange', () => {
 });
 ```
 
-### 5.4 リソース計測
+### 5.4 Resource Monitoring
 
 ```javascript
-// リソースの読み込みパフォーマンスを監視
+// Monitor resource loading performance
 class ResourceMonitor {
   constructor() {
     this.observer = new PerformanceObserver((list) => {
@@ -1668,7 +1669,7 @@ class ResourceMonitor {
           encodedBodySize: entry.encodedBodySize,
           decodedBodySize: entry.decodedBodySize,
 
-          // タイミングの内訳
+          // Timing breakdown
           dns: entry.domainLookupEnd - entry.domainLookupStart,
           tcp: entry.connectEnd - entry.connectStart,
           tls: entry.secureConnectionStart > 0
@@ -1677,16 +1678,16 @@ class ResourceMonitor {
           download: entry.responseEnd - entry.responseStart,
           total: entry.duration,
 
-          // キャッシュ判定
+          // Cache detection
           cached: entry.transferSize === 0 && entry.decodedBodySize > 0,
         };
 
-        // 遅いリソースの警告
+        // Warning for slow resources
         if (timing.total > 3000) {
           console.warn(`Slow resource: ${timing.name} (${timing.total.toFixed(0)}ms)`);
         }
 
-        // 大きなリソースの警告
+        // Warning for large resources
         if (timing.decodedBodySize > 1024 * 1024) {
           console.warn(`Large resource: ${timing.name} (${(timing.decodedBodySize / 1024 / 1024).toFixed(1)}MB)`);
         }
@@ -1704,7 +1705,7 @@ class ResourceMonitor {
 
 ---
 
-## 6. React でのObserverフック
+## 6. Observer Hooks in React
 
 ### 6.1 useIntersectionObserver
 
@@ -1734,7 +1735,7 @@ function useIntersectionObserver(
 
   const frozen = entry?.isIntersecting && freezeOnceVisible;
 
-  // ref callback パターン（DOM要素をステートとして管理）
+  // ref callback pattern (manage the DOM element as state)
   const ref = useCallback((node: Element | null) => {
     setNode(node);
   }, []);
@@ -1762,7 +1763,7 @@ function useIntersectionObserver(
   };
 }
 
-// 使用例: 画像の遅延読み込み
+// Usage: lazy loading images
 function LazyImage({ src, alt, ...props }) {
   const { ref, isIntersecting } = useIntersectionObserver({
     rootMargin: '200px',
@@ -1780,7 +1781,7 @@ function LazyImage({ src, alt, ...props }) {
   );
 }
 
-// 使用例: スクロール連動フェードイン
+// Usage: scroll-linked fade-in
 function FadeInSection({ children }) {
   const { ref, isIntersecting } = useIntersectionObserver({
     threshold: 0.1,
@@ -1797,7 +1798,7 @@ function FadeInSection({ children }) {
   );
 }
 
-// 使用例: 無限スクロール
+// Usage: infinite scroll
 function InfiniteList({ fetchItems }) {
   const [items, setItems] = useState([]);
   const [hasMore, setHasMore] = useState(true);
@@ -1886,7 +1887,7 @@ function useResizeObserver<T extends HTMLElement>(): {
   return { ref, size };
 }
 
-// 使用例: レスポンシブコンポーネント
+// Usage: responsive component
 function ResponsiveCard({ title, content }) {
   const { ref, size } = useResizeObserver<HTMLDivElement>();
 
@@ -1907,7 +1908,7 @@ function ResponsiveCard({ title, content }) {
   );
 }
 
-// 使用例: チャートのリサイズ
+// Usage: chart resizing
 function ResponsiveChartWrapper({ data }) {
   const { ref, size } = useResizeObserver<HTMLDivElement>();
 
@@ -1961,7 +1962,7 @@ function useMutationObserver<T extends HTMLElement>(
   return ref;
 }
 
-// 使用例: DOM変更のデバッグ
+// Usage: debugging DOM changes
 function DebugContainer({ children }) {
   const ref = useMutationObserver({
     callback: (mutations) => {
@@ -1982,67 +1983,67 @@ function DebugContainer({ children }) {
 
 ## 7. scroll vs IntersectionObserver
 
-### 7.1 パフォーマンス比較
+### 7.1 Performance Comparison
 
 ```
-従来のスクロール監視:
+Traditional scroll monitoring:
   window.addEventListener('scroll', () => {
     elements.forEach(el => {
-      const rect = el.getBoundingClientRect(); // ★ 強制レイアウト（Forced Reflow）
+      const rect = el.getBoundingClientRect(); // ★ Forces layout (Forced Reflow)
       if (rect.top < window.innerHeight) {
-        // 処理
+        // processing
       }
     });
   });
 
-  問題点:
-  → scroll イベントは高頻度で発火（1秒に60回以上）
-  → getBoundingClientRect() がレイアウトを強制（Layout Thrashing）
-  → throttle/debounce が必要だがタイミングが難しい
-  → 非アクティブタブでも発火し続ける
-  → 要素が多いほど処理が重くなる（O(n)）
+  Problems:
+  → The scroll event fires at high frequency (60+ times per second)
+  → getBoundingClientRect() forces layout recalculation (Layout Thrashing)
+  → throttle/debounce is required but difficult to time correctly
+  → Continues to fire even on inactive tabs
+  → Performance degrades as element count grows (O(n))
 
 IntersectionObserver:
   const observer = new IntersectionObserver(callback, options);
   elements.forEach(el => observer.observe(el));
 
-  利点:
-  ✓ ブラウザネイティブの最適化（メインスレッドをブロックしない）
-  ✓ Layout Thrashing が発生しない
-  ✓ throttle/debounce 不要（ブラウザが最適なタイミングで通知）
-  ✓ 非アクティブタブで自動的に停止
-  ✓ 要素数に依存しないパフォーマンス
-  ✓ rootMarginで先読みが簡単
+  Advantages:
+  ✓ Browser-native optimization (does not block the main thread)
+  ✓ No Layout Thrashing
+  ✓ No throttle/debounce needed (browser notifies at optimal timing)
+  ✓ Automatically pauses on inactive tabs
+  ✓ Performance does not degrade with element count
+  ✓ Easy prefetching with rootMargin
 
-  制限:
-  △ ピクセル単位のスクロール位置は取得できない
-  △ スクロール方向の判定には別の仕組みが必要
-  △ 連続的なアニメーション（パララックス）には不向き
+  Limitations:
+  △ Cannot retrieve pixel-level scroll position
+  △ Scroll direction detection requires a separate mechanism
+  △ Not suitable for continuous animations (parallax)
 ```
 
-### 7.2 使い分けガイドライン
+### 7.2 Usage Guidelines
 
 ```javascript
-// IntersectionObserver が適している場合:
-// - 要素の表示/非表示の検出
-// - 遅延読み込み（画像、コンポーネント）
-// - 無限スクロール
-// - ビューアビリティ計測
-// - スクロールスナップのセクション検出
+// When IntersectionObserver is appropriate:
+// - Detecting element visibility / invisibility
+// - Lazy loading (images, components)
+// - Infinite scroll
+// - Viewability measurement
+// - Section detection for scroll-snap
 
-// scroll イベント が適している場合:
-// - パララックスエフェクト（連続的なスクロール位置が必要）
-// - ヘッダーの縮小/展開（スクロール量に基づく）
-// - スクロールプログレスバー
-// - スクロール方向の検出
+// When scroll events are appropriate:
+// - Parallax effects (require continuous scroll position)
+// - Header shrink/expand (based on scroll amount)
+// - Scroll progress bars
+// - Scroll direction detection
 
-// scroll イベントを使う場合のベストプラクティス
+// Best practices when using scroll events
 let ticking = false;
 
 function onScroll() {
   if (!ticking) {
     requestAnimationFrame(() => {
-      // ここでスクロール位置に基づく処理を行う
+      // Perform scroll-position-based processing here
       updateParallax(window.scrollY);
       ticking = false;
     });
@@ -2051,48 +2052,48 @@ function onScroll() {
 }
 
 window.addEventListener('scroll', onScroll, { passive: true });
-// passive: true でスクロールのブロックを防止
+// passive: true prevents blocking of scrolling
 ```
 
 ---
 
-## 8. ベストプラクティスとパフォーマンス最適化
+## 8. Best Practices and Performance Optimization
 
-### 8.1 Observer の統合
+### 8.1 Sharing Observer Instances
 
 ```javascript
-// ★ 同じ設定の Observer は共有する
-// 悪い例: 要素ごとにObserverを作成
+// ★ Share a single Observer for the same configuration
+// Bad example: creating a new Observer per element
 document.querySelectorAll('.lazy-image').forEach(img => {
-  const observer = new IntersectionObserver(/* ... */); // 100個のObserver!
+  const observer = new IntersectionObserver(/* ... */); // 100 observers!
   observer.observe(img);
 });
 
-// 良い例: 1つのObserverで複数要素を監視
-const observer = new IntersectionObserver(/* ... */); // 1つだけ
+// Good example: monitor multiple elements with one Observer
+const observer = new IntersectionObserver(/* ... */); // just one
 document.querySelectorAll('.lazy-image').forEach(img => {
-  observer.observe(img); // 同じObserverに追加
+  observer.observe(img); // add to the same Observer
 });
 
-// ★ 不要になったらunobserve/disconnectする
-// メモリリーク防止のため、不要な監視は必ず停止する
-observer.unobserve(element); // 個別停止
-observer.disconnect();       // 全停止
+// ★ Call unobserve/disconnect when no longer needed
+// Always stop unnecessary observation to prevent memory leaks
+observer.unobserve(element); // stop individual element
+observer.disconnect();       // stop all
 ```
 
-### 8.2 コールバック内の処理を軽量に
+### 8.2 Keep Callback Logic Lightweight
 
 ```javascript
-// ★ Observerのコールバック内で重い処理を避ける
-// 悪い例
+// ★ Avoid heavy processing inside Observer callbacks
+// Bad example
 const observer = new ResizeObserver((entries) => {
   for (const entry of entries) {
-    // 重い再描画処理を直接実行
+    // Execute heavy redraw logic directly
     renderComplexChart(entry.contentRect.width, entry.contentRect.height);
   }
 });
 
-// 良い例: requestAnimationFrameでバッチ化
+// Good example: batch with requestAnimationFrame
 let rafId = null;
 
 const observer = new ResizeObserver((entries) => {
@@ -2106,7 +2107,7 @@ const observer = new ResizeObserver((entries) => {
   });
 });
 
-// 良い例: デバウンスの併用
+// Good example: combine with debounce
 function debounce(fn, delay) {
   let timer;
   return (...args) => {
@@ -2125,29 +2126,29 @@ const observer = new ResizeObserver((entries) => {
 });
 ```
 
-### 8.3 ブラウザサポートとPolyfill
+### 8.3 Browser Support and Polyfills
 
 ```javascript
-// Observer APIのブラウザサポート状況
+// Browser support for Observer APIs
 // IntersectionObserver: Chrome 51+, Firefox 55+, Safari 12.1+, Edge 15+
 // ResizeObserver: Chrome 64+, Firefox 69+, Safari 13.1+, Edge 79+
 // MutationObserver: Chrome 26+, Firefox 14+, Safari 7+, Edge 12+
 // PerformanceObserver: Chrome 52+, Firefox 57+, Safari 11+, Edge 79+
 
-// フィーチャーデテクション
+// Feature detection
 if ('IntersectionObserver' in window) {
-  // IntersectionObserverを使用
+  // Use IntersectionObserver
 } else {
-  // フォールバック: scroll イベント + getBoundingClientRect
+  // Fallback: scroll event + getBoundingClientRect
 }
 
 if ('ResizeObserver' in window) {
-  // ResizeObserverを使用
+  // Use ResizeObserver
 } else {
-  // フォールバック: window.onresize
+  // Fallback: window.onresize
 }
 
-// Polyfill の読み込み（必要な場合のみ）
+// Loading polyfills (only when needed)
 // npm install intersection-observer
 // npm install resize-observer-polyfill
 ```
@@ -2156,19 +2157,19 @@ if ('ResizeObserver' in window) {
 
 ## FAQ
 
-### Q1: IntersectionObserverを使って無限スクロールを実装する際の注意点は？
+### Q1: What should I watch out for when implementing infinite scroll with IntersectionObserver?
 
-IntersectionObserverによる無限スクロール実装では、以下の点に注意する必要がある。
+When implementing infinite scroll with IntersectionObserver, keep the following points in mind.
 
-1. **番兵要素（Sentinel）の配置**: スクロールコンテナの最後に空のdiv要素を配置し、これを監視する。この要素が表示されたら次のデータを読み込む。
-2. **ローディングフラグの管理**: 読み込み中に再度コールバックが発火しないよう、`loading`フラグで制御する。非同期処理が完了するまで新たなリクエストを抑制することが重要。
-3. **rootMarginによる先読み**: `rootMargin: '200px 0px'`のように設定することで、ユーザーがスクロールする前にデータを先読みでき、スムーズなUXを実現できる。
-4. **終端の検出**: サーバーから返されるデータが空、またはhasMoreフラグがfalseになったら、observerをdisconnect()して監視を停止する。
-5. **エラーハンドリング**: ネットワークエラー時にリトライ可能なUIを提供する。番兵要素をクリック可能にしてユーザーが手動で再試行できるようにするとよい。
+1. **Sentinel element placement**: Place an empty div element at the end of the scroll container and observe it. When this element becomes visible, load the next batch of data.
+2. **Loading flag management**: Use a `loading` flag to prevent the callback from triggering again while data is already loading. It is important to suppress new requests until the async operation completes.
+3. **Prefetching with rootMargin**: Setting `rootMargin: '200px 0px'` allows data to be prefetched before the user scrolls to the bottom, providing a smooth UX.
+4. **End-of-data detection**: When the server returns empty data or the hasMore flag is false, call `observer.disconnect()` to stop observation.
+5. **Error handling**: Provide a UI that allows retry on network errors. Making the sentinel element clickable so users can manually retry is a good approach.
 
 ```javascript
 const { ref, isIntersecting } = useIntersectionObserver({
-  rootMargin: '300px', // 300px手前から読み込み開始
+  rootMargin: '300px', // Start loading 300px before the bottom
 });
 
 useEffect(() => {
@@ -2186,45 +2187,45 @@ useEffect(() => {
 }, [isIntersecting, hasMore, loading]);
 ```
 
-### Q2: ResizeObserverとwindow.resizeイベントの違いと使い分けは？
+### Q2: What is the difference between ResizeObserver and the window.resize event, and when should I use each?
 
-ResizeObserverとwindow.resizeイベントは目的が異なる。
+ResizeObserver and the window.resize event serve different purposes.
 
-**window.resizeイベント**:
-- ブラウザウィンドウのサイズ変更のみを検出
-- 高頻度で発火するため、throttle/debounceが必須
-- グローバルなレイアウト調整（ヘッダーの固定解除、モバイルメニューの切り替えなど）に適している
+**window.resize event**:
+- Detects only browser window size changes
+- Fires at high frequency, so throttle/debounce is essential
+- Suitable for global layout adjustments (unfixing the header, toggling mobile menus, etc.)
 
 **ResizeObserver**:
-- 特定のDOM要素のサイズ変更を検出（CSSアニメーション、フレックスボックス、グリッドレイアウトによる変更も含む）
-- ブラウザが最適なタイミングで通知（throttle不要）
-- 個別コンポーネントの内部調整（チャートのリサイズ、テキストの自動縮小、仮想スクロールの再計算など）に適している
+- Detects size changes of specific DOM elements (including changes caused by CSS animations, flexbox, and grid layouts)
+- The browser notifies at optimal timing (no throttling needed)
+- Suitable for internal adjustments within individual components (chart resizing, auto-shrinking text, virtual scroll recalculation, etc.)
 
-使い分けの指針:
-- **ビューポート全体のサイズに依存する処理** → window.resize + matchMedia()
-- **特定要素のコンテンツサイズに依存する処理** → ResizeObserver
-- **コンテナクエリのような振る舞い** → ResizeObserver（またはネイティブの@container）
+Usage guidelines:
+- **Processing that depends on the overall viewport size** → window.resize + matchMedia()
+- **Processing that depends on a specific element's content size** → ResizeObserver
+- **Behavior similar to container queries** → ResizeObserver (or native `@container`)
 
-ResizeObserverは要素ごとに独立して動作するため、コンポーネント指向の設計に適している。一方、window.resizeはアプリケーション全体のブレークポイント管理に使うとよい。
+ResizeObserver operates independently per element, making it well-suited for component-oriented design. On the other hand, window.resize is best used for application-wide breakpoint management.
 
-### Q3: Observer APIを使うことでパフォーマンスがどれだけ改善されるのか？
+### Q3: How much does using the Observer API actually improve performance?
 
-Observer APIの最大の利点は、**レイアウトスラッシング（Layout Thrashing）の回避**である。
+The greatest benefit of the Observer API is **avoiding Layout Thrashing**.
 
-**従来のscrollイベント + getBoundingClientRect()**:
+**Traditional scroll event + getBoundingClientRect()**:
 ```javascript
 window.addEventListener('scroll', () => {
   elements.forEach(el => {
-    const rect = el.getBoundingClientRect(); // 強制リフロー発生
+    const rect = el.getBoundingClientRect(); // Forces reflow
     if (rect.top < window.innerHeight) {
       el.classList.add('visible');
     }
   });
 });
 ```
-- scrollイベントは1秒間に60回以上発火する可能性がある
-- getBoundingClientRect()は現在のレイアウトを強制的に計算させる（Forced Reflow）
-- 要素が100個あれば、1秒間に6000回のレイアウト計算が発生する可能性がある
+- The scroll event can fire 60+ times per second
+- getBoundingClientRect() forces the current layout to be computed (Forced Reflow)
+- With 100 elements, up to 6,000 layout calculations may occur per second
 
 **IntersectionObserver**:
 ```javascript
@@ -2237,47 +2238,47 @@ const observer = new IntersectionObserver((entries) => {
 });
 elements.forEach(el => observer.observe(el));
 ```
-- ブラウザが内部で最適化されたタイミングで通知
-- レイアウト計算をメインスレッドでブロックしない
-- 非アクティブタブでは自動的に停止
+- The browser notifies at internally optimized timing
+- Layout computation does not block the main thread
+- Automatically pauses on inactive tabs
 
-実測例（Chrome DevTools Performance測定）:
-- scrollイベント版: 1回のスクロールで30-50msのScripting時間（jank発生）
-- IntersectionObserver版: 1回のスクロールで1-3msのScripting時間（スムーズ）
+Measured results (Chrome DevTools Performance profiling):
+- scroll event version: 30-50ms of Scripting time per scroll (jank occurs)
+- IntersectionObserver version: 1-3ms of Scripting time per scroll (smooth)
 
-特に要素数が多い場合やモバイルデバイスでは、体感できるほどの差が出る。Core Web VitalsのINP（Interaction to Next Paint）指標の改善にも直結する。
-
----
-
-## まとめ
-
-| Observer | 監視対象 | 主な用途 | パフォーマンス |
-|----------|---------|---------|--------------|
-| IntersectionObserver | ビューポートとの交差 | 遅延読み込み、無限スクロール、ビューアビリティ | メインスレッド非ブロック |
-| ResizeObserver | 要素サイズの変更 | レスポンシブ、チャートリサイズ、仮想スクロール | レイアウト強制なし |
-| MutationObserver | DOM変更 | サードパーティ監視、自動初期化、変更検出 | マイクロタスクで実行 |
-| PerformanceObserver | パフォーマンスイベント | Web Vitals計測、リソース監視、Long Task検出 | 非同期バッファリング |
-
-### 選択指針
-
-1. **要素の可視性を知りたい** → IntersectionObserver
-2. **要素のサイズ変更に反応したい** → ResizeObserver
-3. **DOMの変更を検出したい** → MutationObserver
-4. **パフォーマンスメトリクスを収集したい** → PerformanceObserver
-5. **連続的なスクロール位置が必要** → scroll イベント + requestAnimationFrame
-6. **ウィンドウサイズの変更のみ** → matchMedia() またはCSSコンテナクエリ
+The difference is especially noticeable with large numbers of elements or on mobile devices. It also directly contributes to improving the INP (Interaction to Next Paint) metric of Core Web Vitals.
 
 ---
 
-## 次に読むべきガイド
+## Summary
 
-- [Webストレージ（localStorage, sessionStorage, IndexedDB）](../04-storage-and-caching/00-web-storage.md)
-- [Performance API 詳解](../04-storage-and-caching/02-performance-api.md)
-- [Fetch と Streams API](./01-fetch-and-streams.md)
+| Observer | What It Monitors | Primary Use Cases | Performance |
+|----------|-----------------|-------------------|-------------|
+| IntersectionObserver | Intersection with the viewport | Lazy loading, infinite scroll, viewability | Does not block the main thread |
+| ResizeObserver | Element size changes | Responsive layouts, chart resizing, virtual scroll | No forced layout |
+| MutationObserver | DOM changes | Third-party monitoring, auto-initialization, change detection | Executed as microtask |
+| PerformanceObserver | Performance events | Web Vitals measurement, resource monitoring, Long Task detection | Asynchronous buffering |
+
+### Selection Guidelines
+
+1. **Need to know if an element is visible** → IntersectionObserver
+2. **Need to react to element size changes** → ResizeObserver
+3. **Need to detect DOM changes** → MutationObserver
+4. **Need to collect performance metrics** → PerformanceObserver
+5. **Need continuous scroll position** → scroll event + requestAnimationFrame
+6. **Only need window size changes** → matchMedia() or CSS container queries
 
 ---
 
-## 参考文献
+## Further Reading
+
+- [Web Storage (localStorage, sessionStorage, IndexedDB)](../04-storage-and-caching/00-web-storage.md)
+- [Performance API Deep Dive](../04-storage-and-caching/02-performance-api.md)
+- [Fetch and Streams API](./01-fetch-and-streams.md)
+
+---
+
+## References
 
 1. MDN Web Docs. "Intersection Observer API." Mozilla, 2024. https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
 2. MDN Web Docs. "Resize Observer API." Mozilla, 2024. https://developer.mozilla.org/en-US/docs/Web/API/Resize_Observer_API

--- a/04-web-and-network/browser-and-web-platform/docs/04-storage-and-caching/02-performance-api.md
+++ b/04-web-and-network/browser-and-web-platform/docs/04-storage-and-caching/02-performance-api.md
@@ -1,58 +1,58 @@
 # Performance API
 
-> Performance API はブラウザのパフォーマンス計測の基盤である。Navigation Timing、Resource Timing、User Timing、PerformanceObserver を用いて Core Web Vitals を含むパフォーマンス指標を計測・分析し、Lighthouse や RUM（Real User Monitoring）と統合することで、継続的なパフォーマンス改善サイクルを構築できる。
+> The Performance API is the foundation for measuring browser performance. By using Navigation Timing, Resource Timing, User Timing, and PerformanceObserver to measure and analyze performance metrics including Core Web Vitals, and integrating with Lighthouse and RUM (Real User Monitoring), you can establish a continuous performance improvement cycle.
 
 ---
 
-## 目次
+## Table of Contents
 
-1. [Performance API の全体像](#1-performance-api-の全体像)
+1. [Overview of the Performance API](#1-overview-of-the-performance-api)
 2. [Navigation Timing API](#2-navigation-timing-api)
 3. [Resource Timing API](#3-resource-timing-api)
 4. [User Timing API](#4-user-timing-api)
-5. [PerformanceObserver の活用](#5-performanceobserver-の活用)
-6. [Core Web Vitals の計測](#6-core-web-vitals-の計測)
-7. [Lighthouse とパフォーマンス監査](#7-lighthouse-とパフォーマンス監査)
-8. [パフォーマンスデータの送信と分析基盤](#8-パフォーマンスデータの送信と分析基盤)
-9. [パフォーマンスバジェットと CI 統合](#9-パフォーマンスバジェットと-ci-統合)
-10. [アンチパターンと回避策](#10-アンチパターンと回避策)
-11. [エッジケース分析](#11-エッジケース分析)
-12. [段階別演習](#12-段階別演習)
+5. [Using PerformanceObserver](#5-using-performanceobserver)
+6. [Measuring Core Web Vitals](#6-measuring-core-web-vitals)
+7. [Lighthouse and Performance Auditing](#7-lighthouse-and-performance-auditing)
+8. [Sending Performance Data and Building an Analytics Foundation](#8-sending-performance-data-and-building-an-analytics-foundation)
+9. [Performance Budgets and CI Integration](#9-performance-budgets-and-ci-integration)
+10. [Anti-patterns and Workarounds](#10-anti-patterns-and-workarounds)
+11. [Edge Case Analysis](#11-edge-case-analysis)
+12. [Tiered Exercises](#12-tiered-exercises)
 13. [FAQ](#13-faq)
-14. [比較表](#14-比較表)
-15. [参考文献](#15-参考文献)
+14. [Comparison Tables](#14-comparison-tables)
+15. [References](#15-references)
 
 ---
 
-## 前提知識
+## Prerequisites
 
-本章を最大限に活用するため、以下の前提知識を習得しておくことを推奨する。
+To get the most out of this chapter, it is recommended that you have the following background knowledge.
 
-- **Service Worker とキャッシュの理解**: Performance API で計測するパフォーマンス指標の多くは、Service Worker によるキャッシュ戦略の影響を受ける。Cache First や Stale-While-Revalidate がリソースタイミングや Core Web Vitals（特に LCP）にどのように作用するかを理解するため、[Service Worker とキャッシュ戦略](./01-service-worker-cache.md) の内容を事前に把握しておくことが望ましい。
-- **レンダリングパイプラインの基礎**: Largest Contentful Paint（LCP）や Cumulative Layout Shift（CLS）などの指標は、ブラウザのレンダリングプロセスと密接に関連している。パースからレイアウト、ペイント、コンポジットに至るまでの流れを理解していると、パフォーマンス指標の背景にある仕組みが明確になる。詳細は [レンダリングパイプライン](../01-rendering/00-rendering-pipeline.md) を参照のこと。
-- **Core Web Vitals の概念**: Google が定義する LCP（Largest Contentful Paint）、INP（Interaction to Next Paint）、CLS（Cumulative Layout Shift）の 3 つの指標は、ユーザー体験を定量化する標準的な指標である。これらの基本概念を理解していることで、本章の計測・改善手法がより実践的に活用できる。
+- **Understanding Service Workers and caching**: Many of the performance metrics measured with the Performance API are affected by caching strategies implemented via Service Workers. To understand how Cache First and Stale-While-Revalidate affect resource timing and Core Web Vitals (especially LCP), it is advisable to review [Service Workers and Caching Strategies](./01-service-worker-cache.md) beforehand.
+- **Rendering pipeline basics**: Metrics such as Largest Contentful Paint (LCP) and Cumulative Layout Shift (CLS) are closely tied to the browser's rendering process. Understanding the flow from parsing through layout, paint, and compositing makes the mechanisms behind performance metrics clearer. For details, refer to [Rendering Pipeline](../01-rendering/00-rendering-pipeline.md).
+- **Core Web Vitals concepts**: The three metrics defined by Google — LCP (Largest Contentful Paint), INP (Interaction to Next Paint), and CLS (Cumulative Layout Shift) — are standard metrics for quantifying user experience. Familiarity with these basic concepts allows you to apply the measurement and improvement techniques in this chapter more practically.
 
-これらの知識がない場合でも本章を読み進めることは可能だが、上記のガイドを先に参照することで理解が深まる。
-
----
-
-## この章で学ぶこと
-
-- [ ] Navigation Timing と Resource Timing の使い方を理解する
-- [ ] User Timing でカスタム計測を行う方法を把握する
-- [ ] PerformanceObserver によるリアルタイム監視の仕組みを学ぶ
-- [ ] Core Web Vitals（LCP・INP・CLS）の計測と改善手法を習得する
-- [ ] Lighthouse のスコアリングアルゴリズムと自動監査の活用法を理解する
-- [ ] パフォーマンスバジェットの設計と CI/CD パイプラインへの組み込みを実践する
-- [ ] RUM データの収集・送信・分析基盤を構築する方法を学ぶ
+Even without this background knowledge you can still work through this chapter, but reviewing the guides listed above first will deepen your understanding.
 
 ---
 
-## 1. Performance API の全体像
+## What You Will Learn
 
-### 1.1 アーキテクチャ概要
+- [ ] Understand how to use Navigation Timing and Resource Timing
+- [ ] Know how to perform custom measurements with User Timing
+- [ ] Learn how real-time monitoring works with PerformanceObserver
+- [ ] Master measurement and improvement techniques for Core Web Vitals (LCP, INP, CLS)
+- [ ] Understand Lighthouse's scoring algorithm and how to use automated audits
+- [ ] Practice designing performance budgets and integrating them into CI/CD pipelines
+- [ ] Learn how to build a pipeline for collecting, sending, and analyzing RUM data
 
-Performance API は W3C が策定する一連の仕様群であり、ブラウザにおけるパフォーマンス計測の標準基盤を提供する。以下の ASCII 図は、Performance API を構成する主要な仕様とその関係性を示している。
+---
+
+## 1. Overview of the Performance API
+
+### 1.1 Architecture Overview
+
+The Performance API is a set of specifications developed by the W3C that provides a standard foundation for measuring browser performance. The ASCII diagram below shows the major specifications that make up the Performance API and their relationships.
 
 ```
 +-------------------------------------------------------------------+
@@ -72,78 +72,82 @@ Performance API は W3C が策定する一連の仕様群であり、ブラウ�
         v              v              v              v
 +-------------------------------------------------------------------+
 |                   PerformanceObserver                              |
-|  (リアルタイムのエントリ通知・buffered オプション)                  |
+|  (real-time entry notifications / buffered option)                 |
 +-------------------------------------------------------------------+
         |
         v
 +-------------------------------------------------------------------+
-|  Analytics / RUM 基盤                                              |
-|  (Beacon API / fetch keepalive / サードパーティ SDK)               |
+|  Analytics / RUM Foundation                                        |
+|  (Beacon API / fetch keepalive / third-party SDKs)                |
 +-------------------------------------------------------------------+
 ```
 
-### 1.2 Performance Timeline の基本概念
+### 1.2 Basic Concepts of the Performance Timeline
 
-Performance Timeline は全てのパフォーマンスエントリを統一的に扱う仕組みである。各エントリは `PerformanceEntry` インターフェースを継承し、共通のプロパティを持つ。
+The Performance Timeline is a mechanism for handling all performance entries in a unified way. Each entry inherits the `PerformanceEntry` interface and has common properties.
 
-| プロパティ       | 型       | 説明                                 |
-|------------------|----------|--------------------------------------|
-| `name`           | string   | エントリの識別名（URL やマーク名）   |
-| `entryType`      | string   | エントリの種別                       |
-| `startTime`      | double   | 計測開始時刻（ミリ秒、timeOrigin 基準） |
-| `duration`       | double   | 計測期間（ミリ秒）                   |
+| Property         | Type     | Description                                          |
+|------------------|----------|------------------------------------------------------|
+| `name`           | string   | Identifying name of the entry (URL or mark name)     |
+| `entryType`      | string   | Type of the entry                                    |
+| `startTime`      | double   | Measurement start time (milliseconds, relative to timeOrigin) |
+| `duration`       | double   | Measurement duration (milliseconds)                  |
 
 ```javascript
-// Performance Timeline の基本操作
-// 全てのエントリを取得
+// Basic operations on the Performance Timeline
+// Retrieve all entries
 const allEntries = performance.getEntries();
 
-// 種別でフィルタリング
+// Filter by type
 const navEntries = performance.getEntriesByType('navigation');
 const resEntries = performance.getEntriesByType('resource');
 const markEntries = performance.getEntriesByType('mark');
 const measureEntries = performance.getEntriesByType('measure');
 
-// 名前で検索
+// Search by name
 const specificEntry = performance.getEntriesByName('my-custom-mark');
 
-// タイムオリジンの確認
+// Check the time origin
 console.log('Time origin:', performance.timeOrigin);
-// => Unix エポックからの経過ミリ秒（高精度タイムスタンプ）
+// => Milliseconds elapsed since the Unix epoch (high-resolution timestamp)
 
-// 現在の高精度タイムスタンプ
+// Current high-resolution timestamp
 console.log('Now:', performance.now());
-// => timeOrigin からの経過ミリ秒
+// => Milliseconds elapsed since timeOrigin
 ```
 
-### 1.3 高精度タイムスタンプと Spectre 緩和
+### 1.3 High-Resolution Timestamps and Spectre Mitigations
 
-`performance.now()` はマイクロ秒精度のタイムスタンプを返すが、Spectre 等のサイドチャネル攻撃への対策として、ブラウザはタイムスタンプの精度を意図的に下げている。
+`performance.now()` returns a timestamp with microsecond precision, but browsers intentionally reduce this precision as a countermeasure against side-channel attacks such as Spectre.
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  Spectre 緩和前後のタイムスタンプ精度                │
+│  Timestamp Precision Before and After Spectre        │
+│  Mitigations                                        │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
-│  緩和前:  performance.now() => 1234.567890123       │
+│  Before mitigation:                                 │
+│           performance.now() => 1234.567890123       │
 │                                 ^^^^^^^^^^^^^^^^    │
-│                                 マイクロ秒精度      │
+│                                 microsecond precision│
 │                                                     │
-│  緩和後:  performance.now() => 1234.500             │
-│           (Cross-Origin-Isolated なし)              │
+│  After mitigation:                                  │
+│           performance.now() => 1234.500             │
+│           (without Cross-Origin-Isolated)           │
 │                                 ^^^^^^^             │
-│                                 100μs に丸め        │
+│                                 rounded to 100μs    │
 │                                                     │
-│  COOP+COEP 設定時:                                  │
+│  With COOP+COEP configured:                         │
 │           performance.now() => 1234.567             │
 │                                 ^^^^^^^^^           │
-│                                 5μs 精度に回復      │
+│                                 restored to 5μs     │
 │                                                     │
-│  ※ SharedArrayBuffer を使う場合も同様の設定が必要   │
+│  * The same configuration is required when using    │
+│    SharedArrayBuffer                                │
 └─────────────────────────────────────────────────────┘
 ```
 
-Cross-Origin-Isolated 環境を有効化するには、以下の HTTP ヘッダを設定する。
+To enable a Cross-Origin-Isolated environment, set the following HTTP headers.
 
 ```
 Cross-Origin-Opener-Policy: same-origin
@@ -154,9 +158,9 @@ Cross-Origin-Embedder-Policy: require-corp
 
 ## 2. Navigation Timing API
 
-### 2.1 ページ読み込みライフサイクル
+### 2.1 Page Load Lifecycle
 
-Navigation Timing API は、ブラウザがページを読み込む過程の各段階を計測する仕組みである。以下の図はページ読み込みの全段階を時系列で示す。
+The Navigation Timing API measures each stage of the process by which the browser loads a page. The diagram below shows all stages of a page load in chronological order.
 
 ```
  navigationStart
@@ -164,14 +168,14 @@ Navigation Timing API は、ブラウザがページを読み込む過程の各�
        v
  +-----------+    +-----------+    +----------+    +----------+
  | Redirect  |--->|   DNS     |--->|   TCP    |--->|   TLS    |
- | (0-N回)   |    |  Lookup   |    | Connect  |    | Handshake|
+ | (0-N times)|   |  Lookup   |    | Connect  |    | Handshake|
  +-----------+    +-----------+    +----------+    +----------+
        |                                                 |
        v                                                 v
  +-------------+    +-----------+    +-----------+    +----------+
  | Request     |--->| Response  |--->|  DOM      |--->|  Load    |
  | Send        |    | Receive   |    | Processing|    | Event    |
- | (TTFB算出)  |    | (download)|    | (parse +  |    | (onload) |
+ | (TTFB calc) |    | (download)|    | (parse +  |    | (onload) |
  +-------------+    +-----------+    |  scripts) |    +----------+
                                      +-----------+
                                           |
@@ -179,57 +183,57 @@ Navigation Timing API は、ブラウザがページを読み込む過程の各�
                                   DOMContentLoaded
 ```
 
-### 2.2 詳細な計測実装
+### 2.2 Detailed Measurement Implementation
 
 ```javascript
-// ページ読み込みの各段階を体系的に計測する関数
+// Function to systematically measure each stage of page load
 function collectNavigationMetrics() {
   const entry = performance.getEntriesByType('navigation')[0];
 
   if (!entry) {
-    console.warn('Navigation Timing エントリが取得できません');
+    console.warn('Navigation Timing entry could not be retrieved');
     return null;
   }
 
   const metrics = {
-    // ========== ネットワーク段階 ==========
-    // リダイレクト処理時間（HTTP 301/302 など）
+    // ========== Network phase ==========
+    // Redirect processing time (HTTP 301/302, etc.)
     redirect: {
       duration: entry.redirectEnd - entry.redirectStart,
       count: entry.redirectCount,
-      note: 'リダイレクトが多いと初期表示が遅延する',
+      note: 'Many redirects delay initial rendering',
     },
 
-    // DNS 解決時間
+    // DNS resolution time
     dns: {
       duration: entry.domainLookupEnd - entry.domainLookupStart,
-      note: 'DNS プリフェッチで短縮可能',
+      note: 'Can be shortened with DNS prefetch',
     },
 
-    // TCP 接続確立時間
+    // TCP connection establishment time
     tcp: {
       duration: entry.connectEnd - entry.connectStart,
-      note: 'HTTP/2 の多重化で接続再利用が可能',
+      note: 'HTTP/2 multiplexing allows connection reuse',
     },
 
-    // TLS ハンドシェイク時間
+    // TLS handshake time
     tls: {
       duration: entry.secureConnectionStart > 0
         ? entry.connectEnd - entry.secureConnectionStart
         : 0,
       isSecure: entry.secureConnectionStart > 0,
-      note: 'TLS 1.3 で 1-RTT に短縮可能',
+      note: 'TLS 1.3 can reduce this to 1-RTT',
     },
 
-    // ========== サーバー応答段階 ==========
-    // TTFB（Time to First Byte）
+    // ========== Server response phase ==========
+    // TTFB (Time to First Byte)
     ttfb: {
       duration: entry.responseStart - entry.requestStart,
-      threshold: 800, // ms - 推奨上限
-      note: 'サーバー処理時間を含む重要指標',
+      threshold: 800, // ms - recommended upper limit
+      note: 'An important metric that includes server processing time',
     },
 
-    // コンテンツダウンロード時間
+    // Content download time
     download: {
       duration: entry.responseEnd - entry.responseStart,
       transferSize: entry.transferSize,
@@ -240,21 +244,21 @@ function collectNavigationMetrics() {
         : 'N/A',
     },
 
-    // ========== レンダリング段階 ==========
-    // DOM 処理時間
+    // ========== Rendering phase ==========
+    // DOM processing time
     domProcessing: {
       duration: entry.domContentLoadedEventEnd - entry.responseEnd,
       interactive: entry.domInteractive - entry.startTime,
       contentLoaded: entry.domContentLoadedEventEnd - entry.startTime,
     },
 
-    // 全体の読み込み完了時間
+    // Overall load completion time
     total: {
       loadComplete: entry.loadEventEnd - entry.startTime,
       domContentLoaded: entry.domContentLoadedEventEnd - entry.startTime,
     },
 
-    // ========== メタ情報 ==========
+    // ========== Meta information ==========
     meta: {
       type: entry.type,          // 'navigate', 'reload', 'back_forward', 'prerender'
       protocol: entry.nextHopProtocol, // 'h2', 'h3', 'http/1.1'
@@ -265,42 +269,42 @@ function collectNavigationMetrics() {
   return metrics;
 }
 
-// 使用例: ページ読み込み完了後に実行
+// Usage: execute after page load completes
 window.addEventListener('load', () => {
-  // loadEventEnd が記録されるのを待つ
+  // Wait for loadEventEnd to be recorded
   setTimeout(() => {
     const metrics = collectNavigationMetrics();
     if (metrics) {
       console.table({
-        'リダイレクト': `${metrics.redirect.duration.toFixed(0)}ms (${metrics.redirect.count}回)`,
-        'DNS 解決': `${metrics.dns.duration.toFixed(0)}ms`,
-        'TCP 接続': `${metrics.tcp.duration.toFixed(0)}ms`,
-        'TLS ハンドシェイク': `${metrics.tls.duration.toFixed(0)}ms`,
+        'Redirect': `${metrics.redirect.duration.toFixed(0)}ms (${metrics.redirect.count} times)`,
+        'DNS Resolution': `${metrics.dns.duration.toFixed(0)}ms`,
+        'TCP Connection': `${metrics.tcp.duration.toFixed(0)}ms`,
+        'TLS Handshake': `${metrics.tls.duration.toFixed(0)}ms`,
         'TTFB': `${metrics.ttfb.duration.toFixed(0)}ms`,
-        'ダウンロード': `${metrics.download.duration.toFixed(0)}ms`,
-        'DOM 処理': `${metrics.domProcessing.duration.toFixed(0)}ms`,
-        '全体': `${metrics.total.loadComplete.toFixed(0)}ms`,
-        'プロトコル': metrics.meta.protocol,
-        'ナビゲーション種別': metrics.meta.type,
+        'Download': `${metrics.download.duration.toFixed(0)}ms`,
+        'DOM Processing': `${metrics.domProcessing.duration.toFixed(0)}ms`,
+        'Total': `${metrics.total.loadComplete.toFixed(0)}ms`,
+        'Protocol': metrics.meta.protocol,
+        'Navigation Type': metrics.meta.type,
       });
     }
   }, 0);
 });
 ```
 
-### 2.3 Navigation Type の判別と活用
+### 2.3 Identifying and Using Navigation Types
 
-`PerformanceNavigationTiming.type` プロパティは、ページ遷移の種類を示す。これを用いてナビゲーション種別ごとの分析が可能になる。
+The `PerformanceNavigationTiming.type` property indicates the type of page navigation. This allows analysis by navigation type.
 
-| type 値        | 意味                             | 典型的なシナリオ                   |
-|----------------|----------------------------------|------------------------------------|
-| `navigate`     | 通常のナビゲーション             | リンククリック、アドレスバー入力   |
-| `reload`       | ページリロード                   | F5、Ctrl+R                         |
-| `back_forward` | 履歴ナビゲーション               | ブラウザの「戻る」「進む」ボタン   |
-| `prerender`    | プリレンダリング                 | Speculation Rules API による投機的読み込み |
+| type value     | Meaning                          | Typical scenario                         |
+|----------------|----------------------------------|------------------------------------------|
+| `navigate`     | Normal navigation                | Link click, address bar input            |
+| `reload`       | Page reload                      | F5, Ctrl+R                               |
+| `back_forward` | History navigation               | Browser Back/Forward buttons             |
+| `prerender`    | Prerendering                     | Speculative load via Speculation Rules API |
 
 ```javascript
-// ナビゲーション種別ごとにメトリクスを分類して送信
+// Classify and send metrics by navigation type
 function categorizeByNavigationType(metrics) {
   const entry = performance.getEntriesByType('navigation')[0];
   const navType = entry?.type || 'unknown';
@@ -308,9 +312,9 @@ function categorizeByNavigationType(metrics) {
   return {
     navigationType: navType,
     metrics,
-    // 戻る/進む操作では bfcache の効果を確認
+    // Check the effect of bfcache on back/forward navigation
     bfcacheUsed: navType === 'back_forward' && metrics.total.loadComplete < 50,
-    // プリレンダリング済みならほぼ即時表示
+    // Near-instant display if prerendered
     prerendered: navType === 'prerender',
   };
 }
@@ -320,23 +324,23 @@ function categorizeByNavigationType(metrics) {
 
 ## 3. Resource Timing API
 
-### 3.1 リソース読み込みの詳細計測
+### 3.1 Detailed Measurement of Resource Loading
 
-Resource Timing API は、HTML ドキュメント以外の個別リソース（スクリプト、スタイルシート、画像、フォント、API リクエストなど）の読み込みパフォーマンスを計測する。
+The Resource Timing API measures the loading performance of individual resources other than the HTML document (scripts, stylesheets, images, fonts, API requests, etc.).
 
 ```javascript
-// 個別リソースの読み込み時間を詳細に計測する
+// Measure load times for individual resources in detail
 function analyzeResources() {
   const resources = performance.getEntriesByType('resource');
 
-  // リソースごとの詳細分析
+  // Detailed analysis per resource
   const analysis = resources.map(entry => ({
-    // 基本情報
+    // Basic information
     url: entry.name,
     type: entry.initiatorType,
     // script, css, img, link, fetch, xmlhttprequest, beacon, video, audio
 
-    // タイミング詳細
+    // Timing details
     timing: {
       redirect: entry.redirectEnd - entry.redirectStart,
       dns: entry.domainLookupEnd - entry.domainLookupStart,
@@ -348,34 +352,34 @@ function analyzeResources() {
       total: entry.duration,
     },
 
-    // サイズ情報
+    // Size information
     size: {
       transferSize: entry.transferSize,
       encodedBodySize: entry.encodedBodySize,
       decodedBodySize: entry.decodedBodySize,
     },
 
-    // キャッシュ判定
+    // Cache determination
     cache: {
       fromCache: entry.transferSize === 0 && entry.decodedBodySize > 0,
       fromServiceWorker: entry.workerStart > 0,
-      // 304 Not Modified の検出
+      // Detecting 304 Not Modified
       conditionalRequest: entry.transferSize > 0
         && entry.transferSize < entry.encodedBodySize,
     },
 
-    // HTTP/2 Server Push の検出
+    // Detecting HTTP/2 Server Push
     serverPush: entry.transferSize > 0
       && entry.requestStart === entry.responseStart,
 
-    // レンダリングブロッキング判定
+    // Render-blocking determination
     renderBlocking: entry.renderBlockingStatus || 'unknown',
   }));
 
   return analysis;
 }
 
-// 遅いリソースの検出と報告
+// Detecting and reporting slow resources
 function detectSlowResources(thresholdMs = 1000) {
   const resources = performance.getEntriesByType('resource');
 
@@ -383,7 +387,7 @@ function detectSlowResources(thresholdMs = 1000) {
     .filter(r => r.duration > thresholdMs)
     .sort((a, b) => b.duration - a.duration)
     .map(r => ({
-      url: new URL(r.name).pathname,  // パスのみ表示
+      url: new URL(r.name).pathname,  // Show only the path
       duration: `${r.duration.toFixed(0)}ms`,
       type: r.initiatorType,
       size: `${(r.transferSize / 1024).toFixed(1)}KB`,
@@ -393,7 +397,7 @@ function detectSlowResources(thresholdMs = 1000) {
   return slowResources;
 }
 
-// ボトルネックの自動判定
+// Automatic bottleneck identification
 function identifyBottleneck(entry) {
   const timing = {
     dns: entry.domainLookupEnd - entry.domainLookupStart,
@@ -409,10 +413,10 @@ function identifyBottleneck(entry) {
 }
 ```
 
-### 3.2 リソースタイプ別の集計ダッシュボード
+### 3.2 Aggregated Dashboard by Resource Type
 
 ```javascript
-// リソースタイプ別に集計してパフォーマンスの全体像を把握する
+// Aggregate by resource type to understand the overall performance picture
 function createResourceDashboard() {
   const resources = performance.getEntriesByType('resource');
 
@@ -445,7 +449,7 @@ function createResourceDashboard() {
     group.entries.push(r);
   });
 
-  // 集計結果のフォーマット
+  // Format aggregation results
   const summary = Object.entries(dashboard).map(([type, data]) => ({
     type,
     count: data.count,
@@ -460,23 +464,23 @@ function createResourceDashboard() {
 }
 ```
 
-### 3.3 Timing-Allow-Origin とクロスオリジン制約
+### 3.3 Timing-Allow-Origin and Cross-Origin Restrictions
 
-クロスオリジンリソースの計測には、サーバー側で `Timing-Allow-Origin` ヘッダの設定が必要である。このヘッダが設定されていない場合、多くのタイミング値がゼロに制限される。
+Measuring cross-origin resources requires the server to set the `Timing-Allow-Origin` header. Without this header, many timing values are restricted to zero.
 
 ```
-クロスオリジンリソースのタイミング情報制約:
+Cross-origin resource timing information restrictions:
 
 ┌──────────────────────────────────────────────────────────────┐
-│  Timing-Allow-Origin ヘッダなし（デフォルト）               │
+│  Without Timing-Allow-Origin header (default)                │
 │                                                              │
-│  取得可能:                                                   │
+│  Available:                                                  │
 │    - startTime, duration                                     │
-│    - transferSize = 0 (隠蔽)                                │
-│    - encodedBodySize = 0 (隠蔽)                             │
-│    - decodedBodySize = 0 (隠蔽)                             │
+│    - transferSize = 0 (hidden)                               │
+│    - encodedBodySize = 0 (hidden)                            │
+│    - decodedBodySize = 0 (hidden)                            │
 │                                                              │
-│  ゼロに制限:                                                 │
+│  Restricted to zero:                                         │
 │    - redirectStart / redirectEnd                             │
 │    - domainLookupStart / domainLookupEnd                     │
 │    - connectStart / connectEnd                               │
@@ -484,15 +488,15 @@ function createResourceDashboard() {
 │    - requestStart / responseStart                            │
 │                                                              │
 ├──────────────────────────────────────────────────────────────┤
-│  Timing-Allow-Origin: * （または特定オリジン）              │
+│  Timing-Allow-Origin: * (or specific origin)                 │
 │                                                              │
-│  全てのタイミング値が取得可能                                │
-│  サイズ情報も正確に報告される                                │
+│  All timing values are available                             │
+│  Size information is also reported accurately                │
 └──────────────────────────────────────────────────────────────┘
 ```
 
 ```javascript
-// Timing-Allow-Origin の確認と影響の検出
+// Check Timing-Allow-Origin and detect its impact
 function checkTimingAccess() {
   const resources = performance.getEntriesByType('resource');
   const crossOrigin = resources.filter(r => {
@@ -507,9 +511,9 @@ function checkTimingAccess() {
     r.requestStart === 0 && r.responseStart === 0
   );
 
-  console.log(`クロスオリジンリソース: ${crossOrigin.length}件`);
-  console.log(`タイミング制限あり: ${restricted.length}件`);
-  console.log('制限リソース一覧:');
+  console.log(`Cross-origin resources: ${crossOrigin.length}`);
+  console.log(`Timing-restricted: ${restricted.length}`);
+  console.log('Restricted resource list:');
   restricted.forEach(r => {
     console.log(`  - ${new URL(r.name).hostname}${new URL(r.name).pathname}`);
   });
@@ -520,33 +524,33 @@ function checkTimingAccess() {
 
 ## 4. User Timing API
 
-### 4.1 mark と measure の基本
+### 4.1 Basics of mark and measure
 
-User Timing API は、開発者がアプリケーション固有のパフォーマンス計測ポイントを定義するための仕組みである。`performance.mark()` でタイムスタンプを記録し、`performance.measure()` で2点間の所要時間を算出する。
+The User Timing API provides a mechanism for developers to define application-specific performance measurement points. Use `performance.mark()` to record timestamps and `performance.measure()` to calculate the elapsed time between two points.
 
 ```javascript
 // ==================================================
-// User Timing API の基本操作と応用パターン
+// Basic operations and practical patterns of the User Timing API
 // ==================================================
 
-// (1) 基本的な mark と measure
+// (1) Basic mark and measure
 performance.mark('app-init-start');
 
-// アプリケーション初期化処理
+// Application initialization processing
 initializeApp();
 loadConfiguration();
 setupEventHandlers();
 
 performance.mark('app-init-end');
 
-// 2つの mark 間の時間を計測
+// Measure the time between two marks
 performance.measure('app-initialization', 'app-init-start', 'app-init-end');
 
 const initMeasure = performance.getEntriesByName('app-initialization')[0];
-console.log(`アプリ初期化: ${initMeasure.duration.toFixed(2)}ms`);
+console.log(`App initialization: ${initMeasure.duration.toFixed(2)}ms`);
 
 
-// (2) mark にメタデータを付与（Performance API Level 3）
+// (2) Attaching metadata to a mark (Performance API Level 3)
 performance.mark('data-fetch-complete', {
   detail: {
     endpoint: '/api/users',
@@ -555,12 +559,12 @@ performance.mark('data-fetch-complete', {
   },
 });
 
-// メタデータの取得
+// Retrieving metadata
 const fetchMark = performance.getEntriesByName('data-fetch-complete')[0];
-console.log('取得件数:', fetchMark.detail.recordCount);
+console.log('Record count:', fetchMark.detail.recordCount);
 
 
-// (3) measure にもメタデータを付与可能
+// (3) Metadata can also be attached to measures
 performance.measure('api-call', {
   start: 'api-call-start',
   end: 'api-call-end',
@@ -572,28 +576,28 @@ performance.measure('api-call', {
 });
 
 
-// (4) navigationStart からの経過時間を計測
+// (4) Measure elapsed time from navigationStart
 performance.measure('time-to-interactive', {
-  start: 0,  // navigationStart を起点とする
+  start: 0,  // Use navigationStart as the reference point
   end: performance.now(),
 });
 
 
-// (5) エントリのクリーンアップ
+// (5) Cleaning up entries
 performance.clearMarks('app-init-start');
 performance.clearMarks('app-init-end');
 performance.clearMeasures('app-initialization');
 
-// 全エントリのクリア
-performance.clearMarks();     // 全 mark を削除
-performance.clearMeasures();  // 全 measure を削除
+// Clear all entries
+performance.clearMarks();     // Delete all marks
+performance.clearMeasures();  // Delete all measures
 ```
 
-### 4.2 実用的な計測パターン集
+### 4.2 Collection of Practical Measurement Patterns
 
 ```javascript
 // ==================================================
-// パターン1: 非同期処理の計測ラッパー
+// Pattern 1: Async function measurement wrapper
 // ==================================================
 async function measureAsync(name, asyncFn) {
   const markStart = `${name}-start`;
@@ -622,14 +626,14 @@ async function measureAsync(name, asyncFn) {
   }
 }
 
-// 使用例
+// Usage example
 const users = await measureAsync('fetch-users', () =>
   fetch('/api/users').then(r => r.json())
 );
 
 
 // ==================================================
-// パターン2: React コンポーネントのライフサイクル計測
+// Pattern 2: React component lifecycle measurement
 // ==================================================
 function usePerformanceMark(componentName) {
   const markPrefix = `component-${componentName}`;
@@ -655,7 +659,7 @@ function usePerformanceMark(componentName) {
   }, []);
 }
 
-// 使用例
+// Usage example
 function ProductList() {
   usePerformanceMark('ProductList');
 
@@ -668,7 +672,7 @@ function ProductList() {
 
 
 // ==================================================
-// パターン3: ルーティング遷移の計測
+// Pattern 3: Route transition measurement
 // ==================================================
 class RoutePerformanceTracker {
   constructor() {
@@ -709,18 +713,18 @@ class RoutePerformanceTracker {
 
 ---
 
-## 5. PerformanceObserver の活用
+## 5. Using PerformanceObserver
 
-### 5.1 基本的な使い方
+### 5.1 Basic Usage
 
-PerformanceObserver は、パフォーマンスエントリが記録されるたびにコールバックを呼び出す Observer パターンの実装である。ポーリングではなくイベント駆動でエントリを取得できるため、効率的かつリアルタイムな計測が可能になる。
+PerformanceObserver is an implementation of the Observer pattern that invokes a callback each time a performance entry is recorded. Because it retrieves entries in an event-driven manner rather than polling, it enables efficient, real-time measurement.
 
 ```javascript
 // ==================================================
-// PerformanceObserver の基本操作
+// Basic operations of PerformanceObserver
 // ==================================================
 
-// (1) 特定の entryType を監視
+// (1) Observe a specific entryType
 const resourceObserver = new PerformanceObserver((list, observer) => {
   const entries = list.getEntries();
 
@@ -729,14 +733,14 @@ const resourceObserver = new PerformanceObserver((list, observer) => {
   });
 });
 
-// observe の開始
+// Start observing
 resourceObserver.observe({
   type: 'resource',
-  buffered: true,  // 過去のエントリも含める
+  buffered: true,  // Also include past entries
 });
 
 
-// (2) 複数の entryType を同時に監視
+// (2) Observe multiple entryTypes simultaneously
 const multiObserver = new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
     switch (entry.entryType) {
@@ -753,56 +757,56 @@ const multiObserver = new PerformanceObserver((list) => {
   }
 });
 
-// entryTypes（複数形）で配列を渡す
+// Pass an array using entryTypes (plural)
 multiObserver.observe({
   entryTypes: ['resource', 'mark', 'measure'],
 });
 
 
-// (3) 監視の停止
+// (3) Stop observing
 resourceObserver.disconnect();
 
 
-// (4) 監視可能な entryType の一覧を取得
+// (4) Retrieve the list of observable entryTypes
 const supportedTypes = PerformanceObserver.supportedEntryTypes;
-console.log('サポートされている entryType:', supportedTypes);
-// 典型的な出力:
+console.log('Supported entryTypes:', supportedTypes);
+// Typical output:
 // ['element', 'event', 'first-input', 'largest-contentful-paint',
 //  'layout-shift', 'longtask', 'mark', 'measure', 'navigation',
 //  'paint', 'resource', 'visibility-state']
 ```
 
-### 5.2 buffered オプションの重要性
+### 5.2 Importance of the buffered Option
 
-`buffered: true` は、Observer の登録前に記録されたエントリも取得するオプションである。ページ読み込み完了後にスクリプトを実行するケース（defer や async で読み込まれるスクリプト）では、このオプションがないと初期のエントリを取りこぼす。
+`buffered: true` is an option that also retrieves entries recorded before the Observer was registered. In cases where a script executes after page load completion (scripts loaded with `defer` or `async`), without this option, initial entries will be missed.
 
 ```javascript
-// buffered オプションの効果
+// Effect of the buffered option
 //
-// スクリプト実行時点: T = 3000ms
-// ページ読み込み開始: T = 0ms
+// Script execution time: T = 3000ms
+// Page load start: T = 0ms
 //
-// buffered: false の場合:
-//   T=0 ~ T=3000 に発生したエントリは取得できない
+// With buffered: false:
+//   Entries that occurred from T=0 to T=3000 cannot be retrieved
 //
-// buffered: true の場合:
-//   T=0 ~ T=3000 に発生したエントリも含めて取得可能
+// With buffered: true:
+//   Entries that occurred from T=0 to T=3000 are also included
 
-// 典型的な使い方（遅延読み込みスクリプトで安全に使用）
+// Typical usage (safely used in deferred-load scripts)
 new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
-    // 過去のエントリも含めて処理される
+    // Past entries are also processed
     processEntry(entry);
   }
 }).observe({ type: 'largest-contentful-paint', buffered: true });
 ```
 
-### 5.3 Long Tasks の検出
+### 5.3 Detecting Long Tasks
 
-メインスレッドで 50ms を超えるタスクは "Long Task" と定義され、ユーザー入力への応答遅延を引き起こす。PerformanceObserver を用いてこれらを検出し、インタラクション品質の低下原因を特定できる。
+Tasks on the main thread that exceed 50ms are defined as "Long Tasks" and cause delayed responses to user input. You can use PerformanceObserver to detect these and identify the causes of degraded interaction quality.
 
 ```javascript
-// Long Tasks の監視と分析
+// Monitoring and analyzing Long Tasks
 const longTasks = [];
 
 new PerformanceObserver((list) => {
@@ -810,7 +814,7 @@ new PerformanceObserver((list) => {
     longTasks.push({
       startTime: entry.startTime,
       duration: entry.duration,
-      // attribution で原因のスクリプトを特定
+      // Use attribution to identify the script responsible
       attribution: entry.attribution?.map(attr => ({
         name: attr.name,
         containerType: attr.containerType,
@@ -829,7 +833,7 @@ new PerformanceObserver((list) => {
   }
 }).observe({ type: 'longtask', buffered: true });
 
-// 一定間隔でサマリーを出力
+// Output a summary at a fixed interval
 setInterval(() => {
   if (longTasks.length === 0) return;
 
@@ -837,22 +841,22 @@ setInterval(() => {
   const avg = total / longTasks.length;
   const max = Math.max(...longTasks.map(t => t.duration));
 
-  console.log(`Long Tasks サマリー:
-    件数: ${longTasks.length}
-    合計: ${total.toFixed(0)}ms
-    平均: ${avg.toFixed(0)}ms
-    最大: ${max.toFixed(0)}ms
+  console.log(`Long Tasks summary:
+    Count: ${longTasks.length}
+    Total: ${total.toFixed(0)}ms
+    Average: ${avg.toFixed(0)}ms
+    Max: ${max.toFixed(0)}ms
   `);
 }, 10000);
 ```
 
 ---
 
-## 6. Core Web Vitals の計測
+## 6. Measuring Core Web Vitals
 
-### 6.1 Core Web Vitals の概要
+### 6.1 Overview of Core Web Vitals
 
-Core Web Vitals は Google が定義した、ユーザー体験の品質を評価する3つの主要指標である。2024年以降、INP（Interaction to Next Paint）が FID（First Input Delay）を正式に置き換えた。
+Core Web Vitals are three key metrics defined by Google for evaluating the quality of user experience. Since 2024, INP (Interaction to Next Paint) has officially replaced FID (First Input Delay).
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -861,87 +865,87 @@ Core Web Vitals は Google が定義した、ユーザー体験の品質を評�
 │                                                                 │
 │  LCP (Largest Contentful Paint)                                │
 │  ┌─────────────────────────────────────────────────────────┐   │
-│  │  ページの主要コンテンツが表示されるまでの時間           │   │
+│  │  Time until the page's main content is displayed        │   │
 │  │                                                         │   │
 │  │  Good        Needs Improvement     Poor                 │   │
 │  │  |<--- 2.5s --->|<--- 4.0s --->|<--- ... --->|         │   │
-│  │  [  緑: 良好  ] [ 黄: 改善必要 ] [  赤: 不良 ]         │   │
+│  │  [ Green: Good ] [ Yellow: Improve ] [ Red: Poor ]      │   │
 │  └─────────────────────────────────────────────────────────┘   │
 │                                                                 │
 │  INP (Interaction to Next Paint)                               │
 │  ┌─────────────────────────────────────────────────────────┐   │
-│  │  ユーザー操作から画面更新までの応答時間                 │   │
+│  │  Response time from user interaction to screen update   │   │
 │  │                                                         │   │
 │  │  Good        Needs Improvement     Poor                 │   │
 │  │  |<--- 200ms --->|<--- 500ms --->|<--- ... --->|       │   │
-│  │  [  緑: 良好  ]  [ 黄: 改善必要 ] [  赤: 不良 ]       │   │
+│  │  [ Green: Good ]  [ Yellow: Improve ] [ Red: Poor ]    │   │
 │  └─────────────────────────────────────────────────────────┘   │
 │                                                                 │
 │  CLS (Cumulative Layout Shift)                                 │
 │  ┌─────────────────────────────────────────────────────────┐   │
-│  │  視覚的な安定性（レイアウトのずれの累積値）             │   │
+│  │  Visual stability (cumulative value of layout shifts)   │   │
 │  │                                                         │   │
 │  │  Good        Needs Improvement     Poor                 │   │
 │  │  |<--- 0.1 --->|<--- 0.25 --->|<--- ... --->|         │   │
-│  │  [ 緑: 良好 ]  [ 黄: 改善必要 ] [ 赤: 不良  ]         │   │
+│  │  [ Green: Good ] [ Yellow: Improve ] [ Red: Poor ]     │   │
 │  └─────────────────────────────────────────────────────────┘   │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### 6.2 web-vitals ライブラリによる計測
+### 6.2 Measurement Using the web-vitals Library
 
-Google が公式に提供する `web-vitals` ライブラリは、Core Web Vitals の計測を標準化された方法で行うための推奨ツールである。
+The `web-vitals` library officially provided by Google is the recommended tool for measuring Core Web Vitals in a standardized way.
 
 ```javascript
 // ==================================================
-// web-vitals ライブラリを使った包括的な計測
+// Comprehensive measurement using the web-vitals library
 // ==================================================
 import { onLCP, onINP, onCLS, onFCP, onTTFB } from 'web-vitals';
 
-// (1) 基本的な使い方
+// (1) Basic usage
 onLCP((metric) => {
   console.log('LCP:', metric.value, 'ms');
-  console.log('  評価:', metric.rating);       // 'good' | 'needs-improvement' | 'poor'
-  console.log('  要素:', metric.entries);       // LCP の対象要素
-  console.log('  delta:', metric.delta, 'ms');  // 前回からの変化量
-  console.log('  ID:', metric.id);              // 一意な識別子
+  console.log('  Rating:', metric.rating);       // 'good' | 'needs-improvement' | 'poor'
+  console.log('  Element:', metric.entries);       // LCP target element
+  console.log('  delta:', metric.delta, 'ms');    // Change since last report
+  console.log('  ID:', metric.id);                // Unique identifier
   console.log('  navigationType:', metric.navigationType);
   sendToAnalytics({ name: 'LCP', ...metric });
 });
 
 onINP((metric) => {
   console.log('INP:', metric.value, 'ms');
-  console.log('  評価:', metric.rating);
-  // INP の entries には最も遅かったインタラクションが含まれる
+  console.log('  Rating:', metric.rating);
+  // INP entries contain the slowest interaction
   const worstEntry = metric.entries[0];
   if (worstEntry) {
-    console.log('  イベント種別:', worstEntry.name);
-    console.log('  処理時間:', worstEntry.processingEnd - worstEntry.processingStart, 'ms');
-    console.log('  入力遅延:', worstEntry.processingStart - worstEntry.startTime, 'ms');
-    console.log('  描画遅延:', worstEntry.startTime + worstEntry.duration - worstEntry.processingEnd, 'ms');
+    console.log('  Event type:', worstEntry.name);
+    console.log('  Processing time:', worstEntry.processingEnd - worstEntry.processingStart, 'ms');
+    console.log('  Input delay:', worstEntry.processingStart - worstEntry.startTime, 'ms');
+    console.log('  Presentation delay:', worstEntry.startTime + worstEntry.duration - worstEntry.processingEnd, 'ms');
   }
   sendToAnalytics({ name: 'INP', ...metric });
 });
 
 onCLS((metric) => {
   console.log('CLS:', metric.value);
-  console.log('  評価:', metric.rating);
-  // CLS の entries にはレイアウトシフトの詳細が含まれる
+  console.log('  Rating:', metric.rating);
+  // CLS entries contain details of each layout shift
   metric.entries.forEach(entry => {
-    console.log('  シフト値:', entry.value);
-    console.log('  最近の入力:', entry.hadRecentInput);
-    // シフトした要素の特定
+    console.log('  Shift value:', entry.value);
+    console.log('  Had recent input:', entry.hadRecentInput);
+    // Identify the shifted element
     entry.sources?.forEach(source => {
-      console.log('  要素:', source.node);
-      console.log('  移動前:', source.previousRect);
-      console.log('  移動後:', source.currentRect);
+      console.log('  Element:', source.node);
+      console.log('  Previous rect:', source.previousRect);
+      console.log('  Current rect:', source.currentRect);
     });
   });
   sendToAnalytics({ name: 'CLS', ...metric });
 });
 
-// (2) 補助指標の計測
+// (2) Measuring supplementary metrics
 onFCP((metric) => {
   console.log('FCP:', metric.value, 'ms');
   sendToAnalytics({ name: 'FCP', ...metric });
@@ -952,7 +956,7 @@ onTTFB((metric) => {
   sendToAnalytics({ name: 'TTFB', ...metric });
 });
 
-// (3) 分析データの送信関数
+// (3) Analytics data sending function
 function sendToAnalytics(data) {
   const payload = JSON.stringify({
     name: data.name,
@@ -963,13 +967,13 @@ function sendToAnalytics(data) {
     navigationType: data.navigationType,
     url: location.href,
     timestamp: Date.now(),
-    // デバイス情報
+    // Device information
     connection: navigator.connection?.effectiveType,
     deviceMemory: navigator.deviceMemory,
     hardwareConcurrency: navigator.hardwareConcurrency,
   });
 
-  // Beacon API で確実に送信
+  // Send reliably via the Beacon API
   if (navigator.sendBeacon) {
     navigator.sendBeacon('/api/web-vitals', payload);
   } else {
@@ -982,17 +986,17 @@ function sendToAnalytics(data) {
 }
 ```
 
-### 6.3 手動での Core Web Vitals 計測
+### 6.3 Manual Core Web Vitals Measurement
 
-web-vitals ライブラリを使わず、PerformanceObserver で直接計測する方法を理解しておくことも重要である。ライブラリの内部動作を把握することで、トラブルシューティングが容易になる。
+It is also important to understand how to measure directly with PerformanceObserver without using the web-vitals library. Understanding the library's internal behavior makes troubleshooting easier.
 
 ```javascript
 // ==================================================
-// PerformanceObserver による手動計測
+// Manual measurement with PerformanceObserver
 // ==================================================
 
-// --- LCP の手動計測 ---
-// LCP は複数回報告される（最後の値が最終的な LCP）
+// --- Manual LCP measurement ---
+// LCP is reported multiple times (the last value is the final LCP)
 let lcpValue = 0;
 let lcpElement = null;
 
@@ -1001,21 +1005,21 @@ new PerformanceObserver((list) => {
   const lastEntry = entries[entries.length - 1];
 
   lcpValue = lastEntry.startTime;
-  lcpElement = lastEntry.element;  // LCP の対象 DOM 要素
+  lcpElement = lastEntry.element;  // LCP target DOM element
 
-  console.log('LCP 候補:', {
+  console.log('LCP candidate:', {
     value: lcpValue.toFixed(0) + 'ms',
     element: lcpElement?.tagName,
-    url: lastEntry.url,           // 画像の場合の URL
-    size: lastEntry.size,         // 要素の面積（ピクセル）
-    loadTime: lastEntry.loadTime, // リソースの読み込み完了時刻
-    renderTime: lastEntry.renderTime, // レンダリング時刻
+    url: lastEntry.url,           // URL in the case of an image
+    size: lastEntry.size,         // Element area (pixels)
+    loadTime: lastEntry.loadTime, // Resource load completion time
+    renderTime: lastEntry.renderTime, // Rendering time
   });
 }).observe({ type: 'largest-contentful-paint', buffered: true });
 
 
-// --- CLS の手動計測 ---
-// CLS は Session Window 方式で計算する
+// --- Manual CLS measurement ---
+// CLS is calculated using the Session Window method
 let clsValue = 0;
 let clsEntries = [];
 let sessionValue = 0;
@@ -1024,18 +1028,18 @@ let previousSessionEnd = 0;
 
 new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
-    // ユーザー入力に起因するシフトは除外
+    // Exclude shifts caused by user input
     if (entry.hadRecentInput) continue;
 
-    // Session Window のルール:
-    // - 1秒以上のギャップがあれば新しいセッション
-    // - セッションの長さは最大5秒
+    // Session Window rules:
+    // - A gap of 1 second or more starts a new session
+    // - A session is at most 5 seconds long
     if (
       sessionEntries.length > 0 &&
       (entry.startTime - previousSessionEnd > 1000 ||
        entry.startTime - sessionEntries[0].startTime > 5000)
     ) {
-      // 新しいセッションの開始
+      // Start a new session
       if (sessionValue > clsValue) {
         clsValue = sessionValue;
         clsEntries = [...sessionEntries];
@@ -1049,7 +1053,7 @@ new PerformanceObserver((list) => {
     previousSessionEnd = entry.startTime + entry.duration;
   }
 
-  // 現在のセッションが最大の場合も更新
+  // Also update if the current session is the largest
   if (sessionValue > clsValue) {
     clsValue = sessionValue;
     clsEntries = [...sessionEntries];
@@ -1059,14 +1063,14 @@ new PerformanceObserver((list) => {
 }).observe({ type: 'layout-shift', buffered: true });
 
 
-// --- INP の手動計測 ---
-// INP は全インタラクションの中で最も遅い応答を基準とする
-// （98パーセンタイル値を使用）
+// --- Manual INP measurement ---
+// INP is based on the slowest response among all interactions
+// (uses the 98th percentile)
 const interactions = [];
 
 new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
-    // interactionId を持つエントリのみがインタラクション
+    // Only entries with an interactionId are interactions
     if (!entry.interactionId) continue;
 
     const existing = interactions.find(
@@ -1074,7 +1078,7 @@ new PerformanceObserver((list) => {
     );
 
     if (existing) {
-      // 同一インタラクションの複数イベントは最大値を採用
+      // For multiple events of the same interaction, use the maximum value
       existing.duration = Math.max(existing.duration, entry.duration);
     } else {
       interactions.push({
@@ -1089,12 +1093,12 @@ new PerformanceObserver((list) => {
     }
   }
 
-  // INP の計算（98パーセンタイル）
+  // Calculate INP (98th percentile)
   if (interactions.length > 0) {
     const sorted = [...interactions].sort(
       (a, b) => b.duration - a.duration
     );
-    // 50件以上のインタラクションがある場合は98パーセンタイル
+    // Use 98th percentile when there are 50 or more interactions
     const index = Math.min(
       sorted.length - 1,
       Math.floor(sorted.length / 50)
@@ -1105,44 +1109,46 @@ new PerformanceObserver((list) => {
 }).observe({ type: 'event', buffered: true, durationThreshold: 16 });
 ```
 
-### 6.4 INP の内部構造と最適化ポイント
+### 6.4 INP Internal Structure and Optimization Points
 
-INP は、ユーザーのインタラクション（クリック、タップ、キー入力）から次の描画更新までの全時間を計測する。この時間は3つのフェーズに分解できる。
+INP measures the total time from a user interaction (click, tap, key press) to the next paint update. This time can be broken down into three phases.
 
 ```
-INP の内訳 (Interaction to Next Paint)
+INP Breakdown (Interaction to Next Paint)
 
-ユーザー操作          描画更新
+User action         Paint update
     |                    |
     v                    v
     +----+----+----+----+
     | ID | PT | PD | ?? |
     +----+----+----+----+
 
-    ID = Input Delay（入力遅延）
-         メインスレッドがビジーで、イベントハンドラの実行開始が遅れる時間
-         原因: Long Task、大量の JavaScript 実行
+    ID = Input Delay
+         Time that the event handler's execution start is delayed
+         because the main thread is busy
+         Cause: Long Tasks, heavy JavaScript execution
 
-    PT = Processing Time（処理時間）
-         イベントハンドラの実行時間
-         原因: 重い計算、同期的な DOM 操作
+    PT = Processing Time
+         Event handler execution time
+         Cause: Heavy computation, synchronous DOM operations
 
-    PD = Presentation Delay（描画遅延）
-         イベントハンドラ完了後、実際に画面が更新されるまでの時間
-         原因: スタイル再計算、レイアウト、ペイント、コンポジット
+    PD = Presentation Delay
+         Time from event handler completion until the screen
+         is actually updated
+         Cause: Style recalculation, layout, paint, composite
 
     ┌──────────────────────────────────────────────────────────┐
     │  INP = ID + PT + PD                                     │
     │                                                         │
-    │  改善の優先順位:                                        │
+    │  Optimization priority:                                 │
     │  1. Input Delay   -> yield to main thread               │
-    │  2. Processing    -> 処理の分割・遅延・最適化           │
-    │  3. Presentation  -> DOM 操作の最小化                    │
+    │  2. Processing    -> split / defer / optimize work      │
+    │  3. Presentation  -> minimize DOM operations            │
     └──────────────────────────────────────────────────────────┘
 ```
 
 ```javascript
-// INP の各フェーズを分解して分析する
+// Analyze each phase of INP separately
 new PerformanceObserver((list) => {
   for (const entry of list.getEntries()) {
     if (!entry.interactionId) continue;
@@ -1153,7 +1159,7 @@ new PerformanceObserver((list) => {
       - entry.processingEnd;
 
     if (entry.duration > 200) {
-      console.warn(`[INP 警告] ${entry.name} on ${entry.target?.tagName}`, {
+      console.warn(`[INP Warning] ${entry.name} on ${entry.target?.tagName}`, {
         total: `${entry.duration}ms`,
         inputDelay: `${inputDelay.toFixed(0)}ms`,
         processingTime: `${processingTime.toFixed(0)}ms`,
@@ -1169,48 +1175,48 @@ new PerformanceObserver((list) => {
 
 ---
 
-## 7. Lighthouse とパフォーマンス監査
+## 7. Lighthouse and Performance Auditing
 
-### 7.1 Lighthouse のスコアリングモデル
+### 7.1 Lighthouse Scoring Model
 
-Lighthouse はパフォーマンスを100点満点で評価する。スコアは複数のメトリクスの加重平均で算出され、各メトリクスは対数正規分布に基づくスコアリングカーブに当てはめられる。
+Lighthouse evaluates performance on a scale of 100. The score is calculated as a weighted average of multiple metrics, and each metric is mapped to a scoring curve based on a log-normal distribution.
 
-| メトリクス                     | 重み  | Good 閾値   | Poor 閾値   |
-|-------------------------------|-------|-------------|-------------|
-| FCP (First Contentful Paint)  | 10%   | 1.8s        | 3.0s        |
-| SI (Speed Index)              | 10%   | 3.4s        | 5.8s        |
-| LCP (Largest Contentful Paint)| 25%   | 2.5s        | 4.0s        |
-| TBT (Total Blocking Time)    | 30%   | 200ms       | 600ms       |
-| CLS (Cumulative Layout Shift) | 25%   | 0.1         | 0.25        |
+| Metric                         | Weight | Good threshold | Poor threshold |
+|-------------------------------|--------|----------------|----------------|
+| FCP (First Contentful Paint)  | 10%    | 1.8s           | 3.0s           |
+| SI (Speed Index)              | 10%    | 3.4s           | 5.8s           |
+| LCP (Largest Contentful Paint)| 25%    | 2.5s           | 4.0s           |
+| TBT (Total Blocking Time)     | 30%    | 200ms          | 600ms          |
+| CLS (Cumulative Layout Shift) | 25%    | 0.1            | 0.25           |
 
-※ TBT は INP のラボ代替指標として使用される。INP はフィールド（実ユーザー）データでのみ計測可能であるため、Lighthouse では TBT がその代替を担う。
+* TBT is used as a lab proxy metric for INP. Because INP can only be measured from field (real user) data, TBT serves as its substitute in Lighthouse.
 
-### 7.2 Lighthouse CI の自動化
+### 7.2 Automating Lighthouse CI
 
 ```javascript
-// lighthouserc.js - Lighthouse CI 設定ファイル
+// lighthouserc.js - Lighthouse CI configuration file
 module.exports = {
   ci: {
     collect: {
-      // 計測対象の URL 一覧
+      // List of URLs to measure
       url: [
         'http://localhost:3000/',
         'http://localhost:3000/products',
         'http://localhost:3000/checkout',
       ],
-      // 計測回数（中央値を採用するため奇数が推奨）
+      // Number of runs (odd number recommended to use the median)
       numberOfRuns: 5,
-      // Chrome の起動オプション
+      // Chrome launch options
       settings: {
         chromeFlags: '--no-sandbox --headless',
-        // スロットリング設定（モバイル 4G 相当）
+        // Throttling settings (equivalent to mobile 4G)
         throttling: {
           cpuSlowdownMultiplier: 4,
           downloadThroughputKbps: 1600,
           uploadThroughputKbps: 750,
           rttMs: 150,
         },
-        // フォームファクター
+        // Form factor
         formFactor: 'mobile',
         screenEmulation: {
           mobile: true,
@@ -1221,18 +1227,18 @@ module.exports = {
       },
     },
     assert: {
-      // パフォーマンスバジェット
+      // Performance budget
       assertions: {
         'categories:performance': ['error', { minScore: 0.9 }],
         'categories:accessibility': ['warn', { minScore: 0.9 }],
         'categories:best-practices': ['warn', { minScore: 0.9 }],
-        // 個別メトリクスの閾値
+        // Individual metric thresholds
         'first-contentful-paint': ['error', { maxNumericValue: 1800 }],
         'largest-contentful-paint': ['error', { maxNumericValue: 2500 }],
         'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
         'total-blocking-time': ['error', { maxNumericValue: 200 }],
         'speed-index': ['warn', { maxNumericValue: 3400 }],
-        // リソースサイズの制限
+        // Resource size limits
         'resource-summary:script:size': [
           'error', { maxNumericValue: 300 * 1024 },  // 300KB
         ],
@@ -1242,7 +1248,7 @@ module.exports = {
       },
     },
     upload: {
-      // Lighthouse CI Server にアップロード
+      // Upload to Lighthouse CI Server
       target: 'lhci',
       serverBaseUrl: 'https://lhci.example.com',
       token: process.env.LHCI_TOKEN,
@@ -1251,7 +1257,7 @@ module.exports = {
 };
 ```
 
-### 7.3 GitHub Actions での Lighthouse CI 統合
+### 7.3 Integrating Lighthouse CI with GitHub Actions
 
 ```yaml
 # .github/workflows/lighthouse.yml
@@ -1302,15 +1308,15 @@ jobs:
           path: .lighthouseci/
 ```
 
-### 7.4 Lighthouse のプログラマティック実行
+### 7.4 Programmatic Lighthouse Execution
 
 ```javascript
-// Node.js で Lighthouse をプログラマティックに実行する
+// Run Lighthouse programmatically in Node.js
 import lighthouse from 'lighthouse';
 import * as chromeLauncher from 'chrome-launcher';
 
 async function runLighthouse(url, options = {}) {
-  // Chrome を起動
+  // Launch Chrome
   const chrome = await chromeLauncher.launch({
     chromeFlags: ['--headless', '--no-sandbox'],
   });
@@ -1320,7 +1326,7 @@ async function runLighthouse(url, options = {}) {
     output: 'json',
     port: chrome.port,
     onlyCategories: ['performance'],
-    // カスタムスロットリング設定
+    // Custom throttling settings
     throttling: {
       cpuSlowdownMultiplier: 4,
       downloadThroughputKbps: 1600,
@@ -1334,7 +1340,7 @@ async function runLighthouse(url, options = {}) {
   try {
     const result = await lighthouse(url, mergedOptions);
 
-    // スコアと各メトリクスの取得
+    // Retrieve scores and individual metrics
     const { lhr } = result;
     const perfScore = lhr.categories.performance.score * 100;
 
@@ -1351,7 +1357,7 @@ async function runLighthouse(url, options = {}) {
     console.log(`Performance Score: ${perfScore}/100`);
     console.table(metrics);
 
-    // 改善提案の取得
+    // Retrieve improvement suggestions
     const opportunities = Object.values(lhr.audits)
       .filter(audit => audit.details?.type === 'opportunity')
       .filter(audit => audit.details?.overallSavingsMs > 0)
@@ -1364,9 +1370,9 @@ async function runLighthouse(url, options = {}) {
         description: audit.description,
       }));
 
-    console.log('改善提案:');
+    console.log('Improvement suggestions:');
     opportunities.forEach((opp, i) => {
-      console.log(`  ${i + 1}. ${opp.title} (${opp.savings} 削減可能)`);
+      console.log(`  ${i + 1}. ${opp.title} (saves ${opp.savings})`);
     });
 
     return { metrics, opportunities, fullReport: lhr };
@@ -1375,35 +1381,35 @@ async function runLighthouse(url, options = {}) {
   }
 }
 
-// 使用例
+// Usage example
 const result = await runLighthouse('https://example.com');
 ```
 
 ---
 
-## 8. パフォーマンスデータの送信と分析基盤
+## 8. Sending Performance Data and Building an Analytics Foundation
 
-### 8.1 Beacon API と fetch keepalive
+### 8.1 Beacon API and fetch keepalive
 
-パフォーマンスデータの送信で最も重要なのは、ページ離脱時にもデータが失われないことである。Beacon API と `fetch` の `keepalive` オプションは、この要件を満たすために設計されている。
+The most important aspect of sending performance data is that data is not lost even when the user navigates away from the page. The Beacon API and the `keepalive` option for `fetch` are designed to meet this requirement.
 
 ```javascript
 // ==================================================
-// パフォーマンスデータ送信の実装パターン
+// Implementation patterns for sending performance data
 // ==================================================
 
 class PerformanceReporter {
   constructor(endpoint) {
     this.endpoint = endpoint;
     this.buffer = [];
-    this.flushInterval = 10000; // 10秒ごとにバッファをフラッシュ
-    this.maxBufferSize = 50;    // バッファの最大件数
+    this.flushInterval = 10000; // Flush buffer every 10 seconds
+    this.maxBufferSize = 50;    // Maximum number of items in the buffer
 
     this._setupAutoFlush();
     this._setupUnloadHandler();
   }
 
-  // メトリクスをバッファに追加
+  // Add a metric to the buffer
   record(metric) {
     this.buffer.push({
       ...metric,
@@ -1414,26 +1420,26 @@ class PerformanceReporter {
       deviceMemory: navigator.deviceMemory || 'unknown',
     });
 
-    // バッファが上限に達したら即時フラッシュ
+    // Flush immediately if the buffer reaches its limit
     if (this.buffer.length >= this.maxBufferSize) {
       this.flush();
     }
   }
 
-  // バッファの内容を送信
+  // Send the buffer contents
   flush() {
     if (this.buffer.length === 0) return;
 
     const payload = JSON.stringify(this.buffer);
     this.buffer = [];
 
-    // Beacon API を優先使用
+    // Prefer using the Beacon API
     if (navigator.sendBeacon) {
       const blob = new Blob([payload], { type: 'application/json' });
       const success = navigator.sendBeacon(this.endpoint, blob);
 
       if (!success) {
-        // Beacon API が失敗した場合のフォールバック
+        // Fallback if the Beacon API fails
         this._fetchFallback(payload);
       }
       return;
@@ -1447,9 +1453,9 @@ class PerformanceReporter {
       method: 'POST',
       body: payload,
       headers: { 'Content-Type': 'application/json' },
-      keepalive: true,  // ページ離脱後も送信を継続
+      keepalive: true,  // Continue sending even after the page is unloaded
     }).catch(err => {
-      console.warn('パフォーマンスデータの送信に失敗:', err);
+      console.warn('Failed to send performance data:', err);
     });
   }
 
@@ -1458,7 +1464,7 @@ class PerformanceReporter {
   }
 
   _setupUnloadHandler() {
-    // visibilitychange は unload/beforeunload より確実
+    // visibilitychange is more reliable than unload/beforeunload
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         this.flush();
@@ -1467,10 +1473,10 @@ class PerformanceReporter {
   }
 }
 
-// 使用例
+// Usage example
 const reporter = new PerformanceReporter('/api/performance');
 
-// web-vitals と統合
+// Integrate with web-vitals
 import { onLCP, onINP, onCLS } from 'web-vitals';
 
 onLCP(metric => reporter.record({ name: 'LCP', value: metric.value, rating: metric.rating }));
@@ -1478,13 +1484,13 @@ onINP(metric => reporter.record({ name: 'INP', value: metric.value, rating: metr
 onCLS(metric => reporter.record({ name: 'CLS', value: metric.value, rating: metric.rating }));
 ```
 
-### 8.2 RUM（Real User Monitoring）の構築
+### 8.2 Building RUM (Real User Monitoring)
 
-RUM は、実際のユーザー環境でのパフォーマンスデータを収集・分析する仕組みである。合成モニタリング（Lighthouse 等）では再現できない、多様なデバイス・ネットワーク環境のパフォーマンスを把握できる。
+RUM is a mechanism for collecting and analyzing performance data from actual user environments. It allows you to understand performance across diverse device and network environments that cannot be reproduced by synthetic monitoring (such as Lighthouse).
 
 ```javascript
 // ==================================================
-// RUM データ収集の包括的な実装
+// Comprehensive implementation of RUM data collection
 // ==================================================
 class RUMCollector {
   constructor(config) {
@@ -1495,7 +1501,7 @@ class RUMCollector {
       environment: config.environment || 'production',
     };
 
-    // サンプリング判定
+    // Sampling decision
     this.shouldCollect = Math.random() < this.config.sampleRate;
 
     if (this.shouldCollect) {
@@ -1512,7 +1518,7 @@ class RUMCollector {
   }
 
   _collectNavigationTiming() {
-    // ページ読み込み完了後に計測
+    // Measure after page load completes
     window.addEventListener('load', () => {
       setTimeout(() => {
         const nav = performance.getEntriesByType('navigation')[0];
@@ -1534,7 +1540,7 @@ class RUMCollector {
   }
 
   _collectWebVitals() {
-    // 動的インポートで web-vitals を読み込み
+    // Load web-vitals via dynamic import
     import('web-vitals').then(({ onLCP, onINP, onCLS, onFCP, onTTFB }) => {
       onLCP(m => this._send('vital', { name: 'LCP', value: m.value, rating: m.rating }));
       onINP(m => this._send('vital', { name: 'INP', value: m.value, rating: m.rating }));
@@ -1547,7 +1553,7 @@ class RUMCollector {
   _collectResourceTiming() {
     new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
-        // 遅いリソースのみ報告（閾値: 2秒）
+        // Report only slow resources (threshold: 2 seconds)
         if (entry.duration > 2000) {
           this._send('slow-resource', {
             url: entry.name,
@@ -1644,10 +1650,10 @@ class RUMCollector {
   }
 }
 
-// 初期化
+// Initialization
 const rum = new RUMCollector({
   endpoint: '/api/rum',
-  sampleRate: 0.1,  // 10% のユーザーからデータ収集
+  sampleRate: 0.1,  // Collect data from 10% of users
   appVersion: '2.3.1',
   environment: 'production',
 });
@@ -1655,50 +1661,50 @@ const rum = new RUMCollector({
 
 ---
 
-## 9. パフォーマンスバジェットと CI 統合
+## 9. Performance Budgets and CI Integration
 
-### 9.1 パフォーマンスバジェットの設計
+### 9.1 Designing a Performance Budget
 
-パフォーマンスバジェットとは、Web アプリケーションが達成すべきパフォーマンス目標を定量的に定義したものである。チーム全体で共有し、CI/CD パイプラインで自動検証することで、パフォーマンスの退行を防ぐ。
+A performance budget is a quantitative definition of the performance goals that a web application should achieve. By sharing it across the team and automatically validating it in a CI/CD pipeline, you can prevent performance regressions.
 
 ```
 ┌───────────────────────────────────────────────────────────────┐
-│            パフォーマンスバジェットの設計フロー               │
+│           Performance Budget Design Flow                      │
 ├───────────────────────────────────────────────────────────────┤
 │                                                               │
-│  1. 競合分析                                                  │
-│     ├── 競合サイトの Core Web Vitals を調査                  │
-│     ├── CrUX（Chrome UX Report）データを参照                 │
-│     └── 業界平均との比較                                     │
+│  1. Competitive Analysis                                      │
+│     ├── Research Core Web Vitals of competing sites          │
+│     ├── Reference CrUX (Chrome UX Report) data               │
+│     └── Compare against industry averages                    │
 │                                                               │
-│  2. 目標設定                                                  │
-│     ├── Core Web Vitals の閾値                               │
-│     ├── リソースサイズの上限                                  │
-│     ├── リクエスト数の上限                                    │
-│     └── Time to Interactive の目標値                          │
+│  2. Goal Setting                                              │
+│     ├── Core Web Vitals thresholds                           │
+│     ├── Resource size limits                                  │
+│     ├── Request count limits                                  │
+│     └── Time to Interactive target values                     │
 │                                                               │
-│  3. 自動検証                                                  │
-│     ├── bundlesize / size-limit によるバンドル監視            │
-│     ├── Lighthouse CI によるスコア監視                        │
-│     └── PR コメントでの差分レポート                           │
+│  3. Automated Validation                                      │
+│     ├── Bundle monitoring with bundlesize / size-limit        │
+│     ├── Score monitoring with Lighthouse CI                   │
+│     └── Diff reports as PR comments                          │
 │                                                               │
-│  4. 継続的改善                                                │
-│     ├── 週次のパフォーマンスレビュー                          │
-│     ├── バジェット超過時のアラート                            │
-│     └── 改善施策の優先順位付け                                │
+│  4. Continuous Improvement                                    │
+│     ├── Weekly performance reviews                            │
+│     ├── Alerts when budgets are exceeded                      │
+│     └── Prioritization of improvement initiatives             │
 │                                                               │
 └───────────────────────────────────────────────────────────────┘
 ```
 
-### 9.2 size-limit によるバンドルサイズ監視
+### 9.2 Bundle Size Monitoring with size-limit
 
 ```javascript
-// package.json に size-limit の設定を追加
-// package.json (抜粋)
+// Add size-limit configuration to package.json
+// package.json (excerpt)
 {
   "size-limit": [
     {
-      "name": "メインバンドル",
+      "name": "Main bundle",
       "path": "dist/assets/index-*.js",
       "limit": "150 kB",
       "gzip": true
@@ -1710,13 +1716,13 @@ const rum = new RUMCollector({
       "gzip": true
     },
     {
-      "name": "ベンダーバンドル",
+      "name": "Vendor bundle",
       "path": "dist/assets/vendor-*.js",
       "limit": "200 kB",
       "gzip": true
     },
     {
-      "name": "初期読み込み合計",
+      "name": "Initial load total",
       "path": [
         "dist/assets/index-*.js",
         "dist/assets/index-*.css",
@@ -1733,15 +1739,15 @@ const rum = new RUMCollector({
 }
 ```
 
-### 9.3 カスタムパフォーマンスバジェットチェッカー
+### 9.3 Custom Performance Budget Checker
 
 ```javascript
 // ==================================================
-// パフォーマンスバジェットの定義と検証
+// Performance budget definition and validation
 // ==================================================
 
 const PERFORMANCE_BUDGETS = {
-  // Core Web Vitals バジェット
+  // Core Web Vitals budget
   vitals: {
     LCP: { good: 2500, poor: 4000, unit: 'ms' },
     INP: { good: 200, poor: 500, unit: 'ms' },
@@ -1750,7 +1756,7 @@ const PERFORMANCE_BUDGETS = {
     TTFB: { good: 800, poor: 1800, unit: 'ms' },
   },
 
-  // リソースバジェット
+  // Resource budget
   resources: {
     totalTransferSize: 1500 * 1024,   // 1.5MB
     totalRequests: 80,
@@ -1760,7 +1766,7 @@ const PERFORMANCE_BUDGETS = {
     thirdPartySize: 200 * 1024,       // 200KB
   },
 
-  // タイミングバジェット
+  // Timing budget
   timing: {
     domContentLoaded: 3000,  // ms
     loadComplete: 5000,      // ms
@@ -1771,7 +1777,7 @@ const PERFORMANCE_BUDGETS = {
 function checkBudgets(collectedData) {
   const violations = [];
 
-  // Core Web Vitals のチェック
+  // Check Core Web Vitals
   for (const [name, budget] of Object.entries(PERFORMANCE_BUDGETS.vitals)) {
     const value = collectedData.vitals?.[name];
     if (value === undefined) continue;
@@ -1782,7 +1788,7 @@ function checkBudgets(collectedData) {
         metric: name,
         value: `${value}${budget.unit}`,
         budget: `${budget.poor}${budget.unit}`,
-        message: `${name} が不良閾値（${budget.poor}${budget.unit}）を超過`,
+        message: `${name} exceeds the poor threshold (${budget.poor}${budget.unit})`,
       });
     } else if (value > budget.good) {
       violations.push({
@@ -1790,12 +1796,12 @@ function checkBudgets(collectedData) {
         metric: name,
         value: `${value}${budget.unit}`,
         budget: `${budget.good}${budget.unit}`,
-        message: `${name} が良好閾値（${budget.good}${budget.unit}）を超過`,
+        message: `${name} exceeds the good threshold (${budget.good}${budget.unit})`,
       });
     }
   }
 
-  // リソースバジェットのチェック
+  // Check resource budget
   const resources = performance.getEntriesByType('resource');
   const totalSize = resources.reduce((sum, r) => sum + r.transferSize, 0);
   const totalRequests = resources.length;
@@ -1806,7 +1812,7 @@ function checkBudgets(collectedData) {
       metric: 'Total Transfer Size',
       value: `${(totalSize / 1024).toFixed(0)}KB`,
       budget: `${(PERFORMANCE_BUDGETS.resources.totalTransferSize / 1024).toFixed(0)}KB`,
-      message: '合計転送サイズがバジェットを超過',
+      message: 'Total transfer size exceeds the budget',
     });
   }
 
@@ -1816,7 +1822,7 @@ function checkBudgets(collectedData) {
       metric: 'Total Requests',
       value: totalRequests,
       budget: PERFORMANCE_BUDGETS.resources.totalRequests,
-      message: 'リクエスト数がバジェットを超過',
+      message: 'Request count exceeds the budget',
     });
   }
 
@@ -1826,35 +1832,35 @@ function checkBudgets(collectedData) {
 
 ---
 
-## 10. アンチパターンと回避策
+## 10. Anti-patterns and Workarounds
 
-### 10.1 アンチパターン1: performance.getEntries() のポーリング
+### 10.1 Anti-pattern 1: Polling performance.getEntries()
 
-**問題**: `setInterval` で定期的に `performance.getEntries()` を呼び出してパフォーマンスデータを収集するパターン。これはメインスレッドに不必要な負荷をかけ、エントリの重複処理やタイミングの取りこぼしを引き起こす。
+**Problem**: A pattern of periodically calling `performance.getEntries()` with `setInterval` to collect performance data. This places unnecessary load on the main thread and causes duplicate processing of entries and missed timing data.
 
 ```javascript
 // ============================================================
-// アンチパターン: ポーリングによるエントリ収集
+// Anti-pattern: Collecting entries by polling
 // ============================================================
 
-// --- 悪い例 ---
-// setInterval でポーリングする
+// --- Bad example ---
+// Poll using setInterval
 setInterval(() => {
   const entries = performance.getEntries();
   entries.forEach(entry => {
-    // 問題1: 毎回全エントリを取得するため、既に処理済みのエントリも再処理される
-    // 問題2: getEntries() の呼び出しコストがエントリ数に比例して増大
-    // 問題3: ポーリング間隔の間に発生したエントリを見逃す可能性がある
-    // 問題4: バッファが一杯になると古いエントリが消えるが、検知できない
+    // Problem 1: Retrieves all entries each time, so already-processed entries are re-processed
+    // Problem 2: The cost of getEntries() grows proportionally to the number of entries
+    // Problem 3: Entries that occur between polling intervals may be missed
+    // Problem 4: When the buffer is full, old entries disappear without being detected
     processEntry(entry);
   });
 }, 5000);
 
 
-// --- 良い例 ---
-// PerformanceObserver を使用する
+// --- Good example ---
+// Use PerformanceObserver
 const observer = new PerformanceObserver((list) => {
-  // 新しいエントリのみがコールバックに渡される（重複なし）
+  // Only new entries are passed to the callback (no duplicates)
   for (const entry of list.getEntries()) {
     processEntry(entry);
   }
@@ -1862,42 +1868,42 @@ const observer = new PerformanceObserver((list) => {
 
 observer.observe({
   type: 'resource',
-  buffered: true,  // 過去のエントリも初回に取得
+  buffered: true,  // Also retrieve past entries on first call
 });
 
-// 利点:
-// - イベント駆動で効率的（ポーリング不要）
-// - 新しいエントリのみが通知される（重複処理なし）
-// - buffered: true で過去のエントリも取りこぼさない
-// - バッファオーバーフローの検知が可能（droppedEntriesCount）
+// Benefits:
+// - Event-driven and efficient (no polling needed)
+// - Only new entries are notified (no duplicate processing)
+// - buffered: true prevents missing past entries
+// - Buffer overflow can be detected (droppedEntriesCount)
 ```
 
-### 10.2 アンチパターン2: Core Web Vitals の誤った解釈
+### 10.2 Anti-pattern 2: Misinterpreting Core Web Vitals
 
-**問題**: ラボデータ（Lighthouse）とフィールドデータ（RUM/CrUX）の違いを理解せず、Lighthouse のスコアだけでパフォーマンスを判断するパターン。
+**Problem**: Judging performance solely by the Lighthouse score without understanding the difference between lab data (Lighthouse) and field data (RUM/CrUX).
 
 ```javascript
 // ============================================================
-// アンチパターン: Lighthouse スコアのみに依存する
+// Anti-pattern: Relying only on the Lighthouse score
 // ============================================================
 
-// --- 悪い例 ---
-// Lighthouse で100点を目指して最適化し、それで完了と考える
+// --- Bad example ---
+// Optimize to achieve 100 in Lighthouse and consider it complete
 //
-// 問題1: Lighthouse は固定環境（特定のスロットリング設定）での計測であり、
-//         実ユーザーの多様な環境を反映しない
-// 問題2: TBT はラボ指標であり、フィールドの INP とは異なる
-// 問題3: Lighthouse は初回読み込みのみ計測し、SPA のページ遷移は計測しない
-// 問題4: サーバーのレスポンス時間やネットワーク品質の変動を反映しない
+// Problem 1: Lighthouse measures in a fixed environment (specific throttling settings)
+//             and does not reflect the diverse environments of real users
+// Problem 2: TBT is a lab metric and differs from field INP
+// Problem 3: Lighthouse only measures initial load; it does not measure SPA page transitions
+// Problem 4: It does not reflect variation in server response times or network quality
 
-// --- 良い例 ---
-// ラボデータとフィールドデータの両方を活用する
+// --- Good example ---
+// Use both lab data and field data
 
-// 1. Lighthouse（ラボ）: 開発中の退行検知に使用
-//    - CI で自動実行し、スコアの低下を検知
-//    - 改善提案（Opportunities）を開発タスクに変換
+// 1. Lighthouse (lab): Use for detecting regressions during development
+//    - Run automatically in CI to detect score drops
+//    - Convert improvement suggestions (Opportunities) to development tasks
 
-// 2. CrUX（フィールド）: 実ユーザーのパフォーマンスを把握
+// 2. CrUX (field): Understand performance for real users
 async function fetchCrUXData(origin) {
   const response = await fetch(
     `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=${API_KEY}`,
@@ -1918,52 +1924,52 @@ async function fetchCrUXData(origin) {
   return data.record?.metrics;
 }
 
-// 3. 自前 RUM: 細粒度のフィールドデータを収集
-//    - ページ別・ルート別のメトリクス
-//    - ユーザーセグメント別の分析
-//    - パフォーマンスとビジネス指標の相関分析
+// 3. Your own RUM: Collect fine-grained field data
+//    - Metrics by page and route
+//    - Analysis by user segment
+//    - Correlation analysis between performance and business metrics
 ```
 
-### 10.3 アンチパターン3: パフォーマンスバッファの枯渇
+### 10.3 Anti-pattern 3: Exhausting the Performance Buffer
 
-**問題**: `performance.setResourceTimingBufferSize()` を考慮せず、大量のリソースを読み込むアプリケーションでエントリが消失するパターン。
+**Problem**: A pattern where entries are lost in applications that load a large number of resources without considering `performance.setResourceTimingBufferSize()`.
 
 ```javascript
 // ============================================================
-// アンチパターン: バッファサイズの未管理
+// Anti-pattern: Unmanaged buffer size
 // ============================================================
 
-// --- 悪い例 ---
-// デフォルトのバッファサイズ（通常250）で運用し、
-// SPA で多数のリソースを読み込むとエントリが消失する
+// --- Bad example ---
+// Operating with the default buffer size (typically 250),
+// entries disappear in SPAs that load many resources
 
-// --- 良い例 ---
-// バッファサイズを管理する
+// --- Good example ---
+// Manage the buffer size
 performance.setResourceTimingBufferSize(500);
 
-// バッファフルイベントを監視
+// Monitor the buffer-full event
 performance.addEventListener('resourcetimingbufferfull', () => {
-  // 現在のエントリを退避
+  // Save the current entries
   const entries = performance.getEntriesByType('resource');
   archiveResourceEntries(entries);
 
-  // バッファをクリアして新しいエントリを受け入れる
+  // Clear the buffer to accept new entries
   performance.clearResourceTimings();
 
   console.warn(
-    `Resource Timing バッファが一杯になりました。` +
-    `${entries.length}件のエントリをアーカイブしました。`
+    `Resource Timing buffer is full. ` +
+    `Archived ${entries.length} entries.`
   );
 });
 
-// PerformanceObserver の droppedEntriesCount も活用
+// Also use droppedEntriesCount from PerformanceObserver
 new PerformanceObserver((list, observer) => {
   const entries = list.getEntries();
 
-  // ドロップされたエントリ数の確認
+  // Check the number of dropped entries
   if (observer.droppedEntriesCount && observer.droppedEntriesCount > 0) {
     console.warn(
-      `${observer.droppedEntriesCount}件のエントリがドロップされました`
+      `${observer.droppedEntriesCount} entries were dropped`
     );
   }
 
@@ -1973,78 +1979,78 @@ new PerformanceObserver((list, observer) => {
 
 ---
 
-## 11. エッジケース分析
+## 11. Edge Case Analysis
 
-### 11.1 エッジケース1: bfcache（Back/Forward Cache）とパフォーマンス計測
+### 11.1 Edge Case 1: bfcache (Back/Forward Cache) and Performance Measurement
 
-bfcache は、ブラウザの「戻る」「進む」操作時にページの状態をメモリ上にそのまま保持する仕組みである。bfcache から復元されたページでは、通常のページ読み込みイベント（`load`、`DOMContentLoaded`）が発火しないため、パフォーマンス計測に特別な配慮が必要になる。
+bfcache is a mechanism that keeps the page state in memory as-is during browser back/forward navigation. Pages restored from bfcache do not fire the normal page load events (`load`, `DOMContentLoaded`), so performance measurement requires special consideration.
 
 ```javascript
 // ==================================================
-// bfcache 対応のパフォーマンス計測
+// Performance measurement compatible with bfcache
 // ==================================================
 
-// bfcache からの復元を検知
+// Detect restoration from bfcache
 window.addEventListener('pageshow', (event) => {
   if (event.persisted) {
-    // bfcache から復元された
-    console.log('bfcache から復元されました');
+    // Restored from bfcache
+    console.log('Restored from bfcache');
 
-    // Navigation Timing は新しいエントリが記録されない
-    // -> 復元時刻のみを手動で記録する
+    // Navigation Timing will not record a new entry
+    // -> Manually record only the restoration time
     performance.mark('bfcache-restore', {
       detail: { timestamp: event.timeStamp },
     });
 
-    // web-vitals ライブラリは bfcache 復元後の計測を
-    // 自動的に処理するが、カスタム計測は再初期化が必要
+    // The web-vitals library automatically handles measurement
+    // after bfcache restoration, but custom measurements need re-initialization
     reinitializeCustomMetrics();
   }
 });
 
-// bfcache 対応のページ離脱処理
-// 注意: 'unload' イベントハンドラは bfcache を無効化する
-// 代わりに 'pagehide' または 'visibilitychange' を使用する
+// Page unload handling compatible with bfcache
+// Note: 'unload' event handlers disable bfcache
+// Use 'pagehide' or 'visibilitychange' instead
 
-// --- 悪い例（bfcache を阻害）---
+// --- Bad example (blocks bfcache) ---
 window.addEventListener('unload', () => {
-  sendFinalMetrics();  // この処理のせいで bfcache が使えなくなる
+  sendFinalMetrics();  // This processing prevents bfcache from being used
 });
 
-// --- 良い例（bfcache 互換）---
+// --- Good example (bfcache-compatible) ---
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'hidden') {
     sendFinalMetrics();
   }
 });
 
-// bfcache の適格性を確認する（Chrome DevTools API）
-// DevTools > Application > Back/forward cache で確認可能
+// Check bfcache eligibility (Chrome DevTools API)
+// Verify in DevTools > Application > Back/forward cache
 
-// プログラマティックに bfcache ブロッカーを検出
+// Detect bfcache blockers programmatically
 function checkBfcacheBlockers() {
   const issues = [];
 
-  // unload イベントリスナーの検出
-  // （直接検出する API はないが、自分で管理する）
+  // Detecting unload event listeners
+  // (No direct detection API; manage these yourself)
 
-  // Cache-Control: no-store は bfcache を阻害する
-  // -> Cache-Control: no-cache を使用する
+  // Cache-Control: no-store blocks bfcache
+  // -> Use Cache-Control: no-cache instead
 
-  // WebSocket 接続中は bfcache が効かない
-  // -> pagehide でクローズし、pageshow で再接続する
+  // Active WebSocket connections prevent bfcache
+  // -> Close on pagehide and reconnect on pageshow
 
   return issues;
 }
 ```
 
-### 11.2 エッジケース2: Service Worker 経由のリソース計測
+### 11.2 Edge Case 2: Measuring Resources via Service Worker
 
-Service Worker がリソースのリクエストをインターセプトする場合、Resource Timing のタイミング値に Service Worker の処理時間が含まれる。これにより、ネットワーク時間と Service Worker 処理時間を区別して分析する必要がある。
+When a Service Worker intercepts resource requests, the Resource Timing values include the Service Worker's processing time. This makes it necessary to distinguish between network time and Service Worker processing time in analysis.
 
 ```javascript
 // ==================================================
-// Service Worker 経由のリソース計測
+// Measuring resources via Service Worker
 // ==================================================
 
 function analyzeServiceWorkerImpact() {
@@ -2061,26 +2067,26 @@ function analyzeServiceWorkerImpact() {
 
     if (isFromSW) {
       console.log(`[SW] ${new URL(entry.name).pathname}`, {
-        // Service Worker の起動時間
+        // Service Worker startup time
         swStartup: entry.workerStart > 0
           ? `${(entry.fetchStart - entry.workerStart).toFixed(0)}ms`
           : 'N/A',
-        // Service Worker 内の処理時間
+        // Processing time inside the Service Worker
         swProcessing: `${swProcessing.toFixed(0)}ms`,
-        // ネットワークリクエスト時間（SW がネットワークにフォールバックした場合）
+        // Network request time (when SW falls back to the network)
         networkTime: isFromCache
           ? '0ms (cached)'
           : `${(entry.responseEnd - entry.fetchStart).toFixed(0)}ms`,
-        // 合計時間
+        // Total time
         total: `${entry.duration.toFixed(0)}ms`,
-        // キャッシュ状態の推定
+        // Estimated cache state
         cacheStrategy: isFromCache ? 'cache-first' : 'network-first',
       });
     }
   });
 }
 
-// Service Worker のキャッシュ戦略別のパフォーマンス比較
+// Compare performance by Service Worker cache strategy
 function compareSwCacheStrategies() {
   const resources = performance.getEntriesByType('resource');
 
@@ -2118,13 +2124,13 @@ function compareSwCacheStrategies() {
 }
 ```
 
-### 11.3 エッジケース3: SPA（Single Page Application）でのルート遷移計測
+### 11.3 Edge Case 3: Measuring Route Transitions in SPAs (Single Page Applications)
 
-SPA ではページ全体のリロードが発生しないため、Navigation Timing は初回読み込み時のみ有効である。クライアントサイドルーティングによるページ遷移は、User Timing を用いて手動で計測する必要がある。
+Because SPAs do not perform a full page reload, Navigation Timing is only valid for the initial load. Client-side routing page transitions must be measured manually using User Timing.
 
 ```javascript
 // ==================================================
-// SPA ルート遷移のパフォーマンス計測
+// Performance measurement for SPA route transitions
 // ==================================================
 
 class SPANavigationTracker {
@@ -2135,7 +2141,7 @@ class SPANavigationTracker {
   }
 
   _setupHistoryInterception() {
-    // history.pushState / replaceState をインターセプト
+    // Intercept history.pushState / replaceState
     const originalPushState = history.pushState.bind(history);
     const originalReplaceState = history.replaceState.bind(history);
 
@@ -2148,7 +2154,7 @@ class SPANavigationTracker {
       originalReplaceState(...args);
     };
 
-    // popstate（ブラウザの戻る/進む）
+    // popstate (browser back/forward)
     window.addEventListener('popstate', () => {
       this._onNavigationStart(location.pathname);
     });
@@ -2169,8 +2175,8 @@ class SPANavigationTracker {
       startTime: performance.now(),
     };
 
-    // 次のフレーム描画を待って完了とする
-    // (requestAnimationFrame 2回で描画完了を推定)
+    // Wait for the next frame to render and treat it as complete
+    // (estimate paint completion with 2 requestAnimationFrame calls)
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         this._onNavigationEnd();
@@ -2203,7 +2209,7 @@ class SPANavigationTracker {
     return result;
   }
 
-  // 統計情報の取得
+  // Retrieve statistics
   getStats() {
     if (this.navigations.length === 0) return null;
 
@@ -2223,46 +2229,46 @@ const spaTracker = new SPANavigationTracker();
 
 ---
 
-## 12. 段階別演習
+## 12. Tiered Exercises
 
-### 12.1 演習1: 初級 - ページ読み込みレポートの作成
+### 12.1 Exercise 1: Beginner - Creating a Page Load Report
 
-**目標**: Navigation Timing API を使って、現在のページの読み込みパフォーマンスをコンソールに表形式で出力する。
+**Goal**: Use the Navigation Timing API to output the load performance of the current page in tabular form to the console.
 
-**要件**:
-1. DNS 解決、TCP 接続、TTFB、ダウンロード、DOM 処理の各時間を計測する
-2. 結果を `console.table()` で見やすく表示する
-3. TTFB が 800ms を超えている場合は警告を表示する
+**Requirements**:
+1. Measure the time for each phase: DNS resolution, TCP connection, TTFB, download, and DOM processing
+2. Display the results in a readable format using `console.table()`
+3. Display a warning if TTFB exceeds 800ms
 
 ```javascript
 // ==================================================
-// 演習1: 解答例
+// Exercise 1: Sample solution
 // ==================================================
 
 function generateLoadingReport() {
   const nav = performance.getEntriesByType('navigation')[0];
   if (!nav) {
-    console.error('Navigation Timing データが取得できません');
+    console.error('Navigation Timing data could not be retrieved');
     return;
   }
 
   const report = {
-    'DNS 解決': { value: nav.domainLookupEnd - nav.domainLookupStart, unit: 'ms' },
-    'TCP 接続': { value: nav.connectEnd - nav.connectStart, unit: 'ms' },
-    'TLS ハンドシェイク': {
+    'DNS Resolution': { value: nav.domainLookupEnd - nav.domainLookupStart, unit: 'ms' },
+    'TCP Connection': { value: nav.connectEnd - nav.connectStart, unit: 'ms' },
+    'TLS Handshake': {
       value: nav.secureConnectionStart > 0
         ? nav.connectEnd - nav.secureConnectionStart : 0,
       unit: 'ms',
     },
     'TTFB': { value: nav.responseStart - nav.requestStart, unit: 'ms' },
-    'ダウンロード': { value: nav.responseEnd - nav.responseStart, unit: 'ms' },
-    'DOM 処理': { value: nav.domContentLoadedEventEnd - nav.responseEnd, unit: 'ms' },
-    '合計読み込み時間': { value: nav.loadEventEnd - nav.startTime, unit: 'ms' },
-    'プロトコル': { value: nav.nextHopProtocol, unit: '' },
-    '転送サイズ': { value: (nav.transferSize / 1024).toFixed(1), unit: 'KB' },
+    'Download': { value: nav.responseEnd - nav.responseStart, unit: 'ms' },
+    'DOM Processing': { value: nav.domContentLoadedEventEnd - nav.responseEnd, unit: 'ms' },
+    'Total Load Time': { value: nav.loadEventEnd - nav.startTime, unit: 'ms' },
+    'Protocol': { value: nav.nextHopProtocol, unit: '' },
+    'Transfer Size': { value: (nav.transferSize / 1024).toFixed(1), unit: 'KB' },
   };
 
-  // テーブル用にフォーマット
+  // Format for the table
   const tableData = {};
   for (const [key, data] of Object.entries(report)) {
     tableData[key] = typeof data.value === 'number'
@@ -2272,44 +2278,44 @@ function generateLoadingReport() {
 
   console.table(tableData);
 
-  // TTFB の警告
+  // TTFB warning
   const ttfb = nav.responseStart - nav.requestStart;
   if (ttfb > 800) {
     console.warn(
-      `TTFB が 800ms を超えています: ${ttfb.toFixed(0)}ms\n` +
-      '改善案: サーバー処理の最適化、CDN の導入、キャッシュ戦略の見直し'
+      `TTFB exceeds 800ms: ${ttfb.toFixed(0)}ms\n` +
+      'Suggestions: optimize server processing, introduce a CDN, review caching strategy'
     );
   }
 
   return report;
 }
 
-// ページ読み込み完了後に実行
+// Execute after page load completes
 window.addEventListener('load', () => {
   setTimeout(generateLoadingReport, 0);
 });
 ```
 
-### 12.2 演習2: 中級 - リソース最適化ダッシュボード
+### 12.2 Exercise 2: Intermediate - Resource Optimization Dashboard
 
-**目標**: Resource Timing API を使って、リソースの読み込みパフォーマンスを分析するダッシュボードを構築する。
+**Goal**: Use the Resource Timing API to build a dashboard that analyzes resource load performance.
 
-**要件**:
-1. リソースタイプ別（script, css, img, fetch 等）に集計する
-2. 各タイプの合計サイズ、平均読み込み時間、キャッシュヒット率を算出する
-3. 1秒以上かかったリソースをワースト5として報告する
-4. サードパーティリソースを検出して一覧化する
+**Requirements**:
+1. Aggregate by resource type (script, css, img, fetch, etc.)
+2. Calculate total size, average load time, and cache hit rate for each type
+3. Report the worst 5 resources that took more than 1 second
+4. Detect and list third-party resources
 
 ```javascript
 // ==================================================
-// 演習2: 解答例
+// Exercise 2: Sample solution
 // ==================================================
 
 function buildResourceDashboard() {
   const resources = performance.getEntriesByType('resource');
   const currentOrigin = location.origin;
 
-  // --- 1. タイプ別集計 ---
+  // --- 1. Aggregate by type ---
   const byType = {};
   resources.forEach(r => {
     const type = r.initiatorType || 'other';
@@ -2324,20 +2330,20 @@ function buildResourceDashboard() {
     }
   });
 
-  console.log('=== リソースタイプ別集計 ===');
+  console.log('=== Aggregation by Resource Type ===');
   const typeTable = {};
   for (const [type, data] of Object.entries(byType)) {
     typeTable[type] = {
-      件数: data.count,
-      合計サイズ: `${(data.totalSize / 1024).toFixed(1)}KB`,
-      平均時間: `${(data.totalDuration / data.count).toFixed(0)}ms`,
-      キャッシュ率: `${((data.cachedCount / data.count) * 100).toFixed(0)}%`,
+      Count: data.count,
+      'Total Size': `${(data.totalSize / 1024).toFixed(1)}KB`,
+      'Avg Time': `${(data.totalDuration / data.count).toFixed(0)}ms`,
+      'Cache Rate': `${((data.cachedCount / data.count) * 100).toFixed(0)}%`,
     };
   }
   console.table(typeTable);
 
-  // --- 2. ワースト5 ---
-  console.log('\n=== 読み込みが遅いリソース ワースト5 ===');
+  // --- 2. Worst 5 ---
+  console.log('\n=== Worst 5 Slowest Resources ===');
   const worst5 = resources
     .filter(r => r.duration > 1000)
     .sort((a, b) => b.duration - a.duration)
@@ -2345,13 +2351,13 @@ function buildResourceDashboard() {
 
   worst5.forEach((r, i) => {
     console.log(`  ${i + 1}. ${new URL(r.name).pathname}`);
-    console.log(`     タイプ: ${r.initiatorType}`);
-    console.log(`     時間: ${r.duration.toFixed(0)}ms`);
-    console.log(`     サイズ: ${(r.transferSize / 1024).toFixed(1)}KB`);
+    console.log(`     Type: ${r.initiatorType}`);
+    console.log(`     Time: ${r.duration.toFixed(0)}ms`);
+    console.log(`     Size: ${(r.transferSize / 1024).toFixed(1)}KB`);
   });
 
-  // --- 3. サードパーティリソース ---
-  console.log('\n=== サードパーティリソース ===');
+  // --- 3. Third-party resources ---
+  console.log('\n=== Third-party Resources ===');
   const thirdParty = resources.filter(r => {
     try { return new URL(r.name).origin !== currentOrigin; }
     catch { return false; }
@@ -2371,9 +2377,9 @@ function buildResourceDashboard() {
   const domainTable = {};
   for (const [domain, data] of Object.entries(byDomain)) {
     domainTable[domain] = {
-      リクエスト数: data.count,
-      合計サイズ: `${(data.totalSize / 1024).toFixed(1)}KB`,
-      合計時間: `${data.totalDuration.toFixed(0)}ms`,
+      Requests: data.count,
+      'Total Size': `${(data.totalSize / 1024).toFixed(1)}KB`,
+      'Total Time': `${data.totalDuration.toFixed(0)}ms`,
     };
   }
   console.table(domainTable);
@@ -2381,26 +2387,26 @@ function buildResourceDashboard() {
   return { byType: typeTable, worst5, thirdPartyDomains: domainTable };
 }
 
-// 実行
+// Execute
 window.addEventListener('load', () => {
   setTimeout(buildResourceDashboard, 1000);
 });
 ```
 
-### 12.3 演習3: 上級 - 包括的パフォーマンスモニタリングシステム
+### 12.3 Exercise 3: Advanced - Comprehensive Performance Monitoring System
 
-**目標**: PerformanceObserver、User Timing、web-vitals を組み合わせた包括的なパフォーマンスモニタリングシステムを構築する。
+**Goal**: Build a comprehensive performance monitoring system combining PerformanceObserver, User Timing, and web-vitals.
 
-**要件**:
-1. Core Web Vitals（LCP、INP、CLS）をリアルタイムで計測する
-2. Long Task を検出し、原因を分析する
-3. カスタムメトリクス（API レスポンス時間、レンダリング時間）を計測する
-4. 全データを統合してレポートを生成し、Beacon API で送信する
-5. パフォーマンスバジェットとの比較結果を含める
+**Requirements**:
+1. Measure Core Web Vitals (LCP, INP, CLS) in real time
+2. Detect Long Tasks and analyze their causes
+3. Measure custom metrics (API response time, rendering time)
+4. Integrate all data to generate a report and send it via the Beacon API
+5. Include a comparison against performance budgets
 
 ```javascript
 // ==================================================
-// 演習3: 解答例（包括的モニタリングシステム）
+// Exercise 3: Sample solution (comprehensive monitoring system)
 // ==================================================
 
 class PerformanceMonitor {
@@ -2426,7 +2432,7 @@ class PerformanceMonitor {
     this._setupReporting();
   }
 
-  // Core Web Vitals の計測
+  // Measure Core Web Vitals
   _initVitals() {
     import('web-vitals').then(({ onLCP, onINP, onCLS, onFCP, onTTFB }) => {
       const recordVital = (metric) => {
@@ -2436,7 +2442,7 @@ class PerformanceMonitor {
           delta: metric.delta,
         };
 
-        // バジェットチェック
+        // Budget check
         const budget = this.config.budgets[metric.name];
         if (budget && metric.value > budget) {
           this.data.violations.push({
@@ -2449,7 +2455,7 @@ class PerformanceMonitor {
           if (this.config.debug) {
             console.warn(
               `[Budget Violation] ${metric.name}: ` +
-              `${metric.value} > ${budget} (超過: ${(metric.value - budget).toFixed(1)})`
+              `${metric.value} > ${budget} (exceeded by: ${(metric.value - budget).toFixed(1)})`
             );
           }
         }
@@ -2463,7 +2469,7 @@ class PerformanceMonitor {
     });
   }
 
-  // Long Task の監視
+  // Monitor Long Tasks
   _initLongTaskMonitor() {
     if (!PerformanceObserver.supportedEntryTypes.includes('longtask')) return;
 
@@ -2478,7 +2484,7 @@ class PerformanceMonitor {
     }).observe({ type: 'longtask' });
   }
 
-  // カスタムメトリクスの記録
+  // Record custom metrics
   measure(name, fn) {
     const start = performance.now();
     const result = fn();
@@ -2509,7 +2515,7 @@ class PerformanceMonitor {
     }
   }
 
-  // レポートの送信設定
+  // Configure report sending
   _setupReporting() {
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
@@ -2556,13 +2562,13 @@ class PerformanceMonitor {
     }
   }
 
-  // 現在の状態を取得
+  // Get the current state
   getReport() {
     return { ...this.data };
   }
 }
 
-// 初期化と使用例
+// Initialization and usage example
 const monitor = new PerformanceMonitor({
   endpoint: '/api/performance',
   sampleRate: 1.0,
@@ -2576,7 +2582,7 @@ const monitor = new PerformanceMonitor({
   },
 });
 
-// カスタムメトリクスの使用例
+// Usage example for custom metrics
 const data = await monitor.measure('fetch-products', () =>
   fetch('/api/products').then(r => r.json())
 );
@@ -2586,171 +2592,171 @@ const data = await monitor.measure('fetch-products', () =>
 
 ## 13. FAQ
 
-### Q1: Lighthouse のスコアが DevTools と CLI で異なるのはなぜか？
+### Q1: Why does the Lighthouse score differ between DevTools and the CLI?
 
-**A**: Lighthouse のスコアは実行環境によって変動する。主な差異の原因は以下の通りである。
+**A**: Lighthouse scores vary depending on the execution environment. The main causes of the difference are as follows.
 
-1. **スロットリング方式の違い**: DevTools は Simulated Throttling（シミュレーション）をデフォルトで使用するが、CLI では Applied Throttling（実際のネットワーク/CPU 制限）も選択できる。シミュレーション方式はネットワーク・CPU の制限をアルゴリズム的に推定するため、実環境とは異なる結果が出やすい。
+1. **Difference in throttling method**: DevTools uses Simulated Throttling by default, while the CLI also supports Applied Throttling (actual network/CPU restrictions). The simulation method algorithmically estimates network and CPU restrictions, so results tend to differ from the real environment.
 
-2. **バックグラウンドプロセスの影響**: ローカル環境では他のタブやアプリケーションが CPU やメモリを消費しており、計測結果にノイズが入る。CI 環境でも同様に、並列実行されるジョブがリソースを競合する。
+2. **Impact of background processes**: In a local environment, other tabs and applications consume CPU and memory, introducing noise into measurement results. CI environments similarly have competing jobs consuming resources.
 
-3. **ネットワーク条件の変動**: 同一のスロットリング設定でも、実際のネットワーク遅延やサーバー応答時間は変動する。
+3. **Variation in network conditions**: Even with the same throttling settings, actual network latency and server response times vary.
 
-**推奨対策**:
-- 複数回（3〜5回）実行して中央値を採用する
-- CI 環境では一貫した設定を使用する
-- スコアの絶対値よりも変化（差分）に注目する
+**Recommended countermeasures**:
+- Run multiple times (3-5 runs) and use the median
+- Use consistent settings in the CI environment
+- Focus on changes (differences) rather than absolute score values
 
-### Q2: CLS が意図せず高くなる一般的な原因は何か？
+### Q2: What are common causes of unexpectedly high CLS?
 
-**A**: CLS が高くなる典型的な原因と対策を以下に示す。
+**A**: The following shows typical causes of high CLS and countermeasures.
 
-| 原因 | 詳細 | 対策 |
-|------|------|------|
-| 寸法未指定の画像・動画 | 読み込み完了後に要素サイズが確定し、周囲のコンテンツが押し出される | `width`/`height` 属性を必ず指定する。`aspect-ratio` CSS プロパティも有効 |
-| Web フォントの FOIT/FOUT | フォント読み込み中にテキストが非表示（FOIT）またはフォールバックフォントで表示（FOUT）され、切り替え時にシフトが発生 | `font-display: swap` と `size-adjust` を使用。`<link rel="preload">` でフォントを先読み |
-| 動的コンテンツの挿入 | 広告、バナー、Cookie 同意ダイアログなどが既存コンテンツの上に挿入される | 挿入スペースを事前に確保する。`min-height` を設定する |
-| 遅延読み込みコンテンツ | API レスポンス待ちでスケルトン表示からコンテンツに切り替わる際にサイズが変わる | スケルトンのサイズをコンテンツと一致させる。`contain: layout` を使用 |
+| Cause | Details | Countermeasure |
+|-------|---------|----------------|
+| Images/videos without dimensions specified | When loading completes and element size is determined, surrounding content is pushed out | Always specify `width`/`height` attributes. The `aspect-ratio` CSS property is also effective |
+| Web font FOIT/FOUT | Text is hidden (FOIT) or shown in fallback font (FOUT) during font loading, causing a shift when switching | Use `font-display: swap` and `size-adjust`. Preload fonts with `<link rel="preload">` |
+| Dynamic content insertion | Ads, banners, cookie consent dialogs, etc. are inserted above existing content | Reserve space for insertion in advance. Set `min-height` |
+| Lazy-loaded content | Size changes when switching from skeleton display to content while waiting for API response | Match skeleton dimensions to content. Use `contain: layout` |
 
-### Q3: INP と FID の違いは何か？なぜ FID は廃止されたのか？
+### Q3: What is the difference between INP and FID? Why was FID deprecated?
 
-**A**: FID（First Input Delay）は最初のインタラクションの入力遅延のみを計測する指標であった。一方、INP はページライフサイクル全体にわたる全てのインタラクションを対象とし、最も遅い応答（98パーセンタイル）を報告する。
+**A**: FID (First Input Delay) measured only the input delay of the first interaction. INP, on the other hand, covers all interactions across the entire page lifecycle and reports the slowest response (98th percentile).
 
-FID が廃止された主な理由は以下の通りである。
+The main reasons FID was deprecated are as follows.
 
-1. **計測範囲の狭さ**: FID は「最初の」インタラクションのみを計測するため、ページ読み込み後のインタラクション品質を評価できなかった。SPA のような長寿命ページでは、ページ滞在中の操作感こそが重要である。
+1. **Narrow measurement scope**: Since FID measured only the "first" interaction, it could not evaluate interaction quality after page load. For long-lived pages like SPAs, the feel of operations during the page session is what matters.
 
-2. **入力遅延のみの計測**: FID はイベントハンドラの実行開始までの遅延（Input Delay）のみを計測し、処理時間（Processing Time）と描画遅延（Presentation Delay）を含まなかった。ハンドラ内の重い処理はFIDに反映されなかった。
+2. **Only measuring input delay**: FID measured only the delay until event handler execution begins (Input Delay) and did not include processing time (Processing Time) or presentation delay. Heavy processing inside handlers was not reflected in FID.
 
-3. **楽観的な評価**: 多くのサイトで FID が良好（< 100ms）であっても、ユーザー体感としては応答が遅いケースが多かった。INP は実態をより正確に反映する。
+3. **Optimistic evaluation**: Even when many sites showed good FID (< 100ms), users often perceived the response as slow. INP more accurately reflects the actual state.
 
-### Q4: パフォーマンス計測はモバイル端末でどの程度変わるか？
+### Q4: How much does performance measurement vary on mobile devices?
 
-**A**: モバイル端末とデスクトップでは、パフォーマンス特性が大きく異なる。主な差異を以下に整理する。
+**A**: Performance characteristics differ significantly between mobile and desktop. The main differences are summarized below.
 
-| 要素 | デスクトップ | モバイル | 影響 |
-|------|-------------|---------|------|
-| CPU 性能 | 高速マルチコア | 低〜中速、熱による周波数低下 | JavaScript 実行時間が2〜5倍に増加 |
-| メモリ | 8〜32GB | 2〜8GB | 大きなバンドルでメモリ不足の可能性 |
-| ネットワーク | 有線 / Wi-Fi | 4G/5G（変動あり） | TTFB とダウンロード時間が不安定 |
-| 画面サイズ | 大画面 | 小画面 | LCP の対象要素が変わる場合がある |
-| タッチ入力 | マウス + キーボード | タッチ | INP の計測対象イベントが異なる |
+| Factor | Desktop | Mobile | Impact |
+|--------|---------|--------|--------|
+| CPU performance | Fast multi-core | Low to medium speed, frequency throttled by heat | JavaScript execution time increases 2-5x |
+| Memory | 8-32GB | 2-8GB | Risk of memory shortage with large bundles |
+| Network | Wired / Wi-Fi | 4G/5G (variable) | TTFB and download time are unstable |
+| Screen size | Large screen | Small screen | LCP target element may change |
+| Touch input | Mouse + keyboard | Touch | INP target events differ |
 
-Lighthouse のデフォルト設定では、CPU を4倍に遅延させ、ネットワークを 4G 相当にスロットリングすることで、モバイル環境をシミュレートしている。しかし、実際のモバイル端末にはバッテリー残量、熱管理、OS のバックグラウンド処理といった変動要因があり、シミュレーションでは再現できない。フィールドデータ（RUM）との併用が不可欠である。
+Lighthouse's default settings simulate a mobile environment by slowing the CPU by 4x and throttling the network to 4G equivalent. However, real mobile devices have variable factors such as battery level, thermal management, and OS background processing that simulations cannot reproduce. Combining with field data (RUM) is essential.
 
-### Q5: PerformanceObserver の observe で type と entryTypes の違いは何か？
+### Q5: What is the difference between type and entryTypes in PerformanceObserver.observe?
 
-**A**: `observe()` メソッドには2つの指定方法がある。
+**A**: The `observe()` method has two specification methods.
 
-- **`type`（単数形）**: 1つの entryType を指定する。`buffered` オプションが使用可能。新しい API（`droppedEntriesCount` 等）にアクセスできる。Performance Timeline Level 2 で導入された推奨方式。
+- **`type` (singular)**: Specifies one entryType. The `buffered` option can be used. Newer APIs (such as `droppedEntriesCount`) can be accessed. Recommended method introduced in Performance Timeline Level 2.
 
-- **`entryTypes`（複数形）**: 複数の entryType を配列で指定できる。`buffered` オプションは使用不可。古い API 互換の方式。
+- **`entryTypes` (plural)**: Can specify multiple entryTypes as an array. The `buffered` option cannot be used. Older API-compatible method.
 
 ```javascript
-// 推奨: type（単数形）+ buffered
+// Recommended: type (singular) + buffered
 new PerformanceObserver(callback).observe({
   type: 'resource',
   buffered: true,
 });
 
-// 互換: entryTypes（複数形）
+// Compatible: entryTypes (plural)
 new PerformanceObserver(callback).observe({
   entryTypes: ['resource', 'mark', 'measure'],
-  // buffered は使えない
+  // buffered cannot be used
 });
 ```
 
-複数の entryType を監視しつつ `buffered` も使いたい場合は、entryType ごとに別々の Observer を作成する。
+If you want to monitor multiple entryTypes and also use `buffered`, create separate Observers for each entryType.
 
-### Q6: Core Web Vitals（LCP/FID/CLS）を改善する最も効果的な方法は？
+### Q6: What are the most effective ways to improve Core Web Vitals (LCP/FID/CLS)?
 
-**A**: 各指標に対する最も効果的な改善手法を以下にまとめる。
+**A**: The most effective improvement techniques for each metric are summarized below.
 
-**LCP（Largest Contentful Paint）の改善**:
-1. **画像の最適化**: WebP/AVIF 形式への変換、適切なサイズでの配信、`<img srcset>` による responsive images の実装
-2. **クリティカルリソースの優先読み込み**: `<link rel="preload">` で LCP 要素（Hero 画像やメインコンテンツ）を先行ロード
-3. **サーバー応答時間（TTFB）の短縮**: CDN の導入、サーバーサイドキャッシュ、データベースクエリの最適化
-4. **レンダーブロッキングリソースの削減**: CSS のインライン化、JavaScript の defer/async 属性、未使用 CSS の削除
+**Improving LCP (Largest Contentful Paint)**:
+1. **Image optimization**: Convert to WebP/AVIF format, deliver at appropriate sizes, implement responsive images with `<img srcset>`
+2. **Priority loading of critical resources**: Use `<link rel="preload">` to preload the LCP element (hero images and main content)
+3. **Reducing server response time (TTFB)**: Introduce a CDN, server-side caching, database query optimization
+4. **Reducing render-blocking resources**: Inline CSS, `defer`/`async` attributes for JavaScript, remove unused CSS
 
-**INP（Interaction to Next Paint）の改善**:
-1. **Long Task の分割**: `scheduler.yield()` または `setTimeout(fn, 0)` で処理を細かく分割し、メインスレッドを定期的に解放
-2. **JavaScript バンドルサイズの削減**: Code splitting、Tree shaking、dynamic import による遅延読み込み
-3. **イベントハンドラの最適化**: デバウンス/スロットリング、イベント委譲（Event Delegation）、passive リスナーの使用
-4. **Web Worker の活用**: 重い計算処理をバックグラウンドスレッドに移譲
+**Improving INP (Interaction to Next Paint)**:
+1. **Split Long Tasks**: Use `scheduler.yield()` or `setTimeout(fn, 0)` to split processing into small chunks, periodically freeing the main thread
+2. **Reduce JavaScript bundle size**: Code splitting, tree shaking, lazy loading via dynamic import
+3. **Optimize event handlers**: Debounce/throttle, event delegation, use of passive listeners
+4. **Leverage Web Workers**: Delegate heavy computation to a background thread
 
-**CLS（Cumulative Layout Shift）の改善**:
-1. **画像・動画の寸法指定**: `width`/`height` 属性または `aspect-ratio` CSS プロパティを必ず設定
-2. **Web フォントの最適化**: `font-display: swap` と `size-adjust` の使用、フォントのプリロード
-3. **動的コンテンツ用のスペース確保**: 広告やバナー用の `min-height` 設定、スケルトンスクリーンの寸法統一
-4. **CSS `contain` プロパティの活用**: `contain: layout` でレイアウトの影響範囲を制限
+**Improving CLS (Cumulative Layout Shift)**:
+1. **Specify image/video dimensions**: Always set `width`/`height` attributes or `aspect-ratio` CSS property
+2. **Web font optimization**: Use `font-display: swap` and `size-adjust`, preload fonts
+3. **Reserve space for dynamic content**: Set `min-height` for ads and banners, match skeleton screen dimensions
+4. **Use the CSS `contain` property**: Use `contain: layout` to limit the scope of layout impact
 
-### Q7: Performance API と Lighthouse の使い分けは？どちらを優先すべきか？
+### Q7: How should I choose between the Performance API and Lighthouse? Which should take priority?
 
-**A**: Performance API（RUM）と Lighthouse（ラボテスト）は相互補完的であり、両方を活用することが推奨される。
+**A**: The Performance API (RUM) and Lighthouse (lab testing) are complementary, and using both is recommended.
 
-| 観点 | Performance API（RUM） | Lighthouse（ラボテスト） |
-|------|----------------------|------------------------|
-| データ収集源 | 実際のユーザー環境 | 開発者が制御する固定環境 |
-| 結果の一貫性 | 低い（環境の多様性） | 高い（同一設定で再現可能） |
-| 問題の発見 | 実環境での問題を検出 | 潜在的なボトルネックを検出 |
-| デバッグ | 困難（環境再現が難しい） | 容易（トレースで詳細分析） |
-| 改善提案 | なし | 具体的な改善策を提示 |
-| コスト | バックエンド基盤が必要 | 無料（CI 統合も可能） |
+| Aspect | Performance API (RUM) | Lighthouse (lab testing) |
+|--------|----------------------|--------------------------|
+| Data source | Actual user environment | Fixed developer-controlled environment |
+| Result consistency | Low (environment diversity) | High (reproducible with same settings) |
+| Problem discovery | Detects real-environment issues | Detects potential bottlenecks |
+| Debugging | Difficult (hard to reproduce environment) | Easy (detailed analysis with trace) |
+| Improvement suggestions | None | Provides specific suggestions |
+| Cost | Requires backend infrastructure | Free (CI integration also possible) |
 
-**推奨の使い分け**:
-1. **開発フェーズ**: Lighthouse を使って問題を早期発見し、改善提案に従って最適化を行う
-2. **CI/CD パイプライン**: Lighthouse CI でパフォーマンスバジェットを設定し、リグレッションを自動検出
-3. **本番環境**: Performance API で RUM データを収集し、実際のユーザー体験を監視
-4. **問題調査**: Lighthouse のトレース機能で詳細なボトルネック分析を実施
-5. **効果検証**: RUM データで改善の効果を定量的に測定
+**Recommended division of use**:
+1. **Development phase**: Use Lighthouse to discover problems early and optimize based on suggestions
+2. **CI/CD pipeline**: Set performance budgets with Lighthouse CI to automatically detect regressions
+3. **Production environment**: Collect RUM data with the Performance API to monitor real user experience
+4. **Problem investigation**: Use Lighthouse's trace feature for detailed bottleneck analysis
+5. **Validating improvements**: Use RUM data to quantitatively measure the effect of improvements
 
-両者を組み合わせることで、「ラボでの理想」と「フィールドでの現実」のギャップを埋めることができる。
+Combining both allows you to bridge the gap between "the ideal in the lab" and "the reality in the field."
 
-### Q8: リアルユーザーモニタリング（RUM）の導入方法と注意点は？
+### Q8: What are the steps and considerations for introducing Real User Monitoring (RUM)?
 
-**A**: RUM の導入には以下のステップと注意点がある。
+**A**: Introducing RUM involves the following steps and considerations.
 
-**導入ステップ**:
+**Introduction steps**:
 
-1. **計測対象の決定**:
-   - Core Web Vitals（LCP/INP/CLS）は必須
-   - Navigation Timing（TTFB, DOMContentLoaded, Load）
-   - Resource Timing（重要リソースのみに絞る）
-   - User Timing（アプリ固有の重要イベント）
+1. **Determine what to measure**:
+   - Core Web Vitals (LCP/INP/CLS) are mandatory
+   - Navigation Timing (TTFB, DOMContentLoaded, Load)
+   - Resource Timing (narrow to important resources only)
+   - User Timing (important app-specific events)
 
-2. **ライブラリの選定**:
-   - Google の `web-vitals` ライブラリ（軽量・公式）
-   - サードパーティ APM（New Relic, Datadog, Sentry など）
-   - 自前実装（PerformanceObserver ベース）
+2. **Select a library**:
+   - Google's `web-vitals` library (lightweight, official)
+   - Third-party APM (New Relic, Datadog, Sentry, etc.)
+   - Custom implementation (PerformanceObserver-based)
 
-3. **データ送信の実装**:
-   - Beacon API または `fetch` with `keepalive: true` を使用
-   - サンプリングレートを設定（全ユーザーの 10〜50% など）
-   - バッチ送信で通信回数を削減
+3. **Implement data sending**:
+   - Use Beacon API or `fetch` with `keepalive: true`
+   - Set a sampling rate (10-50% of all users, etc.)
+   - Batch sending to reduce the number of requests
 
-4. **バックエンド構築**:
-   - エンドポイント実装（POST リクエストを受け取り、データベースに保存）
-   - 集計処理（パーセンタイル計算、時系列データの生成）
-   - ダッシュボード構築（グラフ化、アラート設定）
+4. **Build the backend**:
+   - Implement an endpoint (receive POST requests, save to database)
+   - Aggregation processing (percentile calculation, time series data generation)
+   - Build a dashboard (graphing, alert configuration)
 
-**注意点**:
+**Considerations**:
 
-| 項目 | 詳細 |
-|------|------|
-| プライバシー保護 | 個人識別情報を含めない。GDPR/CCPA 対応のため、事前に同意を取得 |
-| パフォーマンスへの影響 | 計測処理自体がパフォーマンスに影響しないよう、非同期処理と軽量化を徹底 |
-| サンプリング | 全ユーザーを計測する必要はない。10〜50% のサンプリングで十分な統計的有意性が得られる |
-| ボットの除外 | ユーザーエージェント解析やキャプチャで、クローラーや自動化ツールを除外 |
-| データ保持期間 | ストレージコストを考慮し、生データは 30〜90 日、集計データは長期保存 |
-| アラート設定 | 指標が閾値を超えたらチームに通知（Slack, PagerDuty 等） |
+| Item | Details |
+|------|---------|
+| Privacy protection | Do not include personally identifiable information. Obtain consent beforehand in compliance with GDPR/CCPA |
+| Performance impact | Use asynchronous processing and lightweight code so that the measurement processing itself does not affect performance |
+| Sampling | There is no need to measure all users. 10-50% sampling provides sufficient statistical significance |
+| Bot exclusion | Exclude crawlers and automation tools via user-agent analysis or captcha |
+| Data retention period | Considering storage costs, keep raw data for 30-90 days and aggregated data for long-term storage |
+| Alert configuration | Notify the team when metrics exceed thresholds (Slack, PagerDuty, etc.) |
 
-**コード例（軽量な RUM 実装）**:
+**Code example (lightweight RUM implementation)**:
 
 ```javascript
 import { onCLS, onINP, onLCP } from 'web-vitals';
 
 function sendToAnalytics(metric) {
-  // サンプリング（50%）
+  // Sampling (50%)
   if (Math.random() > 0.5) return;
 
   const body = JSON.stringify({
@@ -2762,11 +2768,11 @@ function sendToAnalytics(metric) {
     timestamp: Date.now(),
   });
 
-  // Beacon API で送信
+  // Send via Beacon API
   navigator.sendBeacon('/api/metrics', body);
 }
 
-// Core Web Vitals を監視
+// Monitor Core Web Vitals
 onCLS(sendToAnalytics);
 onINP(sendToAnalytics);
 onLCP(sendToAnalytics);
@@ -2774,76 +2780,76 @@ onLCP(sendToAnalytics);
 
 ---
 
-### Q4: PerformanceObserver のコールバックがパフォーマンスに影響を与えることはありますか?
+### Q4: Can PerformanceObserver callbacks impact performance?
 
-**A**: PerformanceObserver のコールバックはマイクロタスクとして実行されるため、コールバック内で重い処理（大量のログ出力、DOM操作、同期的なネットワーク送信など）を行うとメインスレッドをブロックし、計測対象のパフォーマンスに影響を与えます。コールバック内では最小限のデータ抽出とバッファリングのみを行い、データの送信は `requestIdleCallback` や `Beacon API`（`navigator.sendBeacon`）でアイドル時またはページ離脱時に実行するのが推奨です。
+**A**: PerformanceObserver callbacks run as microtasks, so performing heavy operations inside the callback (large amounts of logging, DOM manipulation, synchronous network requests, etc.) will block the main thread and may affect the performance of what you are measuring. It is recommended to perform only minimal data extraction and buffering inside the callback, and to send data at idle time or on page unload using `requestIdleCallback` or the Beacon API (`navigator.sendBeacon`).
 
-### Q5: 本番環境で全ユーザーのパフォーマンスデータを収集すべきですか?
+### Q5: Should you collect performance data from all users in production?
 
-**A**: 全ユーザーからデータを収集するとサーバー負荷とネットワークコストが増大するため、通常はサンプリングを行います。一般的には全ユーザーの1〜10%をサンプリングし、統計的に有意なデータ量を確保します。サンプリングレートは `Math.random() < 0.05`（5%）のように制御し、セッション単位で固定することで、同一ユーザーのページ遷移を一貫して追跡できます。重要なページ（ランディングページ、チェックアウト）ではサンプリングレートを高めに設定することも有効です。
+**A**: Collecting data from all users increases server load and network costs, so sampling is typically applied. Generally, sampling 1-10% of all users provides a statistically significant amount of data. Control the sampling rate with something like `Math.random() < 0.05` (5%) and fix it at the session level so that navigation across pages by the same user is tracked consistently. Setting a higher sampling rate for important pages (landing pages, checkout) is also effective.
 
-### Q6: TTFB が遅い場合、フロントエンドで改善できることはありますか?
+### Q6: Can anything be improved on the frontend if TTFB is slow?
 
-**A**: TTFB（Time to First Byte）はサーバー側の処理時間に大きく依存しますが、フロントエンド側でも改善余地があります。`<link rel="preconnect">` でCDNやAPIサーバーへの接続を事前に確立する、Service Worker でキャッシュヒット時に即座にレスポンスを返す（Stale-While-Revalidate 戦略）、Navigation Timing API で TTFB を継続的に計測しサーバーチームにデータを共有する、といった施策が有効です。
-
----
-
-## 追加参考文献
-
-- [Google Developers - Optimize Time to First Byte](https://web.dev/articles/optimize-ttfb) - TTFB最適化の包括的ガイド
-- [W3C - Performance Timeline Level 2](https://www.w3.org/TR/performance-timeline/) - PerformanceObserver の公式仕様
-- [Mozilla - PerformanceObserver](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver) - PerformanceObserver の実装ガイド
+**A**: TTFB (Time to First Byte) depends heavily on server-side processing time, but there is also room for improvement on the frontend side. Using `<link rel="preconnect">` to pre-establish connections to CDNs and API servers, having the Service Worker return an immediate response on cache hits (Stale-While-Revalidate strategy), and continuously measuring TTFB with the Navigation Timing API to share data with the server team are all effective measures.
 
 ---
 
-## 14. 比較表
+## Additional References
 
-### 14.1 パフォーマンス計測ツール比較
-
-| 特性 | Performance API（RUM） | Lighthouse（ラボ） | WebPageTest（ラボ） | CrUX（フィールド） |
-|------|----------------------|-------------------|--------------------|--------------------|
-| データソース | 実ユーザー | シミュレーション | 実ネットワーク | 実ユーザー（Chrome） |
-| 環境の多様性 | 高（全デバイス） | 低（固定設定） | 中（選択可能） | 高（Chrome のみ） |
-| 計測タイミング | リアルタイム | オンデマンド/CI | オンデマンド | 28日間集計 |
-| INP 対応 | 対応 | TBT で代替 | 対応（一部） | 対応 |
-| カスタム指標 | 対応 | カスタム監査で対応 | カスタムスクリプト | 非対応 |
-| コスト | 実装コスト | 無料 | 無料/有料プラン | 無料（API） |
-| 結果の一貫性 | 低（環境依存） | 中（変動あり） | 中〜高 | 高（大量データ） |
-| 改善提案 | なし | 詳細な提案あり | 詳細な提案あり | なし |
-| SPA 対応 | 手動実装が必要 | 初回読み込みのみ | 初回読み込みのみ | 限定的 |
-
-### 14.2 データ送信方式の比較
-
-| 特性 | Beacon API | fetch (keepalive) | XMLHttpRequest | Image Pixel |
-|------|-----------|-------------------|----------------|-------------|
-| ページ離脱時の送信 | 確実 | 確実 | 不確実 | 不確実 |
-| ペイロードサイズ制限 | 64KB | 64KB (keepalive時) | 制限なし | URL長さ制限 |
-| レスポンスの取得 | 不可 | 可 | 可 | 不可 |
-| HTTP メソッド | POST のみ | 任意 | 任意 | GET のみ |
-| Content-Type 設定 | 限定的 | 自由 | 自由 | N/A |
-| CORS プリフライト | 条件による | 条件による | 条件による | 不要 |
-| ブラウザサポート | 広範 | 広範 | 広範 | 全ブラウザ |
-| キャンセル可能 | 不可 | AbortController | abort() | N/A |
-| 推奨用途 | パフォーマンスデータ・分析 | 大きなペイロード | レガシー対応 | 最小限のトラッキング |
-
-### 14.3 Core Web Vitals 改善テクニック比較
-
-| テクニック | 対象指標 | 効果の大きさ | 実装難易度 | 説明 |
-|-----------|---------|-------------|-----------|------|
-| 画像の遅延読み込み | LCP, CLS | 大 | 低 | `loading="lazy"` + 寸法指定 |
-| Critical CSS インライン化 | FCP, LCP | 大 | 中 | Above-the-fold の CSS をインライン展開 |
-| JavaScript の分割読み込み | TBT, INP | 大 | 中 | dynamic import + React.lazy |
-| フォントの最適化 | CLS, FCP | 中 | 低 | `font-display: swap` + preload |
-| Service Worker キャッシュ | LCP, TTFB | 大 | 高 | Cache-first 戦略でオフライン対応 |
-| CDN の導入 | TTFB, LCP | 大 | 低 | エッジサーバーからの配信 |
-| HTTP/2 Server Push | LCP | 中 | 中 | 重要リソースの先行送信（非推奨化の流れあり） |
-| `scheduler.yield()` | INP | 大 | 中 | Long Task を分割してメインスレッドを解放 |
-| `content-visibility: auto` | LCP, INP | 中 | 低 | ビューポート外のレンダリングを遅延 |
-| Speculation Rules API | LCP, FCP | 大 | 中 | リンク先の投機的プリレンダリング |
+- [Google Developers - Optimize Time to First Byte](https://web.dev/articles/optimize-ttfb) - Comprehensive guide to TTFB optimization
+- [W3C - Performance Timeline Level 2](https://www.w3.org/TR/performance-timeline/) - Official specification for PerformanceObserver
+- [Mozilla - PerformanceObserver](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver) - PerformanceObserver implementation guide
 
 ---
 
-## 15. 参考文献
+## 14. Comparison Tables
+
+### 14.1 Performance Measurement Tool Comparison
+
+| Characteristic | Performance API (RUM) | Lighthouse (lab) | WebPageTest (lab) | CrUX (field) |
+|----------------|-----------------------|------------------|-------------------|--------------|
+| Data source | Real users | Simulation | Real network | Real users (Chrome) |
+| Environment diversity | High (all devices) | Low (fixed settings) | Medium (selectable) | High (Chrome only) |
+| Measurement timing | Real-time | On-demand / CI | On-demand | 28-day aggregate |
+| INP support | Supported | Replaced by TBT | Partial support | Supported |
+| Custom metrics | Supported | Via custom audits | Custom scripts | Not supported |
+| Cost | Implementation cost | Free | Free / paid plans | Free (API) |
+| Result consistency | Low (environment-dependent) | Medium (some variation) | Medium to high | High (large dataset) |
+| Improvement suggestions | None | Detailed suggestions | Detailed suggestions | None |
+| SPA support | Manual implementation required | Initial load only | Initial load only | Limited |
+
+### 14.2 Data Sending Method Comparison
+
+| Characteristic | Beacon API | fetch (keepalive) | XMLHttpRequest | Image Pixel |
+|----------------|-----------|-------------------|----------------|-------------|
+| Sending on page unload | Reliable | Reliable | Unreliable | Unreliable |
+| Payload size limit | 64KB | 64KB (with keepalive) | No limit | URL length limit |
+| Retrieve response | Not possible | Possible | Possible | Not possible |
+| HTTP method | POST only | Any | Any | GET only |
+| Content-Type setting | Limited | Free | Free | N/A |
+| CORS preflight | Conditional | Conditional | Conditional | Not required |
+| Browser support | Broad | Broad | Broad | All browsers |
+| Cancellable | Not possible | AbortController | abort() | N/A |
+| Recommended use | Performance data / analytics | Large payloads | Legacy support | Minimal tracking |
+
+### 14.3 Core Web Vitals Improvement Technique Comparison
+
+| Technique | Target metric | Effect size | Implementation difficulty | Description |
+|-----------|--------------|-------------|--------------------------|-------------|
+| Image lazy loading | LCP, CLS | Large | Low | `loading="lazy"` + dimension specification |
+| Critical CSS inlining | FCP, LCP | Large | Medium | Inline above-the-fold CSS |
+| JavaScript code splitting | TBT, INP | Large | Medium | dynamic import + React.lazy |
+| Font optimization | CLS, FCP | Medium | Low | `font-display: swap` + preload |
+| Service Worker caching | LCP, TTFB | Large | High | Cache-first strategy for offline support |
+| CDN introduction | TTFB, LCP | Large | Low | Delivery from edge servers |
+| HTTP/2 Server Push | LCP | Medium | Medium | Pre-sending critical resources (being deprecated) |
+| `scheduler.yield()` | INP | Large | Medium | Split Long Tasks to free the main thread |
+| `content-visibility: auto` | LCP, INP | Medium | Low | Defer rendering of off-viewport content |
+| Speculation Rules API | LCP, FCP | Large | Medium | Speculative prerendering of link destinations |
+
+---
+
+## 15. References
 
 1. W3C. "Performance Timeline Level 2." W3C Recommendation, 2024. https://www.w3.org/TR/performance-timeline/
 2. W3C. "Navigation Timing Level 2." W3C Recommendation, 2023. https://www.w3.org/TR/navigation-timing-2/
@@ -2864,53 +2870,53 @@ onLCP(sendToAnalytics);
 
 ## FAQ
 
-### Q1: このトピックを学ぶ上で最も重要なポイントは何ですか？
+### Q1: What is the most important point when learning this topic?
 
-実践的な経験を積むことが最も重要です。理論だけでなく、実際にコードを書いて動作を確認することで理解が深まります。
+Gaining practical experience is most important. Understanding deepens not only through theory but by actually writing code and verifying behavior.
 
-### Q2: 初心者がよく陥る間違いは何ですか？
+### Q2: What mistakes do beginners commonly make?
 
-基礎を飛ばして応用に進むことです。このガイドで説明している基本概念をしっかり理解してから、次のステップに進むことをお勧めします。
+Skipping the fundamentals and jumping to advanced topics. It is recommended to thoroughly understand the basic concepts explained in this guide before moving on to the next step.
 
-### Q3: 実務ではどのように活用されていますか？
+### Q3: How is this used in practice?
 
-このトピックの知識は、日常的な開発業務で頻繁に活用されます。特にコードレビューやアーキテクチャ設計の際に重要になります。
-
----
-
-## まとめ
-
-Performance API は、ブラウザのパフォーマンス計測において不可欠な基盤技術である。本章で扱った内容を以下に整理する。
-
-| カテゴリ | 主要 API / ツール | 用途 |
-|---------|-------------------|------|
-| ページ読み込み計測 | Navigation Timing | リダイレクト、DNS、TCP、TTFB 等の段階別計測 |
-| リソース計測 | Resource Timing | 個別リソースの読み込みパフォーマンス分析 |
-| カスタム計測 | User Timing (mark/measure) | アプリケーション固有のパフォーマンスポイント定義 |
-| リアルタイム監視 | PerformanceObserver | イベント駆動でのパフォーマンスエントリ通知 |
-| ユーザー体験指標 | Core Web Vitals (LCP/INP/CLS) | Google が定義する3大ユーザー体験指標 |
-| 自動監査 | Lighthouse / Lighthouse CI | パフォーマンススコアリングと改善提案 |
-| データ送信 | Beacon API / fetch keepalive | ページ離脱時にも確実なデータ送信 |
-| フィールドデータ | RUM / CrUX | 実ユーザー環境でのパフォーマンス把握 |
-| 品質保証 | パフォーマンスバジェット | CI/CD での自動検証によるパフォーマンス退行防止 |
-
-パフォーマンス改善は一度の対応で完結するものではなく、計測・分析・改善・検証のサイクルを継続的に回すことが重要である。ラボデータ（Lighthouse）とフィールドデータ（RUM/CrUX）を組み合わせ、パフォーマンスバジェットによる自動検証を導入することで、チーム全体でパフォーマンス品質を維持・向上させる体制を構築できる。
+Knowledge of this topic is frequently applied in daily development work. It is especially important during code reviews and architecture design.
 
 ---
 
-## 次に読むべきガイド
+## Summary
 
-Performance API による計測とパフォーマンス改善の基礎を習得した後は、以下のガイドに進むことを推奨する。
+The Performance API is an essential foundational technology for browser performance measurement. The content covered in this chapter is summarized below.
 
-**ブラウザとWebプラットフォームをさらに深く学ぶ**:
-- **ネットワーク基礎**: TCP/IP、HTTP/2、HTTP/3（QUIC）、TLS といったネットワーク層の仕組みを理解することで、TTFB の改善や CDN の効果をより深く把握できる。特に HTTP/2 のマルチプレクシングや Server Push、HTTP/3 の 0-RTT 接続などは、パフォーマンス最適化において重要な知識である。
+| Category | Key APIs / Tools | Use |
+|---------|------------------|-----|
+| Page load measurement | Navigation Timing | Phase-by-phase measurement of redirect, DNS, TCP, TTFB, etc. |
+| Resource measurement | Resource Timing | Load performance analysis of individual resources |
+| Custom measurement | User Timing (mark/measure) | Define application-specific performance measurement points |
+| Real-time monitoring | PerformanceObserver | Event-driven performance entry notifications |
+| User experience metrics | Core Web Vitals (LCP/INP/CLS) | Google's three major user experience metrics |
+| Automated auditing | Lighthouse / Lighthouse CI | Performance scoring and improvement suggestions |
+| Data sending | Beacon API / fetch keepalive | Reliable data sending even on page unload |
+| Field data | RUM / CrUX | Understanding performance in real user environments |
+| Quality assurance | Performance budgets | Preventing performance regressions via automated CI/CD validation |
 
-**Web開発全体への応用**:
-- **Web アプリケーション開発**: React や Vue などのフレームワークを用いた実践的な開発において、パフォーマンス計測と最適化をどのように統合するかを学ぶ。Code splitting、Lazy loading、Server-Side Rendering（SSR）、Static Site Generation（SSG）といった手法と Performance API の組み合わせが扱われる。
+Performance improvement is not a one-time effort; it is important to continuously cycle through measurement, analysis, improvement, and validation. By combining lab data (Lighthouse) and field data (RUM/CrUX) and introducing automated validation through performance budgets, you can build a system that allows the entire team to maintain and improve performance quality.
 
 ---
 
-## 参考文献
+## What to Read Next
 
-- [MDN Web Docs](https://developer.mozilla.org/) - Web技術のリファレンス
-- [Wikipedia](https://ja.wikipedia.org/) - 技術概念の概要
+After mastering the basics of measurement and performance improvement with the Performance API, it is recommended to move on to the following guides.
+
+**Dive deeper into browsers and the web platform**:
+- **Network fundamentals**: Understanding the mechanisms of the network layer — TCP/IP, HTTP/2, HTTP/3 (QUIC), TLS — allows for a deeper understanding of TTFB improvements and CDN effectiveness. In particular, HTTP/2 multiplexing, Server Push, and HTTP/3's 0-RTT connection are important knowledge for performance optimization.
+
+**Application to web development as a whole**:
+- **Web application development**: Learn how to integrate performance measurement and optimization in practical development using frameworks such as React and Vue. Topics covered include the combination of Performance API with techniques such as code splitting, lazy loading, Server-Side Rendering (SSR), and Static Site Generation (SSG).
+
+---
+
+## References
+
+- [MDN Web Docs](https://developer.mozilla.org/) - Web technology reference
+- [Wikipedia](https://en.wikipedia.org/) - Overview of technical concepts

--- a/_meta/scripts/translation-status.js
+++ b/_meta/scripts/translation-status.js
@@ -19,6 +19,7 @@ const { execSync } = require('child_process');
 
 const SKILLS_ROOT = path.resolve(__dirname, '../..');
 const EXCLUDE_DIRS = ['ja', '_meta', '_legacy', '_original-skills'];
+const EXCLUDE_CATEGORIES = ['08-hobby'];
 
 function isJapanese(filePath) {
   try {
@@ -62,7 +63,7 @@ function findFiles(pattern) {
 
   // Walk each category directory
   const categories = fs.readdirSync(SKILLS_ROOT)
-    .filter(d => /^\d{2}-/.test(d))
+    .filter(d => /^\d{2}-/.test(d) && !EXCLUDE_CATEGORIES.includes(d))
     .map(d => path.join(SKILLS_ROOT, d));
 
   for (const catDir of categories) {
@@ -93,7 +94,7 @@ function main() {
   const skillJp = skillFiles.filter(f => isJapanese(f));
   const skillEn = skillFiles.filter(f => !isJapanese(f));
 
-  const totalFiles = 952; // Known total
+  const totalFiles = docsFiles.length + skillFiles.length;
   const totalEn = docsEn.length + skillEn.length;
   const totalJp = docsJp.length + skillJp.length;
   const pct = ((totalEn / totalFiles) * 100).toFixed(1);


### PR DESCRIPTION
## Summary

- Translated 2 remaining files in `04-web-and-network/browser-and-web-platform` → 04-web-and-network 100%完了
- Fixed `translation-status.js` to exclude `08-hobby` from count (751 → 735 total)

## Files

- `03-web-apis/02-intersection-resize-observer.md`
- `04-storage-and-caching/02-performance-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)