### PR TITLE
migrate: web-development

### DIFF
--- a/04-web-and-network/nodejs-development/SKILL.md
+++ b/04-web-and-network/nodejs-development/SKILL.md
@@ -1,6 +1,6 @@
 # Node.js Development Skill
 
-A practical guide collection for Node.js development. Covers all aspects of Node.js application development, including Express, NestJS, asynchronous patterns, and performance optimization.
+> A practical guide collection for Node.js development. Covers all aspects of Node.js application development, including Express, NestJS, asynchronous patterns, and performance optimization.
 
 ## Overview
 

--- a/04-web-and-network/web-development/SKILL.md
+++ b/04-web-and-network/web-development/SKILL.md
@@ -5,6 +5,8 @@ description: Fundamentals of modern web development. Framework selection (React,
 
 # Web Development Skill
 
+> Fundamentals of modern web development. Framework selection (React, Vue, Next.js), project architecture, state management, routing, build tools, and CSS strategy best practices.
+
 ## Table of Contents
 
 ### Fundamentals (this file)

--- a/04-web-and-network/web-development/SKILL.md
+++ b/04-web-and-network/web-development/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: web-development
+description: Fundamentals of modern web development. Framework selection (React, Vue, Next.js), project architecture, state management, routing, build tools, and CSS strategy best practices.
+---
+
+# Web Development Skill
+
+## Table of Contents
+
+### Fundamentals (this file)
+1. [Overview](#overview)
+2. [When to Use](#when-to-use)
+3. [Framework Selection](#framework-selection)
+4. [Project Structure](#project-structure)
+5. [Development Environment](#development-environment)
+6. [Practical Examples](#practical-examples)
+7. [Anti-patterns](#anti-patterns)
+
+### Detailed Guides
+1. [Framework Selection — Complete Guide](./docs/01-framework-selection/framework-selection-complete.md)
+2. [State Management — Complete Guide](./docs/02-state-management/state-management-complete.md)
+3. [Project Architecture — Complete Guide](./docs/03-project-architecture/project-architecture-complete.md)
+
+---
+
+## Overview
+
+This skill covers modern web development fundamentals:
+
+- **Framework selection** — React, Vue, Next.js, Remix, etc.
+- **Project architecture** — Directory structure, file naming conventions
+- **State management** — Context API, Redux, Zustand, Jotai
+- **Routing** — React Router, Next.js App Router
+- **Build tools** — Vite, Webpack, Turbopack
+- **CSS strategy** — Tailwind CSS, CSS Modules, Styled Components
+
+## Official Documentation
+
+- **[MDN Web Docs](https://developer.mozilla.org/)** — Comprehensive web technology reference
+- **[React Documentation](https://react.dev/)** — React library
+- **[Next.js Documentation](https://nextjs.org/docs)** — Next.js framework
+- **[Vue.js Documentation](https://vuejs.org/guide/)** — Vue.js framework
+- **[web.dev](https://web.dev/)** — Google's modern web development guide
+
+---
+
+## When to Use
+
+### Required
+- [ ] Starting a new web project (framework selection)
+- [ ] Designing project architecture
+- [ ] Deciding on a state management strategy
+- [ ] Choosing a CSS strategy
+
+### Periodic
+- [ ] Updating dependencies
+- [ ] Performance optimization
+- [ ] Adding major new features
+
+---
+
+## Framework Selection
+
+| Framework | Use Case | Pros | Cons |
+|-----------|----------|------|------|
+| **Next.js** | Full-stack web apps | SSR/SSG built-in, SEO optimized, App Router | Higher learning curve |
+| **React (Vite)** | SPA, admin dashboards | Simple, flexible | SEO requires extra work |
+| **Remix** | Full-stack | Nested routing, great UX | Smaller ecosystem |
+| **Vue (Nuxt)** | Full-stack | Easier to learn | Smaller ecosystem than React |
+| **Astro** | Content sites | Extremely fast, partial hydration | Not suited for complex apps |
+
+### Decision Flowchart
+
+```
+Is SEO critical?
+├─ Yes → Need server-side rendering
+│   ├─ Prefer React → Next.js
+│   └─ Prefer Vue  → Nuxt.js
+└─ No → SPA is fine
+    ├─ Admin panel / internal tool → React + Vite
+    └─ Content-focused site → Astro
+```
+
+---
+
+## Project Structure
+
+### Next.js App Router (recommended)
+
+```
+project/
+├── app/
+│   ├── (marketing)/
+│   │   ├── layout.tsx
+│   │   ├── page.tsx          # /
+│   │   └── about/page.tsx    # /about
+│   ├── dashboard/
+│   │   ├── layout.tsx
+│   │   └── page.tsx          # /dashboard
+│   ├── api/
+│   │   └── users/route.ts    # /api/users
+│   ├── layout.tsx
+│   └── globals.css
+├── components/
+│   ├── ui/                   # shadcn/ui etc.
+│   └── features/
+├── lib/
+│   ├── utils.ts
+│   ├── api.ts
+│   └── db.ts
+├── hooks/
+├── types/
+└── public/
+```
+
+### React + Vite (SPA)
+
+```
+project/
+├── src/
+│   ├── pages/
+│   ├── components/
+│   │   ├── Header.tsx
+│   │   └── ui/
+│   ├── hooks/
+│   ├── lib/
+│   ├── store/
+│   ├── types/
+│   ├── App.tsx
+│   └── main.tsx
+└── public/
+```
+
+---
+
+## Development Environment
+
+### Recommended Toolset
+
+```json
+{
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+**.prettierrc**
+```json
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}
+```
+
+**Git Hooks (Husky)**
+```bash
+pnpm add -D husky lint-staged
+```
+
+```json
+{
+  "lint-staged": {
+    "*.{ts,tsx}": ["eslint --fix", "prettier --write"]
+  }
+}
+```
+
+---
+
+## Practical Examples
+
+### Example 1: Next.js App Router project
+
+```bash
+pnpm create next-app@latest my-app --typescript --tailwind --app
+cd my-app
+pnpm add zustand zod react-hook-form
+pnpm dlx shadcn-ui@latest init
+```
+
+### Example 2: React + Vite (SPA)
+
+```bash
+pnpm create vite@latest my-app --template react-ts
+cd my-app
+pnpm install
+pnpm add react-router-dom zustand
+pnpm add -D tailwindcss postcss autoprefixer
+```
+
+### Example 3: State management with Zustand
+
+```typescript
+// store/userStore.ts
+import { create } from 'zustand'
+
+interface UserStore {
+  user: User | null
+  setUser: (user: User) => void
+  logout: () => void
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  logout: () => set({ user: null }),
+}))
+```
+
+```tsx
+import { useUserStore } from '@/store/userStore'
+
+export function UserProfile() {
+  const { user, logout } = useUserStore()
+  if (!user) return <div>Not logged in</div>
+  return (
+    <div>
+      <p>{user.name}</p>
+      <button onClick={logout}>Logout</button>
+    </div>
+  )
+}
+```
+
+---
+
+## Anti-patterns
+
+### Over-splitting Components
+
+```tsx
+// ❌ Unnecessary micro-components
+function UserName({ name }: { name: string }) { return <span>{name}</span> }
+function UserEmail({ email }: { email: string }) { return <span>{email}</span> }
+
+// ✅ Keep it simple
+function UserProfile({ user }: { user: User }) {
+  return <div><span>{user.name}</span><span>{user.email}</span></div>
+}
+```
+
+### Prop Drilling
+
+```tsx
+// ❌ Passing props through many layers
+function App() {
+  const [user, setUser] = useState<User | null>(null)
+  return <Dashboard user={user} setUser={setUser} />
+}
+
+// ✅ Use Zustand instead
+const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+}))
+```
+
+### Misusing useEffect for Data Fetching
+
+```tsx
+// ❌ Client-side fetch with useEffect
+function UserList() {
+  const [users, setUsers] = useState<User[]>([])
+  useEffect(() => {
+    fetch('/api/users').then(res => res.json()).then(setUsers)
+  }, [])
+}
+
+// ✅ Server Component (Next.js App Router)
+async function UserList() {
+  const users = await fetch('/api/users').then(res => res.json())
+  return <ul>{users.map(u => <li key={u.id}>{u.name}</li>)}</ul>
+}
+```
+
+---
+
+## Related Skills
+
+- **nextjs-development** — Next.js deep dive
+- **react-development** — React deep dive
+- **frontend-performance** — Performance optimization
+- **web-accessibility** — Accessibility
+
+---
+
+_Last updated: 2026-05-24_

--- a/04-web-and-network/web-development/docs/01-framework-selection/framework-selection-complete.md
+++ b/04-web-and-network/web-development/docs/01-framework-selection/framework-selection-complete.md
@@ -1,0 +1,1555 @@
+# Framework Selection — Complete Guide
+
+A comprehensive guide to comparing React, Next.js, Remix, Vue, Nuxt, and Astro to help you make the optimal framework choice.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [The 6 Major Frameworks](#the-6-major-frameworks)
+3. [Selection Criteria](#selection-criteria)
+4. [Detailed Comparison](#detailed-comparison)
+5. [Decision Flowchart](#decision-flowchart)
+6. [Use-Case Recommendations](#use-case-recommendations)
+7. [Real-World Case Studies](#real-world-case-studies)
+8. [Measured Performance Data](#measured-performance-data)
+9. [Migration Strategies](#migration-strategies)
+10. [Common Mistakes](#common-mistakes)
+11. [Summary](#summary)
+
+---
+
+## Overview
+
+### Why Framework Selection Matters
+
+Choosing the right framework can determine the success of your project:
+
+- **Development speed**: The right framework can improve development efficiency by 2–3x
+- **Performance**: Directly affects SEO and UX
+- **Maintainability**: Reduces long-term development costs
+- **Hiring**: Ease of recruiting developers
+
+### Who This Guide Is For
+
+- **Beginners**: Those choosing a framework for the first time
+- **Intermediate developers**: Those considering migration from an existing project
+- **Advanced developers**: Those optimizing across multiple projects
+
+---
+
+## The 6 Major Frameworks
+
+### 1. React (+ Vite)
+
+**Overview**: UI library developed by Meta + high-speed build tool
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+```
+
+**Characteristics**:
+- ✅ Largest ecosystem (300,000+ npm packages)
+- ✅ Abundant learning resources
+- ✅ High flexibility (free library selection)
+- ❌ No built-in SSR support (requires custom implementation)
+- ❌ Requires SEO workarounds
+
+**Typical use cases**:
+- Admin dashboards, internal tools
+- SPAs (Single Page Applications)
+- Applications where SEO is not required
+
+**Popularity**: 25M+ weekly npm downloads
+
+---
+
+### 2. Next.js
+
+**Overview**: React full-stack framework (developed by Vercel)
+
+```bash
+npx create-next-app@latest my-app --typescript --app
+```
+
+**Characteristics**:
+- ✅ Built-in SSR/SSG/ISR support
+- ✅ SEO optimization (search engine friendly)
+- ✅ Excellent DX with App Router (latest)
+- ✅ Optimized deployment to Vercel
+- ❌ High learning curve (Server Components, caching)
+- ❌ Deployment outside Vercel can be complex
+
+**Typical use cases**:
+- General websites (e-commerce, blogs, corporate sites)
+- SEO-critical applications
+- Full-stack applications
+
+**Popularity**: 7M+ weekly npm downloads
+
+---
+
+### 3. Remix
+
+**Overview**: React full-stack framework (acquired by Shopify)
+
+```bash
+npx create-remix@latest my-app
+```
+
+**Characteristics**:
+- ✅ Nested routing (excellent UX)
+- ✅ Excellent form handling (Progressive Enhancement)
+- ✅ Excellent error handling
+- ✅ Web standards-focused (FormData, fetch, etc.)
+- ❌ Smaller ecosystem
+- ❌ Less documentation in non-English languages
+
+**Typical use cases**:
+- Data-driven applications
+- Form-heavy applications
+- Complex routing requirements
+
+**Popularity**: 400K+ weekly npm downloads
+
+---
+
+### 4. Vue.js (+ Vite)
+
+**Overview**: Progressive framework developed by Evan You
+
+```bash
+npm create vue@latest
+```
+
+**Characteristics**:
+- ✅ Gentle learning curve
+- ✅ Thorough official documentation
+- ✅ Single File Components (.vue)
+- ✅ Composition API (similar to React Hooks)
+- ❌ Smaller ecosystem than React
+- ❌ Less corporate adoption than React
+
+**Typical use cases**:
+- Small to mid-size applications
+- Projects where lower learning cost is a priority
+- Teams that prefer Vue's template syntax
+
+**Popularity**: 5M+ weekly npm downloads
+
+---
+
+### 5. Nuxt.js
+
+**Overview**: Vue full-stack framework
+
+```bash
+npx nuxi@latest init my-app
+```
+
+**Characteristics**:
+- ✅ The Vue equivalent of Next.js (SSR/SSG/ISR)
+- ✅ Auto-imports (excellent developer experience)
+- ✅ Nuxt Modules (rich plugin ecosystem)
+- ✅ Active community
+- ❌ Smaller ecosystem than Next.js
+- ❌ Somewhat longer build times
+
+**Typical use cases**:
+- Vue + SSR/SEO requirements
+- Module-based feature extension
+- Teams already experienced with Vue
+
+**Popularity**: 800K+ weekly npm downloads
+
+---
+
+### 6. Astro
+
+**Overview**: Content-focused, ultra-fast framework
+
+```bash
+npm create astro@latest
+```
+
+**Characteristics**:
+- ✅ Zero JavaScript by default
+- ✅ Partial hydration (Islands Architecture)
+- ✅ Multiple frameworks can coexist (React, Vue, Svelte together)
+- ✅ Ultra-fast (Lighthouse 100 easily achievable)
+- ❌ Not suited for complex interactions
+- ❌ Smaller ecosystem
+
+**Typical use cases**:
+- Blogs, documentation sites
+- Landing pages
+- Content-centric sites
+
+**Popularity**: 300K+ weekly npm downloads
+
+---
+
+## Selection Criteria
+
+### 1. SEO Requirements
+
+| Priority | Recommended Framework | Reason |
+|----------|----------------------|--------|
+| **Critical** | Next.js, Nuxt.js, Remix | Built-in SSR, easy meta tag management |
+| **Moderate** | Astro | Optimized for static sites |
+| **Not needed** | React + Vite, Vue + Vite | SPA — admin dashboards without SEO needs |
+
+**Measured results**:
+- **Next.js SSR**: Google search indexing within 24 hours
+- **React SPA**: Indexing in 3–7 days (waiting for crawler)
+
+---
+
+### 2. Performance
+
+| Metric | Astro | Next.js SSG | Remix | Next.js SSR | React SPA | Nuxt.js |
+|--------|-------|-------------|-------|-------------|-----------|---------|
+| **Lighthouse Score** | 100 | 95–100 | 90–95 | 85–95 | 75–90 | 85–95 |
+| **TTFB** | 10–50ms | 50–200ms | 100–300ms | 200–500ms | 50–150ms | 150–350ms |
+| **Initial bundle** | 0–20KB | 80–120KB | 100–150KB | 80–120KB | 150–300KB | 100–180KB |
+
+**Measured example** (blog site with identical content):
+
+```
+Astro:
+- Lighthouse: 100
+- TTFB: 18ms
+- LCP: 320ms
+- JavaScript: 5KB
+
+Next.js SSG:
+- Lighthouse: 98
+- TTFB: 85ms
+- LCP: 450ms
+- JavaScript: 95KB
+
+React SPA:
+- Lighthouse: 82
+- TTFB: 120ms
+- LCP: 1,200ms
+- JavaScript: 220KB
+```
+
+---
+
+### 3. Learning Cost
+
+| Framework | Learning time (beginner) | Difficulty | Key topics |
+|-----------|--------------------------|------------|------------|
+| **Vue.js** | 1–2 weeks | ★☆☆☆☆ | Basic syntax, Composition API |
+| **React** | 2–3 weeks | ★★☆☆☆ | Hooks, state management |
+| **Nuxt.js** | 2–3 weeks | ★★☆☆☆ | Vue + SSR concepts |
+| **Next.js** | 3–4 weeks | ★★★☆☆ | React + SSR/SSG/ISR + App Router |
+| **Remix** | 3–4 weeks | ★★★☆☆ | React + Loader/Action + nested routing |
+| **Astro** | 1–2 weeks | ★★☆☆☆ | Basic syntax + Islands |
+
+**Learning curve**:
+
+```
+Difficulty
+ High │                    Next.js (App Router)
+      │                   /         Remix
+      │                  /         /
+      │                 /         /
+      │      Next.js   /  Nuxt  /
+      │      (Pages)  /        /
+      │             /  React  /  Astro
+      │            /         /  /
+      │      Vue  /         /  /
+ Low  │         /         /  /
+      └────────────────────────── Time
+           1w   2w   3w   4w
+```
+
+---
+
+### 4. Ecosystem
+
+| Framework | npm packages | UI libraries | State management | Official support |
+|-----------|-------------|--------------|------------------|-----------------|
+| **React** | 300,000+ | MUI, Ant Design, Chakra UI | Redux, Zustand, Jotai | Meta |
+| **Next.js** | React + own | shadcn/ui, Next UI | Same as React | Vercel |
+| **Vue** | 80,000+ | Vuetify, Element Plus | Pinia, Vuex | Community |
+| **Nuxt** | Vue + own | Nuxt UI | Same as Pinia | NuxtLabs |
+| **Remix** | React + own | Same as React | Same as React | Shopify |
+| **Astro** | 5,000+ | Multi-framework | Not needed (static) | Astro |
+
+**React's advantage in popular UI libraries**:
+- Material-UI: React-only (3M weekly downloads)
+- Ant Design: React version most complete (2M weekly downloads)
+- shadcn/ui: React-only (rapidly growing)
+
+---
+
+### 5. Team Skills
+
+| Current skills | Recommended framework | Reason |
+|---------------|----------------------|--------|
+| **HTML/CSS/JS only** | Vue.js, Nuxt.js | Gentle learning curve |
+| **React experience** | Next.js, Remix | Leverage existing knowledge |
+| **Vue experience** | Nuxt.js | Leverage existing knowledge |
+| **No frontend experience** | Vue.js → Nuxt.js | Gradual learning |
+| **Backend developer** | Next.js, Remix | Full-stack development |
+
+---
+
+### 6. Deployment Environment
+
+| Hosting | Recommended framework | Notes |
+|---------|----------------------|-------|
+| **Vercel** | Next.js | Optimized deployment experience |
+| **Netlify** | Next.js, Nuxt, Astro | Good support |
+| **Cloudflare Pages** | Remix, Next.js, Astro | Edge deployment |
+| **AWS/GCP** | All | High flexibility but complex setup |
+| **Static hosting** | Astro, Next.js SSG | GitHub Pages, S3, etc. |
+
+**Measured deployment times**:
+
+```
+Vercel (Next.js):
+- Build + deploy: 1m 30s
+- Preview URL: immediate
+
+Netlify (Nuxt):
+- Build + deploy: 2m 15s
+- Preview URL: immediate
+
+Cloudflare Pages (Remix):
+- Build + deploy: 1m 45s
+- Global edge distribution
+```
+
+---
+
+### 7. Project Scale
+
+| Scale | Recommended framework | Reason |
+|-------|----------------------|--------|
+| **Small (1–3 people, 1–3 months)** | React + Vite, Vue | Simple, flexible |
+| **Medium (3–10 people, 3–12 months)** | Next.js, Nuxt, Remix | Standardized, efficient |
+| **Large (10+ people, 12+ months)** | Next.js | Ecosystem, easy hiring |
+
+**Code volume guidelines**:
+
+```
+Small project:  5,000–20,000 LOC
+Medium project: 20,000–100,000 LOC
+Large project:  100,000+ LOC
+```
+
+---
+
+### 8. TypeScript Support
+
+| Framework | TypeScript support | Type definition quality | Setup ease |
+|-----------|-------------------|------------------------|------------|
+| **Next.js** | ◎ Built-in | ◎ Perfect | ◎ Automatic |
+| **Remix** | ◎ Built-in | ◎ Perfect | ◎ Automatic |
+| **Nuxt.js** | ◎ Built-in | ○ Good | ◎ Automatic |
+| **Astro** | ◎ Built-in | ○ Good | ◎ Automatic |
+| **React + Vite** | ○ Template selection | ◎ Perfect | ○ Manual setup needed |
+| **Vue + Vite** | ○ Template selection | ○ Good | ○ Manual setup needed |
+
+TypeScript is usable with all frameworks, but **Next.js, Remix, and Nuxt have the easiest initial setup**.
+
+---
+
+### 9. Developer Experience (DX)
+
+| Framework | HMR speed | Error messages | DevTools | Overall DX |
+|-----------|-----------|---------------|----------|------------|
+| **Vite-based (React, Vue)** | ⚡ Ultra-fast | ○ | ○ | ◎ |
+| **Next.js** | ○ Fast | ◎ Helpful | ◎ React DevTools | ◎ |
+| **Remix** | ○ Fast | ◎ Helpful | ○ | ○ |
+| **Nuxt.js** | ○ Fast | ○ | ◎ Vue DevTools | ◎ |
+| **Astro** | ⚡ Ultra-fast | ○ | △ | ○ |
+
+**HMR (Hot Module Replacement) measurements**:
+
+```
+Vite (React):
+- Change → reflection: 50–100ms
+
+Next.js:
+- Change → reflection: 200–500ms
+
+Nuxt.js:
+- Change → reflection: 300–600ms
+```
+
+---
+
+### 10. Cost
+
+| Framework | Dev cost | Infrastructure cost (100K PV/month) | Overall cost |
+|-----------|----------|-------------------------------------|-------------|
+| **Astro** | Low | Free–$10 (static hosting) | ★☆☆☆☆ |
+| **Next.js SSG** | Medium | Free–$20 (Vercel Hobby–Pro) | ★★☆☆☆ |
+| **React SPA** | Low | Free–$10 (static hosting) | ★☆☆☆☆ |
+| **Next.js SSR** | High | $20–$100 (Vercel Pro+) | ★★★★☆ |
+| **Remix** | Medium | $20–$100 (Cloudflare, etc.) | ★★★☆☆ |
+| **Nuxt SSR** | Medium | $20–$80 (Netlify, etc.) | ★★★☆☆ |
+
+**Measured example** (500K PV/month, e-commerce site):
+
+```
+Next.js SSR (Vercel Pro):
+- Monthly: $80–$120
+- Reason: Data updates via Server Actions, ISR usage
+
+Astro + API (Netlify):
+- Monthly: $15–$25
+- Reason: Static site + separate serverless API
+```
+
+---
+
+## Detailed Comparison
+
+### React vs Next.js
+
+| Aspect | React + Vite | Next.js |
+|--------|-------------|---------|
+| **SEO** | △ Additional setup required | ◎ Built-in |
+| **Initial load** | Slow (CSR) | Fast (SSR/SSG) |
+| **Dev speed** | Fast (HMR) | Slightly slower |
+| **Flexibility** | ◎ Completely free | ○ Has conventions |
+| **Learning cost** | Low | High |
+| **Deployment** | Simple (static) | Complex (with SSR) |
+
+**When to use each**:
+- **React**: Admin dashboards, internal tools, no SEO needed
+- **Next.js**: General websites, SEO-critical, full-stack
+
+---
+
+### Next.js vs Remix
+
+| Aspect | Next.js | Remix |
+|--------|---------|-------|
+| **Ecosystem** | ◎ Huge | △ Small |
+| **Form handling** | ○ Server Actions | ◎ Loader/Action |
+| **Routing** | ○ App Router | ◎ Nested routing |
+| **Error handling** | ○ Error Boundary | ◎ Excellent |
+| **Caching** | Complex | Simple |
+| **Deployment** | Optimized for Vercel | Optimized for Cloudflare |
+
+**When to use each**:
+- **Next.js**: Ecosystem priority, Vercel deployment, large-scale projects
+- **Remix**: Form-heavy, nested routing required, web standards priority
+
+---
+
+### Vue vs React
+
+| Aspect | Vue | React |
+|--------|-----|-------|
+| **Learning curve** | ◎ Gentle | ○ Slightly steep |
+| **Ecosystem** | ○ Medium | ◎ Largest |
+| **Documentation** | ◎ Thorough | ○ Somewhat less |
+| **Job market** | △ Fewer positions | ◎ Many positions |
+| **Syntax** | Templates | JSX |
+| **State management** | Pinia | Zustand, Redux, etc. |
+
+**When to use each**:
+- **Vue**: Lower learning cost priority, mid to small scale
+- **React**: Job market priority, large scale, ecosystem priority
+
+---
+
+### Nuxt vs Next.js
+
+| Aspect | Nuxt.js | Next.js |
+|--------|---------|---------|
+| **Base** | Vue | React |
+| **Auto-imports** | ◎ Built-in | △ Manual |
+| **Modules** | ◎ Rich | ○ Plugin-based |
+| **Documentation** | ◎ Extensive | ○ Somewhat less |
+| **Ecosystem** | ○ Medium | ◎ Huge |
+| **Deployment** | Netlify, etc. | Optimized for Vercel |
+
+**When to use each**:
+- **Nuxt**: Vue experience, auto-import priority, thorough documentation
+- **Next.js**: React experience, ecosystem priority, large scale
+
+---
+
+### Astro vs Next.js (Static Sites)
+
+| Aspect | Astro | Next.js SSG |
+|--------|-------|-------------|
+| **Performance** | ◎ Best | ○ Good |
+| **JavaScript size** | 0–20KB | 80–120KB |
+| **Lighthouse** | 100 easily | 95–100 |
+| **Interactivity** | △ Limited | ◎ Free |
+| **Build time** | Fast | Slightly slow |
+| **Learning cost** | Low | Medium |
+
+**When to use each**:
+- **Astro**: Blogs, documentation, landing pages, performance-critical
+- **Next.js SSG**: High interactivity, potential future SSR needs
+
+---
+
+## Decision Flowchart
+
+### Level 1: SEO Requirements
+
+```
+Is SEO critical?
+├─ Yes → Server-side rendering required
+│         ├─ React-based preferred → Next.js or Remix
+│         │   ├─ Planning Vercel deployment → Next.js
+│         │   ├─ Form-heavy → Remix
+│         │   └─ Unsure → Next.js (ecosystem)
+│         ├─ Vue-based preferred → Nuxt.js
+│         └─ Mainly static content → Astro
+│
+└─ No → SPA is fine
+          ├─ React-based → React + Vite
+          ├─ Vue-based → Vue + Vite
+          └─ Performance-critical → Astro (partial interactivity)
+```
+
+### Level 2: Project Characteristics
+
+```
+If you chose Next.js:
+├─ Mainly marketing site, blog → SSG-centered
+├─ E-commerce, real-time data → SSR + ISR
+├─ Dashboard, admin panel → SSR or CSR
+└─ Hybrid → Mix with App Router
+
+If you chose Remix:
+├─ Data-driven application → Leverage Loaders
+├─ Form-heavy application → Leverage Actions
+└─ Complex nested routing → Leverage nesting
+
+If you chose Astro:
+├─ Fully static site → Standard build
+├─ Partial interactivity → Islands
+└─ Multi-framework → Mix React + Vue
+```
+
+### Level 3: Team and Organization
+
+```
+Check team situation:
+├─ Many React developers → Next.js or Remix
+├─ Many Vue developers → Nuxt.js
+├─ Many beginners → Vue → Nuxt (learning curve)
+├─ Full-stack oriented → Next.js, Remix, Nuxt
+└─ Frontend specialists → React + Vite, Vue + Vite
+
+Organization scale:
+├─ Startup (1–5 people) → React + Vite, Vue + Vite (flexibility)
+├─ Growth phase (5–20 people) → Next.js, Nuxt (standardization)
+└─ Enterprise (20+ people) → Next.js (ecosystem, easy hiring)
+```
+
+---
+
+## Use-Case Recommendations
+
+### 1. E-Commerce Site
+
+**Recommended**: Next.js (1st), Remix (2nd)
+
+**Reasons**:
+- SEO is critical (product page indexing)
+- ISR for real-time inventory updates
+- Server Actions for cart operations
+- Payment processing (server-side required)
+
+**Implementation example**:
+
+```typescript
+// Next.js App Router
+// app/products/[id]/page.tsx
+
+export async function generateStaticParams() {
+  const products = await getProducts()
+  return products.map((p) => ({ id: p.id }))
+}
+
+export default async function ProductPage({ params }: { params: { id: string } }) {
+  // ISR: regenerate every 10 seconds
+  const product = await fetch(`/api/products/${params.id}`, {
+    next: { revalidate: 10 }
+  }).then(res => res.json())
+
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      <p>{product.price}</p>
+      <AddToCartButton productId={product.id} />
+    </div>
+  )
+}
+```
+
+**Results**:
+- One e-commerce site: After adopting Next.js, average SEO ranking improved by +15 positions
+- Conversion rate: +22% (from LCP improvement)
+
+---
+
+### 2. Blog / Media Site
+
+**Recommended**: Astro (1st), Next.js SSG (2nd)
+
+**Reasons**:
+- Mainly static content
+- Performance is critical (affects ad revenue)
+- SEO required
+- Few interactions
+
+**Implementation example (Astro)**:
+
+```astro
+---
+// src/pages/blog/[slug].astro
+import { getCollection } from 'astro:content'
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog')
+  return posts.map(post => ({
+    params: { slug: post.slug },
+    props: { post }
+  }))
+}
+
+const { post } = Astro.props
+const { Content } = await post.render()
+---
+
+<article>
+  <h1>{post.data.title}</h1>
+  <Content />
+</article>
+```
+
+**Results**:
+- One tech blog: After migrating to Astro, Lighthouse 82 → 100
+- Page load speed: -68% (2.8s → 0.9s)
+- Bounce rate: -15%
+
+---
+
+### 3. SaaS Admin Panel
+
+**Recommended**: React + Vite (1st), Next.js (2nd)
+
+**Reasons**:
+- No SEO needed (post-login screens)
+- Complex interactions
+- Real-time updates
+- Development speed priority (fast HMR)
+
+**Implementation example (React + Vite)**:
+
+```tsx
+// src/pages/Dashboard.tsx
+import { useQuery } from '@tanstack/react-query'
+import { useUserStore } from '@/store/userStore'
+
+export function Dashboard() {
+  const user = useUserStore(state => state.user)
+
+  const { data: stats } = useQuery({
+    queryKey: ['stats', user?.id],
+    queryFn: () => fetchStats(user!.id),
+    refetchInterval: 30000 // update every 30 seconds
+  })
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <StatsChart data={stats} />
+      <RecentActivity userId={user!.id} />
+    </div>
+  )
+}
+```
+
+**Results**:
+- One SaaS: React SPA reduced development period by 30% compared to Next.js
+- HMR: 50–100ms (vs 200–500ms for Next.js)
+
+---
+
+### 4. Corporate Website
+
+**Recommended**: Next.js SSG (1st), Astro (2nd)
+
+**Reasons**:
+- SEO important (corporate information search)
+- Low update frequency (SSG optimal)
+- Contact form (Server Actions)
+- Reliability-focused
+
+**Implementation example (Next.js SSG)**:
+
+```typescript
+// app/page.tsx
+export default async function Home() {
+  // Fetch data at build time (SSG)
+  const news = await getLatestNews()
+
+  return (
+    <main>
+      <Hero />
+      <NewsSection news={news} />
+      <ContactForm />
+    </main>
+  )
+}
+
+// app/contact/actions.ts
+'use server'
+
+export async function submitContact(formData: FormData) {
+  const data = {
+    name: formData.get('name'),
+    email: formData.get('email'),
+    message: formData.get('message')
+  }
+
+  await sendEmail(data)
+  return { success: true }
+}
+```
+
+---
+
+### 5. Landing Page
+
+**Recommended**: Astro (1st), Next.js SSG (2nd)
+
+**Reasons**:
+- Performance is critical (directly affects conversion rate)
+- Single page (simple)
+- SEO required
+- Mostly static
+
+**Implementation example (Astro + React Islands)**:
+
+```astro
+---
+// src/pages/index.astro
+import Hero from '@/components/Hero.astro'
+import CTAForm from '@/components/CTAForm.tsx'
+---
+
+<html>
+  <body>
+    <Hero />
+    <CTAForm client:load />
+  </body>
+</html>
+```
+
+```tsx
+// src/components/CTAForm.tsx (React)
+export default function CTAForm() {
+  const [email, setEmail] = useState('')
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    await fetch('/api/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ email })
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={email} onChange={e => setEmail(e.target.value)} />
+      <button>Subscribe</button>
+    </form>
+  )
+}
+```
+
+**Results**:
+- One LP site: After adopting Astro, achieved Lighthouse 100
+- Conversion rate: +18% (LCP 1.2s → 0.3s)
+
+---
+
+### 6. Documentation Site
+
+**Recommended**: Astro (1st), Next.js (2nd), Docusaurus (3rd)
+
+**Reasons**:
+- Static content
+- Search functionality required
+- Heavy Markdown usage
+- Performance important
+
+**Consider documentation-specific frameworks**:
+- **Docusaurus** (by Meta): Documentation-focused, built-in search
+- **VitePress** (Vue): Ultra-fast, simple
+- **Nextra** (Next.js): Next.js-based, MDX support
+
+---
+
+### 7. Real-Time App (Chat, etc.)
+
+**Recommended**: Next.js (1st), Remix (2nd)
+
+**Reasons**:
+- WebSocket required
+- Server-side processing essential
+- Authentication/authorization important
+- Database integration
+
+**Implementation example (Next.js + Pusher)**:
+
+```typescript
+// app/chat/page.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import Pusher from 'pusher-js'
+
+export default function Chat() {
+  const [messages, setMessages] = useState<Message[]>([])
+
+  useEffect(() => {
+    const pusher = new Pusher(process.env.NEXT_PUBLIC_PUSHER_KEY!)
+    const channel = pusher.subscribe('chat')
+
+    channel.bind('message', (data: Message) => {
+      setMessages(prev => [...prev, data])
+    })
+
+    return () => pusher.disconnect()
+  }, [])
+
+  return <MessageList messages={messages} />
+}
+
+// app/api/message/route.ts
+export async function POST(request: Request) {
+  const data = await request.json()
+
+  // Deliver via Pusher
+  await pusher.trigger('chat', 'message', data)
+
+  return Response.json({ success: true })
+}
+```
+
+---
+
+### 8. Portfolio Site
+
+**Recommended**: Astro (1st), Next.js SSG (2nd)
+
+**Reasons**:
+- Performance-focused (first impressions)
+- Mostly static
+- Free deployment preferred
+- Simple
+
+**Results**:
+- Many developers choose Astro (free GitHub Pages deployment)
+- Lighthouse 100 is easily achievable
+
+---
+
+## Real-World Case Studies
+
+### Case 1: Large E-Commerce Site (Annual Revenue ¥10B)
+
+**Selection**: Next.js
+
+**Background**:
+- Products: 100,000 items
+- Monthly PV: 5M
+- SEO critical
+- Real-time inventory management
+
+**Deciding factors**:
+- ISR for efficient inventory updates
+- Vercel's global edge network
+- Huge React ecosystem (rich UI components)
+
+**Results**:
+- SEO ranking: Average +15 positions
+- Page load speed: -42% (3.2s → 1.85s)
+- Conversion rate: +22%
+- Development period: 6 months
+
+**Tech stack**:
+```
+- Next.js 14 App Router
+- TypeScript
+- Prisma (PostgreSQL)
+- Stripe (payments)
+- Vercel (hosting)
+- Tailwind CSS
+- shadcn/ui
+```
+
+---
+
+### Case 2: Startup SaaS Admin Panel
+
+**Selection**: React + Vite
+
+**Background**:
+- Team: 3 people
+- Development period: 2 months
+- No SEO needed (post-login)
+- Development speed top priority
+
+**Deciding factors**:
+- Ultra-fast HMR (50–100ms)
+- Flexibility (free library selection)
+- Low learning cost
+- Free deployment (Netlify)
+
+**Results**:
+- Development period: 2 months as planned
+- Initial bundle: 180KB (small)
+- Lighthouse: 85 (sufficient)
+
+**Tech stack**:
+```
+- React 18
+- Vite 5
+- TypeScript
+- Zustand (state management)
+- React Query
+- React Router
+- Tailwind CSS
+- Netlify (hosting)
+```
+
+---
+
+### Case 3: Personal Tech Blog
+
+**Selection**: Astro
+
+**Background**:
+- Posts: 200
+- Monthly PV: 100K
+- Performance-critical
+- Minimize costs (free deployment)
+
+**Deciding factors**:
+- Lighthouse 100 easily achievable
+- Built-in Markdown support
+- Free GitHub Pages deployment
+- Short build times
+
+**Results**:
+- Lighthouse: 100 achieved
+- LCP: 0.3s
+- Hosting cost: $0
+- Build time: 8 seconds (200 posts)
+
+**Tech stack**:
+```
+- Astro 4
+- Markdown/MDX
+- Tailwind CSS
+- GitHub Pages (free)
+```
+
+---
+
+### Case 4: Internal HR Tool
+
+**Selection**: Nuxt.js
+
+**Background**:
+- Team: 5 people (Vue-experienced)
+- Internal use only (SEO not needed but SSR desired)
+- Strong Vue experience in team
+
+**Deciding factors**:
+- All team members have Vue experience
+- Auto-imports improve development speed
+- Rich Nuxt Modules for easy feature extension
+- Active community
+
+**Results**:
+- Development period: 4 months
+- Auto-imports improved productivity by +15%
+- Nuxt UI Module reduced UI development time by -30%
+
+**Tech stack**:
+```
+- Nuxt 3
+- TypeScript
+- Pinia (state management)
+- Nuxt UI
+- Supabase (backend)
+```
+
+---
+
+### Case 5: SMB Corporate Website
+
+**Selection**: Next.js SSG
+
+**Background**:
+- Pages: 20
+- Update frequency: Once a month
+- SEO important
+- Contact form required
+
+**Deciding factors**:
+- SSG for high speed (all pages statically generated)
+- Server Actions for simple form handling
+- Easy CMS integration (Contentful)
+- Available on Vercel free plan
+
+**Results**:
+- Lighthouse: 98
+- SEO: Within top 10 for targeted keywords in 3 months
+- Hosting cost: $0 (Vercel Hobby)
+
+**Tech stack**:
+```
+- Next.js 14 SSG
+- TypeScript
+- Contentful (CMS)
+- Tailwind CSS
+- Vercel (free)
+```
+
+---
+
+### Case 6: Data Analytics Dashboard
+
+**Selection**: Remix
+
+**Background**:
+- Many complex forms
+- Nested routing
+- Real-time data display
+- Web standards priority
+
+**Deciding factors**:
+- Loader/Action makes data fetch/update concise
+- Nested routing for partial UI updates
+- Excellent error handling
+- Edge deployment via Cloudflare Pages
+
+**Results**:
+- Form implementation time: -40% compared to Next.js
+- Improved UX during errors (partial error display)
+- Low latency even for global deployments (edge)
+
+**Tech stack**:
+```
+- Remix
+- TypeScript
+- Prisma (PostgreSQL)
+- Tailwind CSS
+- Cloudflare Pages
+```
+
+---
+
+### Case 7: Landing Page (Marketing Campaign)
+
+**Selection**: Astro + React
+
+**Background**:
+- Single page only
+- Performance-critical (high ad spend)
+- Only one interactive form
+- Built in a short period (1 week)
+
+**Deciding factors**:
+- Lighthouse 100 mandatory
+- Minimize JavaScript
+- Only form part is interactive (React)
+- Free static hosting
+
+**Results**:
+- Lighthouse: 100 achieved
+- LCP: 0.28s
+- Conversion rate: +25% above industry average
+- Development period: 5 days
+
+**Tech stack**:
+```
+- Astro
+- React (Islands)
+- Tailwind CSS
+- Netlify (free)
+```
+
+---
+
+### Case 8: Recipe Sharing Site (User-Generated Content)
+
+**Selection**: Next.js
+
+**Background**:
+- User submission feature
+- Image upload
+- SEO critical (recipe search)
+- Real-time search
+
+**Deciding factors**:
+- ISR for efficient caching of user submissions
+- Next/Image for image optimization
+- Server Actions for submission processing
+- Vercel Image Optimization
+
+**Results**:
+- Monthly submissions: 5,000
+- Image optimization reduced bandwidth by -65%
+- SEO: Popular recipes appearing at the top
+
+**Tech stack**:
+```
+- Next.js 14
+- TypeScript
+- Prisma (PostgreSQL)
+- Cloudinary (image storage)
+- Vercel
+```
+
+---
+
+### Case 9: OSS Documentation Site
+
+**Selection**: VitePress
+
+**Background**:
+- Open source project
+- Documentation only
+- Contributor-friendly
+- Free hosting
+
+**Deciding factors**:
+- VitePress (Vue) is ultra-fast
+- Easy Markdown writing
+- Built-in search
+- Free GitHub Pages
+
+**Results**:
+- Lighthouse: 100
+- Build time: 3 seconds (100 pages)
+- Increased contributors (easy to contribute via Markdown)
+
+**Tech stack**:
+```
+- VitePress
+- Markdown
+- GitHub Pages (free)
+```
+
+---
+
+### Case 10: Multi-Tenant SaaS
+
+**Selection**: Next.js
+
+**Background**:
+- Multiple companies (subdomain-based)
+- Large scale (1M users)
+- Complex authentication/authorization
+- Rich customization features
+
+**Deciding factors**:
+- App Router handles complex routing
+- Middleware for subdomain detection
+- Rich ecosystem (auth libraries, etc.)
+- Scale with Vercel Enterprise
+
+**Results**:
+- Stable operation (99.9% uptime)
+- Multi-tenancy via subdomains
+- Efficiently implemented customization features
+
+**Tech stack**:
+```
+- Next.js 14
+- TypeScript
+- Prisma (PostgreSQL)
+- NextAuth.js
+- Vercel Enterprise
+- Redis (cache)
+```
+
+---
+
+## Measured Performance Data
+
+### Build Time Comparison (Same project: 50 pages)
+
+| Framework | First build | Incremental build | CI/CD time |
+|-----------|------------|-------------------|------------|
+| **Astro** | 8s | 1s | 45s |
+| **Next.js SSG** | 32s | 5s | 1m 20s |
+| **Next.js SSR** | 15s | 3s | 55s |
+| **Nuxt SSG** | 42s | 6s | 1m 35s |
+| **Remix** | 18s | 4s | 1m |
+| **React + Vite** | 6s | 0.5s | 35s |
+
+**Measurement environment**: MacBook Pro M2, 16GB RAM
+
+---
+
+### Initial Bundle Size Comparison (after gzip)
+
+| Framework | JavaScript | CSS | Total | Page load time |
+|-----------|------------|-----|-------|----------------|
+| **Astro** | 5KB | 8KB | 13KB | 0.3s |
+| **Next.js SSG** | 95KB | 12KB | 107KB | 0.9s |
+| **Next.js SSR** | 95KB | 12KB | 107KB | 1.2s (incl. TTFB) |
+| **Remix** | 120KB | 10KB | 130KB | 1.4s (incl. TTFB) |
+| **Nuxt SSG** | 110KB | 15KB | 125KB | 1.1s |
+| **React SPA** | 180KB | 8KB | 188KB | 1.5s |
+
+**Measured with**: Lighthouse, Chrome DevTools (Fast 3G)
+
+---
+
+### Lighthouse Score Comparison (Same content)
+
+| Framework | Performance | SEO | Accessibility | Best Practices |
+|-----------|-------------|-----|---------------|----------------|
+| **Astro** | 100 | 100 | 95 | 100 |
+| **Next.js SSG** | 98 | 100 | 95 | 100 |
+| **Next.js SSR** | 92 | 100 | 95 | 100 |
+| **Nuxt SSG** | 95 | 100 | 95 | 100 |
+| **Remix** | 90 | 100 | 95 | 100 |
+| **React SPA** | 78 | 85 | 95 | 95 |
+
+---
+
+### Core Web Vitals Comparison
+
+| Framework | LCP | INP | CLS | TTFB |
+|-----------|-----|-----|-----|------|
+| **Astro** | 0.3s | 20ms | 0.01 | 18ms |
+| **Next.js SSG** | 0.9s | 35ms | 0.02 | 85ms |
+| **Next.js SSR** | 1.2s | 40ms | 0.03 | 320ms |
+| **Nuxt SSG** | 1.1s | 38ms | 0.02 | 95ms |
+| **Remix** | 1.4s | 45ms | 0.02 | 280ms |
+| **React SPA** | 2.2s | 55ms | 0.05 | 120ms |
+
+**Measurement environment**: Real server, Tokyo region, Fast 3G
+
+---
+
+### HMR Speed Comparison (Change → Reflection time)
+
+| Framework | CSS change | JSX/TSX change | Data change |
+|-----------|-----------|----------------|-------------|
+| **Vite-based** | 30ms | 50ms | 80ms |
+| **Next.js** | 100ms | 200ms | 300ms |
+| **Nuxt** | 120ms | 250ms | 350ms |
+| **Remix** | 90ms | 180ms | 280ms |
+
+**Measurement environment**: MacBook Pro M2, development server running
+
+---
+
+## Migration Strategies
+
+### React SPA → Next.js
+
+**Phased migration**:
+
+```
+Phase 1: Setup (1 week)
+├─ Create Next.js project
+├─ Copy existing code to src/app
+├─ Configure routing (App Router)
+└─ Migrate environment variables
+
+Phase 2: Page migration (2–4 weeks)
+├─ Convert static pages to SSG
+├─ Convert dynamic pages to SSR
+└─ Create API routes
+
+Phase 3: Optimization (1–2 weeks)
+├─ Convert to Server Components
+├─ Image optimization (Next/Image)
+├─ Implement caching strategy
+└─ Performance measurement
+
+Phase 4: Deployment (1 week)
+├─ Vercel configuration
+├─ Canary release
+├─ Production deployment
+└─ Monitoring setup
+```
+
+**Implementation example**:
+
+```tsx
+// Before: React SPA
+// src/pages/Home.tsx
+export function Home() {
+  const [posts, setPosts] = useState<Post[]>([])
+
+  useEffect(() => {
+    fetch('/api/posts')
+      .then(res => res.json())
+      .then(setPosts)
+  }, [])
+
+  return <PostList posts={posts} />
+}
+
+// After: Next.js App Router
+// app/page.tsx
+export default async function Home() {
+  const posts = await fetch('/api/posts').then(res => res.json())
+
+  return <PostList posts={posts} />
+}
+```
+
+**Migration period**: 4–8 weeks (depending on scale)
+
+---
+
+### Next.js Pages Router → App Router
+
+**Phased migration**:
+
+```
+Phase 1: Preparation (1 week)
+├─ Upgrade to Next.js 14
+├─ Create app/ directory
+└─ Confirm both routers can coexist
+
+Phase 2: Page migration (2–6 weeks)
+├─ Migrate static pages first
+│   getStaticProps → async function
+├─ Migrate dynamic pages
+│   getServerSideProps → async function
+└─ Migrate API routes
+    pages/api → app/api/route.ts
+
+Phase 3: Server Components conversion (1–3 weeks)
+├─ Mark Client Components ('use client')
+├─ Optimize Server Components
+└─ Improve data fetching
+
+Phase 4: Cleanup (1 week)
+├─ Delete pages/ directory
+├─ Remove unused dependencies
+└─ Verify build
+```
+
+**Implementation example**:
+
+```tsx
+// Before: Pages Router
+// pages/posts/[id].tsx
+export async function getServerSideProps({ params }) {
+  const post = await getPost(params.id)
+  return { props: { post } }
+}
+
+export default function PostPage({ post }: { post: Post }) {
+  return <Post data={post} />
+}
+
+// After: App Router
+// app/posts/[id]/page.tsx
+export default async function PostPage({ params }: { params: { id: string } }) {
+  const post = await getPost(params.id)
+  return <Post data={post} />
+}
+```
+
+**Migration period**: 4–10 weeks (depending on scale)
+
+---
+
+### Vue → Nuxt
+
+**Phased migration**:
+
+```
+Phase 1: Setup (1 week)
+├─ Create Nuxt project
+├─ Copy existing components to components/
+└─ Configure routing
+
+Phase 2: Page migration (2–4 weeks)
+├─ Vue Router routes → Nuxt pages/
+├─ Vuex store → Pinia store
+└─ Migrate environment variables
+
+Phase 3: SSR support (1–2 weeks)
+├─ Add asyncData
+├─ Leverage useFetch
+└─ Create server API
+
+Phase 4: Deployment (1 week)
+├─ Netlify/Vercel configuration
+└─ Production deployment
+```
+
+**Migration period**: 4–8 weeks (depending on scale)
+
+---
+
+## Common Mistakes
+
+### ❌ 1. Using Next.js for Every Project
+
+**Problem**:
+- Using Next.js even for admin dashboards or apps where SEO is not needed
+- High learning cost, over-engineering
+
+**Solution**:
+- No SEO needed → Consider React + Vite
+- Clarify project requirements before choosing a framework
+
+---
+
+### ❌ 2. Selecting Without Considering Performance
+
+**Problem**:
+- Building a content site with React SPA
+- Lighthouse score in the 60s
+
+**Solution**:
+- Content sites → Astro, Next.js SSG
+- Refer to measured performance data
+
+---
+
+### ❌ 3. Ignoring Team Skills
+
+**Problem**:
+- Introducing Next.js App Router to a team without React experience
+- 2–3 months of learning, causing development delays
+
+**Solution**:
+- Choose based on team skills
+- Vue-experienced team → Consider Nuxt.js
+
+---
+
+### ❌ 4. Not Considering the Deployment Environment
+
+**Problem**:
+- Chose Next.js SSR, then struggled on AWS EC2
+- Would have been easy with Vercel
+
+**Solution**:
+- Decide deployment target first
+- Vercel → Next.js, Cloudflare → Remix, etc.
+
+---
+
+### ❌ 5. Ignoring the Ecosystem
+
+**Problem**:
+- Adopted a new framework and found insufficient libraries
+- Ended up building needed features from scratch
+
+**Solution**:
+- Check in advance that required libraries exist
+- React/Next.js has the largest ecosystem
+
+---
+
+### ❌ 6. Not Considering Future Extensibility
+
+**Problem**:
+- Started with a static site (Astro)
+- Later needed interactions → had to rebuild
+
+**Solution**:
+- Consider future requirements as well
+- When in doubt, choose Next.js (high flexibility)
+
+---
+
+### ❌ 7. Not Considering Cost
+
+**Problem**:
+- Next.js SSR with 1M monthly PV
+- Vercel costs reached $500/month
+
+**Solution**:
+- If SSG is sufficient, use SSG
+- Predict traffic before choosing hosting
+
+---
+
+## Summary
+
+### Decision Matrix (Final)
+
+| Requirement | Recommended framework | Alternative |
+|-------------|----------------------|-------------|
+| **SEO critical + React** | Next.js | Remix |
+| **SEO critical + Vue** | Nuxt.js | — |
+| **Static site** | Astro | Next.js SSG |
+| **Admin panel** | React + Vite | Next.js |
+| **E-commerce** | Next.js | Remix |
+| **Blog** | Astro | Next.js SSG |
+| **SaaS** | React + Vite or Next.js | — |
+| **Landing page** | Astro | Next.js SSG |
+| **Documentation** | Astro, VitePress | Docusaurus |
+| **Real-time** | Next.js | Remix |
+
+---
+
+### 3 Steps to Selection
+
+1. **Check SEO requirements**
+   - Important → Next.js, Nuxt, Remix, Astro
+   - Not needed → React + Vite, Vue + Vite
+
+2. **Check team skills**
+   - React experience → Next.js, Remix
+   - Vue experience → Nuxt.js
+   - No experience → Vue → Nuxt.js
+
+3. **Check performance requirements**
+   - Top priority → Astro
+   - High priority → Next.js SSG, Nuxt SSG
+   - Standard → Next.js SSR, Remix
+
+---
+
+### Final Recommendations (2025)
+
+**When in doubt, choose Next.js**:
+- Largest ecosystem
+- Excellent DX from Vercel
+- High flexibility (supports SSR/SSG/ISR)
+- Advantageous in the job market
+
+**When performance is the top priority, choose Astro**:
+- Lighthouse 100 easily achievable
+- Minimal JavaScript
+- Optimal for static sites
+
+**When learning cost matters, choose Vue → Nuxt**:
+- Thorough documentation
+- Gentle learning curve
+
+---
+
+**Next step**: Create an actual project and experience the framework firsthand.
+
+---
+
+_When unsure about framework selection, clarify your project requirements first, then refer to this guide._

--- a/04-web-and-network/web-development/docs/02-state-management/state-management-complete.md
+++ b/04-web-and-network/web-development/docs/02-state-management/state-management-complete.md
@@ -1,0 +1,854 @@
+# State Management — Complete Guide
+
+Comprehensive guide to Context API, Zustand, Jotai, and Redux Toolkit.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [State Management Fundamentals](#state-management-fundamentals)
+3. [Context API](#context-api)
+4. [Zustand](#zustand)
+5. [Jotai](#jotai)
+6. [Redux Toolkit](#redux-toolkit)
+7. [Comparison](#comparison)
+8. [Decision Flowchart](#decision-flowchart)
+9. [Complete Implementation Examples](#complete-implementation-examples)
+10. [Performance Benchmarks](#performance-benchmarks)
+11. [Common Mistakes](#common-mistakes)
+
+---
+
+## Overview
+
+### Why State Management Matters
+
+The complexity of a React app is proportional to the complexity of its state:
+
+- **Avoid prop drilling**: Stop passing data through deeply nested component trees
+- **Global state**: Share state across many components
+- **Performance**: Prevent unnecessary re-renders
+- **Maintainability**: Make state changes easy to trace
+
+### Library Comparison at a Glance
+
+| Library | Type | Learning Curve | Bundle Size | Popularity |
+|---------|------|---------------|------------|------------|
+| **Context API** | React built-in | Low | 0KB | ◎ |
+| **Zustand** | Lightweight store | Low | 1.2KB | ◎ |
+| **Jotai** | Atomic | Medium | 3.2KB | ○ |
+| **Redux Toolkit** | Redux simplified | High | 12KB | ◎ |
+
+---
+
+## State Management Fundamentals
+
+### Types of State
+
+#### 1. Local State
+
+State used only within a single component.
+
+```tsx
+function Counter() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+**Examples**: form inputs, modal open/close, local UI state
+
+#### 2. Global State
+
+State shared across multiple components.
+
+```tsx
+// User info used by many components
+<Header user={user} />
+<Sidebar user={user} />
+<Content user={user} />
+```
+
+**Examples**: authenticated user, theme/language settings, shopping cart
+
+#### 3. Server State
+
+Data fetched from the server.
+
+```tsx
+const { data: posts, isLoading } = useQuery('posts', fetchPosts)
+```
+
+**Recommended libraries**:
+- **TanStack Query (React Query)** — most popular
+- **SWR** — by Vercel
+- **Apollo Client** — for GraphQL
+
+> **Important**: Server state should typically be managed with a dedicated library (React Query, etc.). Zustand/Redux are primarily for client state.
+
+#### 4. URL State
+
+State stored in the URL (search params, etc.).
+
+```tsx
+// /products?category=electronics&page=2
+const [searchParams] = useSearchParams()
+const category = searchParams.get('category')
+const page = searchParams.get('page')
+```
+
+**Examples**: search filters, pagination, active tab
+
+---
+
+### The Prop Drilling Problem
+
+```tsx
+// ❌ Prop drilling through many layers
+function App() {
+  const [user, setUser] = useState<User | null>(null)
+  return <Dashboard user={user} setUser={setUser} />
+}
+
+function Dashboard({ user, setUser }: Props) {
+  return <Sidebar user={user} setUser={setUser} />
+}
+
+function Sidebar({ user, setUser }: Props) {
+  return <UserMenu user={user} setUser={setUser} />
+}
+
+function UserMenu({ user, setUser }: Props) {
+  return <div>{user?.name}</div>  // Finally uses it
+}
+```
+
+**Problems**:
+- Intermediate components pass props they don't use
+- Changing shape requires updating multiple files
+- Duplicate type definitions
+
+**Solution**: Global state management (Context API, Zustand, etc.)
+
+---
+
+## Context API
+
+### Overview
+
+**React's built-in global state management**
+
+- ✅ No additional library required
+- ✅ Low learning curve
+- ✅ Full TypeScript support
+- ❌ Performance optimization is tricky
+- ❌ Multiple contexts can lead to verbose code
+
+### Basic Usage
+
+```tsx
+// contexts/UserContext.tsx
+import { createContext, useContext, useState, useMemo, ReactNode } from 'react'
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+interface UserContextType {
+  user: User | null
+  setUser: (user: User | null) => void
+  logout: () => void
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined)
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const logout = () => setUser(null)
+
+  const value = useMemo(() => ({ user, setUser, logout }), [user])
+
+  return (
+    <UserContext.Provider value={value}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export function useUser() {
+  const context = useContext(UserContext)
+  if (!context) throw new Error('useUser must be used within UserProvider')
+  return context
+}
+```
+
+```tsx
+// App.tsx
+import { UserProvider } from '@/contexts/UserContext'
+
+export default function App() {
+  return (
+    <UserProvider>
+      <Dashboard />
+    </UserProvider>
+  )
+}
+
+// Dashboard.tsx
+import { useUser } from '@/contexts/UserContext'
+
+export function Dashboard() {
+  const { user, logout } = useUser()
+  if (!user) return <Login />
+  return (
+    <div>
+      <h1>Welcome, {user.name}</h1>
+      <button onClick={logout}>Logout</button>
+    </div>
+  )
+}
+```
+
+### Performance Optimization
+
+**Problem**: When Context value changes, ALL child components re-render.
+
+```tsx
+// ❌ Single context for everything
+function AppProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [settings, setSettings] = useState<Settings>(defaultSettings)
+
+  // When either user or settings changes, ALL children re-render
+  return (
+    <AppContext.Provider value={{ user, setUser, settings, setSettings }}>
+      {children}
+    </AppContext.Provider>
+  )
+}
+```
+
+**Solution 1**: Split contexts by concern
+
+```tsx
+// ✅ Separate contexts
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const value = useMemo(() => ({ user, setUser }), [user])
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(defaultSettings)
+  const value = useMemo(() => ({ settings, setSettings }), [settings])
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+// App.tsx
+<UserProvider>
+  <SettingsProvider>
+    <App />
+  </SettingsProvider>
+</UserProvider>
+```
+
+### When to Use Context API
+
+**✅ Good fit**:
+- Small to medium apps
+- Few global state values (1–3)
+- Avoiding extra dependencies
+- Simple state like theme or language settings
+
+**❌ Avoid when**:
+- Large apps with many global state values
+- Frequently updated state
+- Complex state logic
+- Performance is critical
+
+---
+
+## Zustand
+
+### Overview
+
+**Lightweight, flexible state management**
+
+- ✅ Tiny (1.2KB)
+- ✅ Low learning curve
+- ✅ Hooks-based (feels like React)
+- ✅ Full TypeScript support
+- ✅ Redux DevTools compatible
+- ✅ Excellent performance
+- ✅ No Provider required
+
+### Basic Usage
+
+```bash
+npm install zustand
+```
+
+```tsx
+// store/userStore.ts
+import { create } from 'zustand'
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+interface UserStore {
+  user: User | null
+  setUser: (user: User) => void
+  logout: () => void
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  logout: () => set({ user: null }),
+}))
+```
+
+```tsx
+// Dashboard.tsx
+import { useUserStore } from '@/store/userStore'
+
+export function Dashboard() {
+  const { user, logout } = useUserStore()
+  if (!user) return <Login />
+  return (
+    <div>
+      <h1>Welcome, {user.name}</h1>
+      <button onClick={logout}>Logout</button>
+    </div>
+  )
+}
+```
+
+**No Provider needed — just import and use.**
+
+### Selectors for Performance
+
+```tsx
+// ❌ Subscribes to the entire store — re-renders on any change
+function UserName() {
+  const store = useUserStore()
+  return <div>{store.user?.name}</div>
+}
+
+// ✅ Subscribes only to user — re-renders only when user changes
+function UserName() {
+  const user = useUserStore(state => state.user)
+  return <div>{user?.name}</div>
+}
+```
+
+### Middleware
+
+#### persist — survive page reload
+
+```tsx
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      logout: () => set({ user: null }),
+    }),
+    { name: 'user-storage' }  // localStorage key
+  )
+)
+```
+
+#### devtools — Redux DevTools integration
+
+```tsx
+import { devtools } from 'zustand/middleware'
+
+export const useUserStore = create<UserStore>()(
+  devtools(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }, false, 'setUser'),
+      logout: () => set({ user: null }, false, 'logout'),
+    }),
+    { name: 'UserStore' }
+  )
+)
+```
+
+#### immer — mutable-style updates
+
+```tsx
+import { immer } from 'zustand/middleware/immer'
+
+export const useTodoStore = create<TodoStore>()(
+  immer((set) => ({
+    todos: [],
+    addTodo: (text) =>
+      set((state) => {
+        state.todos.push({ id: nanoid(), text, done: false })
+      }),
+    toggleTodo: (id) =>
+      set((state) => {
+        const todo = state.todos.find((t) => t.id === id)
+        if (todo) todo.done = !todo.done
+      }),
+  }))
+)
+```
+
+### Multiple Stores
+
+```tsx
+// Use multiple stores in one component
+function Header() {
+  const user = useUserStore(state => state.user)
+  const cartCount = useCartStore(state => state.items.length)
+  const theme = useSettingsStore(state => state.theme)
+
+  return <header>{/* ... */}</header>
+}
+```
+
+### When to Use Zustand
+
+**✅ Good fit**: Small to large apps, want simple API, care about bundle size.
+
+> **When in doubt, choose Zustand** — it handles most use cases well.
+
+**❌ Consider alternatives when**:
+- You want full Redux patterns → Redux Toolkit
+- You want atomic state design → Jotai
+
+---
+
+## Jotai
+
+### Overview
+
+**Atomic state management (inspired by Recoil)**
+
+- ✅ Atomic (fine-grained state units)
+- ✅ Minimal boilerplate
+- ✅ Full TypeScript support
+- ✅ Suspense compatible
+- ❌ Medium learning curve (atomic concept)
+- ❌ Larger than Zustand (3.2KB)
+
+### Basic Usage
+
+```bash
+npm install jotai
+```
+
+```tsx
+// atoms/userAtom.ts
+import { atom } from 'jotai'
+
+export const userAtom = atom<User | null>(null)
+```
+
+```tsx
+// Dashboard.tsx
+import { useAtom } from 'jotai'
+import { userAtom } from '@/atoms/userAtom'
+
+export function Dashboard() {
+  const [user, setUser] = useAtom(userAtom)
+  if (!user) return <Login />
+  return (
+    <div>
+      <h1>Welcome, {user.name}</h1>
+      <button onClick={() => setUser(null)}>Logout</button>
+    </div>
+  )
+}
+```
+
+### Derived Atoms
+
+```tsx
+import { atom } from 'jotai'
+
+const cartItemsAtom = atom<CartItem[]>([])
+
+// Derived atom — computed from cartItemsAtom
+const cartTotalAtom = atom((get) => {
+  const items = get(cartItemsAtom)
+  return items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+})
+
+const cartCountAtom = atom((get) => get(cartItemsAtom).length)
+
+function CartSummary() {
+  const total = useAtomValue(cartTotalAtom)
+  const count = useAtomValue(cartCountAtom)
+  return <div>{count} items — ${total.toFixed(2)}</div>
+}
+```
+
+### When to Use Jotai
+
+**✅ Good fit**: Fine-grained reactivity, complex derived state, Suspense usage.
+
+**❌ Avoid when**: Team prefers simpler Zustand API, or Redux patterns required.
+
+---
+
+## Redux Toolkit
+
+### Overview
+
+**Official Redux package — significantly reduced boilerplate**
+
+- ✅ Industry standard for large apps
+- ✅ Excellent DevTools
+- ✅ Time-travel debugging
+- ✅ Predictable state flow
+- ❌ Higher learning curve
+- ❌ Larger bundle (12KB)
+- ❌ More verbose than Zustand
+
+### Basic Usage
+
+```bash
+npm install @reduxjs/toolkit react-redux
+```
+
+```tsx
+// store/userSlice.ts
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+interface UserState {
+  user: User | null
+  isLoading: boolean
+  error: string | null
+}
+
+const initialState: UserState = {
+  user: null,
+  isLoading: false,
+  error: null,
+}
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    setUser: (state, action: PayloadAction<User>) => {
+      state.user = action.payload
+    },
+    logout: (state) => {
+      state.user = null
+    },
+    setLoading: (state, action: PayloadAction<boolean>) => {
+      state.isLoading = action.payload
+    },
+  },
+})
+
+export const { setUser, logout, setLoading } = userSlice.actions
+export default userSlice.reducer
+```
+
+```tsx
+// store/index.ts
+import { configureStore } from '@reduxjs/toolkit'
+import userReducer from './userSlice'
+import cartReducer from './cartSlice'
+
+export const store = configureStore({
+  reducer: {
+    user: userReducer,
+    cart: cartReducer,
+  },
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+```
+
+```tsx
+// App.tsx
+import { Provider } from 'react-redux'
+import { store } from '@/store'
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <Dashboard />
+    </Provider>
+  )
+}
+
+// Dashboard.tsx
+import { useSelector, useDispatch } from 'react-redux'
+import { RootState } from '@/store'
+import { logout } from '@/store/userSlice'
+
+export function Dashboard() {
+  const user = useSelector((state: RootState) => state.user.user)
+  const dispatch = useDispatch()
+
+  if (!user) return <Login />
+  return (
+    <div>
+      <h1>Welcome, {user.name}</h1>
+      <button onClick={() => dispatch(logout())}>Logout</button>
+    </div>
+  )
+}
+```
+
+### When to Use Redux Toolkit
+
+**✅ Good fit**: Large enterprise apps, existing Redux codebase, strong DevTools requirements, complex async flows.
+
+**❌ Overkill for**: Small/medium apps, new projects without Redux history.
+
+---
+
+## Comparison
+
+| Feature | Context API | Zustand | Jotai | Redux Toolkit |
+|---------|-------------|---------|-------|---------------|
+| Bundle size | 0KB | 1.2KB | 3.2KB | 12KB |
+| Learning curve | Low | Low | Medium | High |
+| Provider required | Yes | No | Provider optional | Yes |
+| DevTools | No | Yes | Yes | Excellent |
+| Performance | Manual optimization | Auto with selectors | Fine-grained | Excellent |
+| Boilerplate | Low | Very low | Very low | Medium |
+| Async support | Manual | Manual | Built-in | createAsyncThunk |
+
+---
+
+## Decision Flowchart
+
+```
+New project?
+├─ Small app (< 5 global states, < 3 devs)
+│   └─ Context API + useState (no extra library)
+├─ Medium app (typical SaaS/dashboard)
+│   └─ Zustand ← recommended default
+├─ Large app (enterprise, 15+ devs)
+│   ├─ Complex state + strong DevTools needed → Redux Toolkit
+│   └─ Fine-grained reactivity needed → Jotai
+└─ Existing Redux project → Redux Toolkit (stick with it)
+```
+
+---
+
+## Complete Implementation Examples
+
+### Shopping Cart (Zustand)
+
+```tsx
+// store/cartStore.ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface CartItem {
+  id: string
+  name: string
+  price: number
+  quantity: number
+}
+
+interface CartStore {
+  items: CartItem[]
+  addItem: (item: Omit<CartItem, 'quantity'>) => void
+  removeItem: (id: string) => void
+  updateQuantity: (id: string, quantity: number) => void
+  clearCart: () => void
+  total: () => number
+}
+
+export const useCartStore = create<CartStore>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      addItem: (item) =>
+        set((state) => {
+          const existing = state.items.find((i) => i.id === item.id)
+          if (existing) {
+            return {
+              items: state.items.map((i) =>
+                i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+              ),
+            }
+          }
+          return { items: [...state.items, { ...item, quantity: 1 }] }
+        }),
+      removeItem: (id) =>
+        set((state) => ({ items: state.items.filter((i) => i.id !== id) })),
+      updateQuantity: (id, quantity) =>
+        set((state) => ({
+          items:
+            quantity === 0
+              ? state.items.filter((i) => i.id !== id)
+              : state.items.map((i) => (i.id === id ? { ...i, quantity } : i)),
+        })),
+      clearCart: () => set({ items: [] }),
+      total: () =>
+        get().items.reduce((sum, item) => sum + item.price * item.quantity, 0),
+    }),
+    { name: 'cart-storage' }
+  )
+)
+```
+
+```tsx
+// components/Cart.tsx
+export function Cart() {
+  const { items, removeItem, updateQuantity, total } = useCartStore()
+
+  if (items.length === 0) return <p>Your cart is empty</p>
+
+  return (
+    <div>
+      {items.map((item) => (
+        <div key={item.id}>
+          <span>{item.name}</span>
+          <input
+            type="number"
+            value={item.quantity}
+            onChange={(e) => updateQuantity(item.id, Number(e.target.value))}
+            min={0}
+          />
+          <span>${(item.price * item.quantity).toFixed(2)}</span>
+          <button onClick={() => removeItem(item.id)}>Remove</button>
+        </div>
+      ))}
+      <div>Total: ${total().toFixed(2)}</div>
+    </div>
+  )
+}
+```
+
+### Authentication (Zustand + persist)
+
+```tsx
+// store/authStore.ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface AuthStore {
+  token: string | null
+  user: User | null
+  login: (token: string, user: User) => void
+  logout: () => void
+  isAuthenticated: () => boolean
+}
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set, get) => ({
+      token: null,
+      user: null,
+      login: (token, user) => set({ token, user }),
+      logout: () => set({ token: null, user: null }),
+      isAuthenticated: () => !!get().token,
+    }),
+    { name: 'auth-storage' }
+  )
+)
+```
+
+---
+
+## Performance Benchmarks
+
+### Scenario: 10 child components, 1 updates state
+
+| Method | Re-renders | Update Time |
+|--------|-----------|-------------|
+| Context (single, no split) | 10/10 | 8ms |
+| Context (split by concern) | 3/10 | 2ms (-75%) |
+| Zustand (no selector) | 10/10 | 6ms |
+| Zustand (with selector) | 3/10 | 1.5ms (-75%) |
+| Jotai (atom) | 1–3/10 | 1ms |
+| Redux Toolkit | 3/10 | 2ms |
+
+---
+
+## Common Mistakes
+
+### ❌ Context re-render on every render
+
+```tsx
+// ❌ New object created every render = all consumers re-render
+function Provider({ children }) {
+  const [user, setUser] = useState(null)
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+// ✅ Memoize the value
+function Provider({ children }) {
+  const [user, setUser] = useState(null)
+  const value = useMemo(() => ({ user, setUser }), [user])
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+}
+```
+
+### ❌ Zustand without selectors
+
+```tsx
+// ❌ Re-renders on any store change
+const { user, cart, settings } = useStore()
+
+// ✅ Subscribe to specific slices
+const user = useStore(state => state.user)
+const cartCount = useStore(state => state.cart.length)
+```
+
+### ❌ Storing server state in global state
+
+```tsx
+// ❌ Managing server data in Zustand
+const usePostStore = create((set) => ({
+  posts: [],
+  isLoading: false,
+  fetchPosts: async () => {
+    set({ isLoading: true })
+    const posts = await api.getPosts()
+    set({ posts, isLoading: false })
+  },
+}))
+
+// ✅ Use TanStack Query for server state
+const { data: posts, isLoading } = useQuery({
+  queryKey: ['posts'],
+  queryFn: api.getPosts,
+})
+```
+
+### ❌ One giant store for everything
+
+```tsx
+// ❌ Everything in one store
+const useStore = create((set) => ({
+  user: null,
+  cart: [],
+  settings: {},
+  posts: [],
+  comments: [],
+  notifications: [],
+  // ... 50 more fields
+}))
+
+// ✅ Split by domain
+const useUserStore = create(...)
+const useCartStore = create(...)
+const useSettingsStore = create(...)
+```

--- a/04-web-and-network/web-development/docs/03-project-architecture/project-architecture-complete.md
+++ b/04-web-and-network/web-development/docs/03-project-architecture/project-architecture-complete.md
@@ -1,0 +1,599 @@
+# Project Architecture — Complete Guide
+
+Scalable directory structures, build tools, CSS strategy, and development environment setup.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Directory Structure](#directory-structure)
+3. [File Naming Conventions](#file-naming-conventions)
+4. [Module Splitting Strategy](#module-splitting-strategy)
+5. [Build Tool Comparison](#build-tool-comparison)
+6. [CSS Strategy Comparison](#css-strategy-comparison)
+7. [Development Environment Setup](#development-environment-setup)
+8. [Monorepo Structure](#monorepo-structure)
+9. [Performance Data](#performance-data)
+10. [Common Mistakes](#common-mistakes)
+
+---
+
+## Overview
+
+### Why Project Architecture Matters
+
+A well-structured project directly impacts long-term development velocity:
+
+- **Scalability**: Structure that holds up with 100+ engineers
+- **Maintainability**: Understandable 6 months later
+- **Onboarding**: New members productive in a day
+- **Build time**: Up to 50% faster builds with proper structure
+
+---
+
+## Directory Structure
+
+### Next.js App Router (Small: 1–3 people)
+
+```
+project/
+├── app/
+│   ├── (marketing)/
+│   │   ├── page.tsx          # /
+│   │   ├── about/page.tsx    # /about
+│   │   └── contact/page.tsx  # /contact
+│   ├── blog/
+│   │   ├── page.tsx          # /blog
+│   │   └── [slug]/page.tsx   # /blog/[slug]
+│   ├── api/
+│   │   └── posts/route.ts
+│   ├── layout.tsx
+│   └── globals.css
+├── components/
+│   ├── ui/
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   └── input.tsx
+│   └── header.tsx
+├── lib/
+│   ├── utils.ts
+│   └── api.ts
+├── public/
+├── .env.local
+├── next.config.js
+├── tailwind.config.ts
+└── package.json
+```
+
+**Characteristics**: Simple, ~50 files, entire codebase fits in one person's head.
+
+---
+
+### Next.js App Router (Medium: 5–15 people)
+
+```
+project/
+├── app/
+│   ├── (marketing)/
+│   │   ├── layout.tsx
+│   │   ├── page.tsx
+│   │   ├── about/page.tsx
+│   │   └── pricing/page.tsx
+│   ├── (dashboard)/
+│   │   ├── layout.tsx
+│   │   ├── dashboard/page.tsx
+│   │   ├── settings/page.tsx
+│   │   └── profile/page.tsx
+│   ├── api/
+│   │   ├── auth/[...nextauth]/route.ts
+│   │   ├── posts/route.ts
+│   │   └── users/route.ts
+│   ├── layout.tsx
+│   └── globals.css
+├── components/
+│   ├── ui/
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   ├── dialog.tsx
+│   │   └── input.tsx
+│   ├── marketing/
+│   │   ├── hero.tsx
+│   │   ├── features.tsx
+│   │   └── pricing-table.tsx
+│   ├── dashboard/
+│   │   ├── sidebar.tsx
+│   │   └── stats-card.tsx
+│   └── layout/
+│       ├── header.tsx
+│       └── footer.tsx
+├── lib/
+│   ├── api/
+│   │   ├── posts.ts
+│   │   └── users.ts
+│   ├── utils/
+│   │   ├── format.ts
+│   │   └── date.ts
+│   └── db.ts
+├── hooks/
+│   ├── use-user.ts
+│   └── use-posts.ts
+├── types/
+│   ├── user.ts
+│   └── post.ts
+├── store/
+│   ├── userStore.ts
+│   └── uiStore.ts
+└── config/
+    ├── site.ts
+    └── constants.ts
+```
+
+**Characteristics**: Feature-grouped directories, 50–200 files, team can own domains.
+
+---
+
+### Next.js App Router (Large: 15+ people, Feature-based)
+
+```
+project/
+├── app/
+│   ├── (marketing)/
+│   ├── (dashboard)/
+│   ├── (admin)/
+│   ├── api/
+│   └── layout.tsx
+├── features/
+│   ├── auth/
+│   │   ├── components/
+│   │   │   ├── login-form.tsx
+│   │   │   └── signup-form.tsx
+│   │   ├── hooks/
+│   │   │   └── use-auth.ts
+│   │   ├── api/
+│   │   │   └── auth.ts
+│   │   ├── types/
+│   │   │   └── auth.ts
+│   │   └── index.ts
+│   ├── posts/
+│   │   ├── components/
+│   │   │   ├── post-card.tsx
+│   │   │   └── post-editor.tsx
+│   │   ├── hooks/
+│   │   ├── api/
+│   │   ├── types/
+│   │   └── index.ts
+│   └── users/
+│       ├── components/
+│       ├── hooks/
+│       ├── api/
+│       ├── types/
+│       └── index.ts
+├── components/         # Shared across all features
+│   ├── ui/
+│   └── layout/
+├── lib/
+│   ├── api/
+│   ├── utils/
+│   └── db/
+│       ├── client.ts
+│       └── schema.ts
+├── tests/
+│   ├── unit/
+│   ├── integration/
+│   └── e2e/
+└── docs/
+    ├── architecture.md
+    └── api.md
+```
+
+**Characteristics**: Feature-based isolation, 200–1000+ files, teams own features independently.
+
+**Advantages of feature-based architecture**:
+- Easy to add/remove features
+- Clear impact boundary
+- Fewer merge conflicts
+
+---
+
+### React + Vite (SPA, Medium)
+
+```
+project/
+├── src/
+│   ├── pages/
+│   │   ├── Home.tsx
+│   │   ├── Dashboard.tsx
+│   │   └── Settings.tsx
+│   ├── components/
+│   │   ├── ui/
+│   │   └── layout/
+│   │       ├── Header.tsx
+│   │       ├── Sidebar.tsx
+│   │       └── Footer.tsx
+│   ├── hooks/
+│   │   ├── useAuth.ts
+│   │   └── useApi.ts
+│   ├── lib/
+│   │   ├── api.ts
+│   │   └── utils.ts
+│   ├── store/
+│   │   ├── userStore.ts
+│   │   └── uiStore.ts
+│   ├── routes/
+│   │   └── index.tsx
+│   ├── types/
+│   ├── App.tsx
+│   └── main.tsx
+├── public/
+├── index.html
+├── vite.config.ts
+└── package.json
+```
+
+---
+
+## File Naming Conventions
+
+### Components
+
+```
+✅ Good (PascalCase):
+- Button.tsx
+- UserProfile.tsx
+- PostCard.tsx
+
+❌ Bad:
+- button.tsx     (lowercase)
+- user-profile.tsx (kebab-case)
+- userProfile.tsx  (camelCase)
+```
+
+### Utilities and Hooks
+
+```
+✅ Good (camelCase):
+- useAuth.ts
+- useUser.ts
+- formatDate.ts
+- validateEmail.ts
+
+❌ Bad:
+- UseAuth.ts    (PascalCase)
+- use-auth.ts   (kebab-case)
+- format-date.ts
+```
+
+### Directories
+
+```
+✅ Good (kebab-case):
+- user-profile/
+- post-editor/
+- api-client/
+
+❌ Bad:
+- UserProfile/  (PascalCase)
+- userProfile/  (camelCase)
+```
+
+---
+
+## Module Splitting Strategy
+
+### Feature-based vs Layer-based
+
+| Approach | Pros | Cons | Best for |
+|----------|------|------|----------|
+| **Layer-based** | Simple, familiar | Cross-feature changes touch many dirs | Small teams |
+| **Feature-based** | Clear ownership, less coupling | More upfront structure | Medium/large teams |
+
+**Layer-based** (components/, hooks/, lib/, store/):
+- Familiar structure
+- Good for small apps
+
+**Feature-based** (features/auth/, features/posts/):
+- Each feature is self-contained
+- Teams own entire features
+- Better for scaling
+
+### Import Rules
+
+```typescript
+// ✅ Feature can import from shared/components
+import { Button } from '@/components/ui/button'
+import { formatDate } from '@/lib/utils'
+
+// ❌ Features should not import from each other directly
+import { useAuth } from '@/features/auth'  // OK if exported via index.ts
+import { PostCard } from '@/features/posts/components/post-card'  // BAD — use index.ts
+
+// ✅ Cross-feature access via public interface
+import { PostCard } from '@/features/posts'  // via features/posts/index.ts
+```
+
+---
+
+## Build Tool Comparison
+
+| Tool | HMR | Production Build | Config | Best for |
+|------|-----|-----------------|--------|----------|
+| **Vite** | ~80ms | ~18s | Simple | New projects, SPA |
+| **Turbopack** | ~30ms | ~12s | Next.js only | Next.js projects |
+| **Webpack** | ~300ms | ~45s | Complex | Legacy projects |
+
+### Vite Configuration
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+          router: ['react-router-dom'],
+        },
+      },
+    },
+  },
+})
+```
+
+---
+
+## CSS Strategy Comparison
+
+| Strategy | Bundle Size | DX | Runtime cost | Best for |
+|----------|------------|-----|-------------|----------|
+| **Tailwind CSS** | 8–30KB | ✅ Great | None | Most projects |
+| **CSS Modules** | Per-component | ✅ Good | None | Component libraries |
+| **Styled Components** | +13KB | ✅ Good | Small | Complex theming |
+| **Vanilla CSS** | Minimal | Moderate | None | Simple projects |
+
+### Tailwind CSS Setup
+
+```bash
+npm install -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+```
+
+```javascript
+// tailwind.config.ts
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f0f9ff',
+          500: '#3b82f6',
+          900: '#1e3a5f',
+        },
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config
+```
+
+### CSS Modules
+
+```tsx
+// Button.module.css
+.button {
+  padding: 8px 16px;
+  border-radius: 4px;
+}
+
+.primary {
+  background: #3b82f6;
+  color: white;
+}
+
+// Button.tsx
+import styles from './Button.module.css'
+
+export function Button({ variant = 'primary', children }) {
+  return (
+    <button className={`${styles.button} ${styles[variant]}`}>
+      {children}
+    </button>
+  )
+}
+```
+
+---
+
+## Development Environment Setup
+
+### ESLint
+
+```json
+// .eslintrc.json
+{
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "error",
+    "prefer-const": "error",
+    "no-console": ["warn", { "allow": ["error"] }]
+  }
+}
+```
+
+### Prettier
+
+```json
+// .prettierrc
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}
+```
+
+### Git Hooks with Husky
+
+```bash
+pnpm add -D husky lint-staged
+npx husky install
+npx husky add .husky/pre-commit "npx lint-staged"
+```
+
+```json
+// package.json
+{
+  "lint-staged": {
+    "*.{ts,tsx}": ["eslint --fix", "prettier --write"],
+    "*.{json,md,css}": ["prettier --write"]
+  }
+}
+```
+
+### TypeScript Configuration
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+---
+
+## Monorepo Structure
+
+### Turborepo Setup
+
+```
+monorepo/
+├── apps/
+│   ├── web/          # Main web app (Next.js)
+│   ├── admin/        # Admin panel (Next.js)
+│   └── mobile/       # Mobile app (React Native)
+├── packages/
+│   ├── ui/           # Shared UI components
+│   │   ├── src/
+│   │   │   ├── button.tsx
+│   │   │   └── index.ts
+│   │   └── package.json
+│   ├── utils/        # Shared utilities
+│   └── types/        # Shared TypeScript types
+├── turbo.json
+└── package.json
+```
+
+```json
+// turbo.json
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {},
+    "test": {}
+  }
+}
+```
+
+---
+
+## Performance Data
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| Vite HMR | 300ms (Webpack) | 80ms | -73% |
+| Turbopack HMR | 300ms (Webpack) | 30ms | -90% |
+| Production build | 45s (Webpack) | 18s (Vite) | -60% |
+| Tailwind CSS bundle | 200KB (no purge) | 8–30KB | -85–96% |
+| Feature-based: merge conflicts | High | Low | Significant |
+
+---
+
+## Common Mistakes
+
+### ❌ No Path Aliases
+
+```typescript
+// ❌ Relative hell
+import { Button } from '../../../components/ui/button'
+
+// ✅ Alias
+import { Button } from '@/components/ui/button'
+```
+
+### ❌ Everything in components/
+
+```
+// ❌ Flat structure
+components/
+├── Header.tsx
+├── UserProfile.tsx
+├── LoginForm.tsx
+├── Dashboard.tsx
+└── ProductCard.tsx
+
+// ✅ Organized by concern
+components/ui/          # Generic UI primitives
+components/layout/      # Layout components
+features/auth/          # Auth-specific
+features/products/      # Product-specific
+```
+
+### ❌ Inconsistent Naming
+
+```
+// ❌ Mixed naming
+UserProfile.tsx
+user-settings.tsx
+useauth.ts
+
+// ✅ Consistent
+UserProfile.tsx    (components: PascalCase)
+useAuth.ts         (hooks: camelCase)
+formatDate.ts      (utils: camelCase)
+```
+
+### ❌ No .env.example
+
+```bash
+# ❌ Missing template — new devs don't know what's needed
+
+# ✅ Always commit .env.example
+DATABASE_URL=postgresql://...
+NEXTAUTH_SECRET=your-secret-here
+STRIPE_SECRET_KEY=sk_test_...
+```


### PR DESCRIPTION
Migrate and translate web-development skill from _legacy to 04-web-and-network.

- SKILL.md (overview, framework selection, project structure, anti-patterns)
- docs/01-framework-selection/framework-selection-complete.md (already existed)
- docs/02-state-management/state-management-complete.md (Context API, Zustand, Jotai, Redux Toolkit)
- docs/03-project-architecture/project-architecture-complete.md (directory structures, build tools, CSS strategy)