### PR TITLE
feat(react): 02-hooks セクション追加（useState / useEffect / カスタムフック）

### DIFF
--- a/ja/04-web-and-network/react-development/docs/02-hooks/01-usestate-deep-dive.md
+++ b/ja/04-web-and-network/react-development/docs/02-hooks/01-usestate-deep-dive.md
@@ -1,0 +1,695 @@
+
+# useState の深い理解と実践パターン
+
+## この章で学べること
+
+この章では、Reactの最も基本的なHookである `useState` を、実践的な視点から深く理解します。
+
+- Discriminated Union パターンによる型安全な状態管理
+- Lazy Initialization（遅延初期化）のパフォーマンス改善効果
+- Functional Update（関数型更新）の正しい使い方
+- バッチ更新の仕組みと想定される効果
+- よくある失敗パターンと対策
+
+**前提知識**: useState の基本的な使い方
+
+**所要時間**: 40-50分
+
+
+## 目次
+
+1. [useState の基本おさらい](#1-usestate-の基本おさらい)
+2. [Discriminated Union パターン](#2-discriminated-union-パターン)
+3. [Lazy Initialization（遅延初期化）](#3-lazy-initialization遅延初期化)
+4. [Functional Update（関数型更新）](#4-functional-update関数型更新)
+5. [バッチ更新の仕組み](#5-バッチ更新の仕組み)
+6. [よくある失敗パターン](#6-よくある失敗パターン)
+7. [想定パフォーマンスデータ](#7-想定パフォーマンスデータ)
+8. [まとめ](#8-まとめ)
+
+
+## 1. useState の基本おさらい
+
+### 1.1 基本的な使い方
+
+まず、useState の基本的な使い方をおさらいしましょう。
+
+```typescript
+import { useState } from 'react'
+
+function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>+1</button>
+    </div>
+  )
+}
+```
+
+これは誰でも知っている基本的な使い方です。しかし、実務ではもっと深い理解が必要になります。
+
+### 1.2 TypeScript との組み合わせ
+
+TypeScript を使うことで、型安全な状態管理が可能になります。
+
+```typescript
+// - 型推論が効く（おすすめ）
+const [count, setCount] = useState(0) // number型と推論される
+const [name, setName] = useState('') // string型と推論される
+const [isOpen, setIsOpen] = useState(false) // boolean型と推論される
+
+// - 明示的に型を指定（nullableな場合）
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+const [user, setUser] = useState<User | null>(null)
+
+// ❌ 型エラーを防ぐ
+setUser({ name: 'John' }) // 型エラー！idとemailが必要
+```
+
+### 1.3 オブジェクトと配列の更新
+
+オブジェクトや配列を更新する際は、**イミュータブル（不変）な方法**で更新する必要があります。
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+// オブジェクトの部分的な更新
+const [user, setUser] = useState<User>({
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com'
+})
+
+// - スプレッド構文で更新
+setUser(prevUser => ({
+  ...prevUser,
+  name: 'Jane Doe' // nameだけ更新
+}))
+
+// 配列の操作
+interface Todo {
+  id: string
+  text: string
+  completed: boolean
+}
+
+const [todos, setTodos] = useState<Todo[]>([])
+
+// - 追加
+setTodos(prev => [...prev, { id: '1', text: 'New todo', completed: false }])
+
+// - 更新
+setTodos(prev =>
+  prev.map(todo =>
+    todo.id === '1' ? { ...todo, completed: true } : todo
+  )
+)
+
+// - 削除
+setTodos(prev => prev.filter(todo => todo.id !== '1'))
+```
+
+
+## 2. Discriminated Union パターン
+
+### 2.1 問題：複数の状態の整合性
+
+実務でよくある問題は、**複数の状態が整合性を保てない**ことです。
+
+```typescript
+// ❌ 悪い例：複数のuseState
+function BadDataFetching() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [data, setData] = useState<User[] | null>(null)
+
+  // 問題点：
+  // 1. loading=true かつ data が存在する状態が起こりうる
+  // 2. error と data が同時に存在する状態が起こりうる
+  // 3. 状態の整合性が保証されない
+}
+```
+
+### 2.2 解決：Discriminated Union（タグ付きユニオン）
+
+TypeScript の Discriminated Union を使うことで、状態を型安全に管理できます。
+
+```typescript
+// - 良い例：Discriminated Union
+type FetchState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error }
+
+function GoodDataFetching() {
+  const [state, setState] = useState<FetchState<User[]>>({ status: 'idle' })
+
+  const fetchUsers = async () => {
+    setState({ status: 'loading' })
+
+    try {
+      const response = await fetch('/api/users')
+      const data = await response.json()
+      setState({ status: 'success', data })
+    } catch (error) {
+      setState({ status: 'error', error: error as Error })
+    }
+  }
+
+  // TypeScriptが状態を正しく絞り込む
+  if (state.status === 'loading') {
+    return <Spinner />
+  }
+
+  if (state.status === 'error') {
+    return <ErrorMessage message={state.error.message} />
+  }
+
+  if (state.status === 'success') {
+    return (
+      <ul>
+        {state.data.map(user => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  return <button onClick={fetchUsers}>Fetch Users</button>
+}
+```
+
+### 2.3 メリット
+
+**1. 型安全性**
+- `status === 'success'` のとき、TypeScript は `data` が存在することを保証
+- `status === 'error'` のとき、`error` が存在することを保証
+- 不可能な状態（loading かつ data 存在）を型レベルで排除
+
+**2. 可読性**
+- 状態遷移が明確
+- コードレビューがしやすい
+
+**3. 保守性**
+- 新しい状態を追加しやすい
+- バグが混入しにくい
+
+
+## 3. Lazy Initialization（遅延初期化）
+
+### 3.1 問題：毎レンダリングで関数実行
+
+useState の初期値に関数の実行結果を渡すと、**毎レンダリングで関数が実行されます**。
+
+```typescript
+// ❌ 悪い例：毎レンダリングで expensiveComputation() が実行される
+function ExpensiveComponent() {
+  const [value] = useState(expensiveComputation()) // 毎回計算される！
+  return <div>{value}</div>
+}
+
+function expensiveComputation() {
+  console.log('Computing...') // 毎レンダリングでログが出る
+  // 重い計算...
+  return Math.random()
+}
+```
+
+### 3.2 解決：関数を渡す（Lazy Initialization）
+
+useState に**関数そのもの**を渡すことで、初回のみ実行されます。
+
+```typescript
+// - 良い例：初回のみ実行
+function OptimizedComponent() {
+  const [value] = useState(() => expensiveComputation()) // 初回のみ
+  return <div>{value}</div>
+}
+
+function expensiveComputation() {
+  console.log('Computing...') // 初回のみログが出る
+  // 重い計算...
+  return Math.random()
+}
+```
+
+### 3.3 実例：localStorage からの読み込み
+
+localStorage からの読み込みは重い処理なので、Lazy Initialization が有効です。
+
+```typescript
+function useLocalStorageState<T>(key: string, defaultValue: T) {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const item = localStorage.getItem(key)
+      return item ? JSON.parse(item) : defaultValue
+    } catch (error) {
+      console.error(`Error reading localStorage key "${key}":`, error)
+      return defaultValue
+    }
+  })
+
+  // localStorage への書き込みは useEffect で
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state))
+    } catch (error) {
+      console.error(`Error writing localStorage key "${key}":`, error)
+    }
+  }, [key, state])
+
+  return [state, setState] as const
+}
+
+// 使用例
+function App() {
+  const [theme, setTheme] = useLocalStorageState<'light' | 'dark'>('theme', 'light')
+
+  return (
+    <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+      Current: {theme}
+    </button>
+  )
+}
+```
+
+
+## 4. Functional Update（関数型更新）
+
+### 4.1 問題：古い値を参照
+
+useState の setter に直接値を渡すと、**古い値を参照する**問題が起こります。
+
+```typescript
+// ❌ 悪い例：古い値を参照
+function Counter() {
+  const [count, setCount] = useState(0)
+
+  const incrementTwice = () => {
+    setCount(count + 1) // 0 + 1 = 1
+    setCount(count + 1) // 0 + 1 = 1（期待は2だが、結果は1）
+  }
+
+  return <button onClick={incrementTwice}>{count}</button>
+}
+```
+
+**なぜ1になるのか？**
+- 両方の `setCount` は同じ `count` の値（0）を参照
+- バッチ更新により、最後の `setCount(1)` のみが適用される
+
+### 4.2 解決：関数形式の updater
+
+**関数形式の updater** を使うことで、常に最新の値を参照できます。
+
+```typescript
+// - 良い例：関数形式のupdater
+function Counter() {
+  const [count, setCount] = useState(0)
+
+  const incrementTwice = () => {
+    setCount(prev => prev + 1) // 0 + 1 = 1
+    setCount(prev => prev + 1) // 1 + 1 = 2（正しい）
+  }
+
+  return <button onClick={incrementTwice}>{count}</button>
+}
+```
+
+### 4.3 非同期処理での安全性
+
+非同期処理では、**必ず関数形式の updater** を使うべきです。
+
+```typescript
+function AsyncCounter() {
+  const [count, setCount] = useState(0)
+
+  const incrementAfterDelay = () => {
+    setTimeout(() => {
+      // - 常に最新の値を参照
+      setCount(prev => prev + 1)
+    }, 1000)
+  }
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={incrementAfterDelay}>+1 (after 1s)</button>
+    </div>
+  )
+}
+```
+
+### 4.4 複雑なオブジェクトの更新
+
+```typescript
+interface FormState {
+  name: string
+  email: string
+  age: number
+}
+
+function UserForm() {
+  const [form, setForm] = useState<FormState>({
+    name: '',
+    email: '',
+    age: 0
+  })
+
+  // - 関数形式で部分更新
+  const updateField = (field: keyof FormState, value: string | number) => {
+    setForm(prev => ({
+      ...prev,
+      [field]: value
+    }))
+  }
+
+  return (
+    <div>
+      <input
+        value={form.name}
+        onChange={(e) => updateField('name', e.target.value)}
+        placeholder="Name"
+      />
+      <input
+        value={form.email}
+        onChange={(e) => updateField('email', e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="number"
+        value={form.age}
+        onChange={(e) => updateField('age', parseInt(e.target.value))}
+        placeholder="Age"
+      />
+    </div>
+  )
+}
+```
+
+
+## 5. バッチ更新の仕組み
+
+### 5.1 React のバッチ更新
+
+React は、**複数の状態更新を1回のレンダリングにまとめます**（バッチ更新）。
+
+```typescript
+function BatchExample() {
+  const [count, setCount] = useState(0)
+  const [flag, setFlag] = useState(false)
+
+  const handleClick = () => {
+    console.log('Before updates')
+    setCount(count + 1)
+    setFlag(!flag)
+    console.log('After updates (not re-rendered yet)')
+    // ここでは再レンダリングはまだ起こらない
+  }
+
+  console.log('Rendering...') // クリックごとに1回だけ表示される
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <p>Flag: {flag ? 'ON' : 'OFF'}</p>
+      <button onClick={handleClick}>Update</button>
+    </div>
+  )
+}
+```
+
+### 5.2 React 18 での改善
+
+React 18 以降は、**すべての更新が自動的にバッチ化**されます。
+
+```typescript
+function React18Batching() {
+  const [count, setCount] = useState(0)
+  const [flag, setFlag] = useState(false)
+
+  const handleClick = async () => {
+    // React 17以前：これらはバッチ化されない
+    // React 18以降：これらもバッチ化される
+    await fetch('/api/data')
+    setCount(c => c + 1)
+    setFlag(f => !f)
+    // 1回だけ再レンダリング
+  }
+
+  return <button onClick={handleClick}>Update</button>
+}
+```
+
+### 5.3 バッチ更新を無効化する（flushSync）
+
+稀に、即座にDOMを更新したい場合は `flushSync` を使います。
+
+```typescript
+import { flushSync } from 'react-dom'
+
+function ScrollToBottom() {
+  const [messages, setMessages] = useState<string[]>([])
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const addMessage = (message: string) => {
+    flushSync(() => {
+      setMessages(prev => [...prev, message])
+    })
+    // ここでDOMが更新されている
+    listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+  }
+
+  return (
+    <div ref={listRef}>
+      {messages.map((msg, i) => (
+        <div key={i}>{msg}</div>
+      ))}
+      <button onClick={() => addMessage('New message')}>Add</button>
+    </div>
+  )
+}
+```
+
+
+## 6. よくある失敗パターン
+
+### 6.1 失敗1: オブジェクトを直接変更
+
+```typescript
+// ❌ 悪い例：オブジェクトを直接変更
+function BadTodoList() {
+  const [todos, setTodos] = useState<Todo[]>([])
+
+  const toggleTodo = (id: string) => {
+    const todo = todos.find(t => t.id === id)
+    if (todo) {
+      todo.completed = !todo.completed // 直接変更（NG）
+      setTodos(todos) // 同じ参照なので再レンダリングされない
+    }
+  }
+}
+
+// - 良い例：新しいオブジェクトを作成
+function GoodTodoList() {
+  const [todos, setTodos] = useState<Todo[]>([])
+
+  const toggleTodo = (id: string) => {
+    setTodos(prev =>
+      prev.map(todo =>
+        todo.id === id ? { ...todo, completed: !todo.completed } : todo
+      )
+    )
+  }
+}
+```
+
+### 6.2 失敗2: 非同期更新の誤解
+
+```typescript
+// ❌ 悪い例：setStateは非同期
+function BadCounter() {
+  const [count, setCount] = useState(0)
+
+  const handleClick = () => {
+    setCount(count + 1)
+    console.log(count) // まだ0（更新前の値）
+  }
+}
+
+// - 良い例：useEffectで監視
+function GoodCounter() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    console.log('Count updated:', count) // 更新後の値
+  }, [count])
+
+  const handleClick = () => {
+    setCount(count + 1)
+  }
+}
+```
+
+### 6.3 失敗3: 依存する状態の更新忘れ
+
+```typescript
+// ❌ 悪い例：依存する状態の更新忘れ
+function BadForm() {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [fullName, setFullName] = useState('') // 同期が必要
+
+  // firstName や lastName が変わってもfullNameは更新されない
+}
+
+// - 良い例：計算で導出
+function GoodForm() {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const fullName = `${firstName} ${lastName}` // 常に最新
+
+  // または useMemo
+  const fullNameMemo = useMemo(
+    () => `${firstName} ${lastName}`,
+    [firstName, lastName]
+  )
+}
+```
+
+
+## 7. 想定パフォーマンスデータ
+
+### 7.1 Lazy Initialization の効果
+
+**計測環境**: React 18, Chrome DevTools
+
+```typescript
+// 計測対象：localStorage からの大量データ読み込み
+const heavyData = Array.from({ length: 10000 }, (_, i) => ({
+  id: i,
+  value: Math.random()
+}))
+
+// ❌ Lazy なし
+function WithoutLazy() {
+  const [data] = useState(JSON.parse(localStorage.getItem('data') || '[]'))
+  // 毎レンダリング: 約15ms（100レンダリングで1.5秒）
+}
+
+// - Lazy あり
+function WithLazy() {
+  const [data] = useState(() => JSON.parse(localStorage.getItem('data') || '[]'))
+  // 初回のみ: 約15ms（100レンダリングで15ms）
+}
+```
+
+**結果**: **100倍の高速化**（100レンダリング時）
+
+### 7.2 Functional Update の効果
+
+```typescript
+// 計測：連続した状態更新
+function BenchmarkUpdate() {
+  const [count, setCount] = useState(0)
+
+  // ❌ 直接更新
+  const directUpdate = () => {
+    for (let i = 0; i < 100; i++) {
+      setCount(count + 1) // 常に count + 1 = 1
+    }
+    // 結果: count = 1
+  }
+
+  // - 関数型更新
+  const functionalUpdate = () => {
+    for (let i = 0; i < 100; i++) {
+      setCount(prev => prev + 1)
+    }
+    // 結果: count = 100（正しい）
+  }
+}
+```
+
+**結果**: 正確性が **100倍向上**
+
+### 7.3 バッチ更新の効果
+
+```typescript
+// 計測：複数の状態更新
+function BenchmarkBatch() {
+  const [state1, setState1] = useState(0)
+  const [state2, setState2] = useState(0)
+  const [state3, setState3] = useState(0)
+
+  const updateAll = () => {
+    setState1(v => v + 1)
+    setState2(v => v + 1)
+    setState3(v => v + 1)
+  }
+
+  console.log('Render') // クリックごとに1回だけ
+
+  // バッチ更新なし: 3回レンダリング（仮定）
+  // バッチ更新あり: 1回レンダリング
+}
+```
+
+**結果**: レンダリング回数が **3分の1に削減**
+
+
+## 8. まとめ
+
+### 8.1 重要ポイント
+
+**1. Discriminated Union で型安全な状態管理**
+- 複数の状態を1つの型で管理
+- 不可能な状態を型レベルで排除
+
+**2. Lazy Initialization でパフォーマンス改善**
+- 重い初期化処理は関数で渡す
+- localStorage 読み込みなどに有効
+
+**3. Functional Update で競合状態を回避**
+- 非同期処理では必須
+- 連続した更新でも安全
+
+**4. バッチ更新を理解する**
+- React 18 ではすべての更新がバッチ化
+- 不要なレンダリングを削減
+
+### 8.2 チェックリスト
+
+useState を使う際は、以下をチェックしましょう：
+
+- [ ] 型安全性は確保されているか？（TypeScript）
+- [ ] 重い初期化処理は Lazy Initialization しているか？
+- [ ] 非同期処理で Functional Update を使っているか？
+- [ ] オブジェクト/配列をイミュータブルに更新しているか？
+- [ ] 複数の関連する状態は Discriminated Union でまとめられないか？
+
+### 8.3 次のステップ
+
+次の Chapter 2 では、useEffect の完全ガイドを学びます：
+- 依存配列の完全理解
+- クリーンアップ関数のパターン
+- データフェッチのベストプラクティス
+- よくある失敗（無限ループ、メモリリーク）
+
+
+**参考リンク**:
+- [React 公式ドキュメント - useState](https://react.dev/reference/react/useState)
+- [TypeScript Handbook - Discriminated Unions](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions)

--- a/ja/04-web-and-network/react-development/docs/02-hooks/02-useeffect-complete-guide.md
+++ b/ja/04-web-and-network/react-development/docs/02-hooks/02-useeffect-complete-guide.md
@@ -1,0 +1,989 @@
+
+# useEffect 実践ガイドと罠の回避
+
+## この章で学べること
+
+この章では、Reactで最も誤解されやすいHookである `useEffect` を実践的に理解します。
+
+- 依存配列の正しい理解と設定方法
+- クリーンアップ関数の必要性と実装パターン
+- データフェッチのベストプラクティス
+- useEffect の無限ループを回避する方法
+- メモリリークの原因と対策
+- 想定される効果：正しい依存配列設定による改善効果
+
+**前提知識**: useEffect の基本的な使い方
+
+**所要時間**: 50-60分
+
+
+## 目次
+
+1. [useEffect の基本おさらい](#1-useeffect-の基本おさらい)
+2. [依存配列の正しい理解](#2-依存配列の正しい理解)
+3. [クリーンアップ関数のパターン](#3-クリーンアップ関数のパターン)
+4. [データフェッチのベストプラクティス](#4-データフェッチのベストプラクティス)
+5. [無限ループを回避する](#5-無限ループを回避する)
+6. [メモリリークの原因と対策](#6-メモリリークの原因と対策)
+7. [useEffect vs useLayoutEffect](#7-useeffect-vs-uselayouteffect)
+8. [想定パフォーマンスデータ](#8-想定パフォーマンスデータ)
+9. [まとめ](#9-まとめ)
+
+
+## 1. useEffect の基本おさらい
+
+### 1.1 useEffect とは
+
+`useEffect` は、**副作用（side effects）** を実行するためのHookです。
+
+**副作用の例**:
+- データフェッチ
+- DOM操作
+- イベントリスナーの登録/解除
+- タイマーの設定/クリア
+- ログ記録
+
+```typescript
+import { useEffect, useState } from 'react'
+
+function Example() {
+  const [count, setCount] = useState(0)
+
+  // 基本的な useEffect
+  useEffect(() => {
+    document.title = `Count: ${count}`
+  })
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+### 1.2 実行タイミング
+
+useEffect は、**レンダリング後**に実行されます。
+
+```typescript
+function ExecutionOrder() {
+  console.log('1. Render phase')
+
+  useEffect(() => {
+    console.log('3. useEffect runs (after render)')
+  })
+
+  console.log('2. Still render phase')
+
+  return <div>Check console</div>
+}
+```
+
+**実行順序**:
+1. コンポーネント関数の実行（レンダリング）
+2. DOMの更新
+3. 画面への描画
+4. **useEffect の実行** ← ここ
+
+### 1.3 依存配列の3パターン
+
+```typescript
+// パターン1: 依存配列なし（毎レンダリングで実行）
+useEffect(() => {
+  console.log('Runs after every render')
+})
+
+// パターン2: 空の依存配列（初回のみ実行）
+useEffect(() => {
+  console.log('Runs only once (on mount)')
+}, [])
+
+// パターン3: 依存配列あり（依存値が変わったときのみ実行）
+useEffect(() => {
+  console.log('Runs when count changes')
+}, [count])
+```
+
+
+## 2. 依存配列の正しい理解
+
+### 2.1 アンチパターン1: 依存配列の欠落
+
+**問題**: 依存している値を配列に含めないと、古い値を参照します。
+
+```typescript
+// ❌ 悪い例
+function SearchResults({ query }: { query: string }) {
+  const [results, setResults] = useState<string[]>([])
+
+  useEffect(() => {
+    fetch(`/api/search?q=${query}`)
+      .then(res => res.json())
+      .then(setResults)
+  }, []) // queryが依存に必要（ESLint警告）
+
+  // query が変わっても検索されない！
+  return (
+    <ul>
+      {results.map((result, i) => (
+        <li key={i}>{result}</li>
+      ))}
+    </ul>
+  )
+}
+
+// - 良い例
+function SearchResults({ query }: { query: string }) {
+  const [results, setResults] = useState<string[]>([])
+
+  useEffect(() => {
+    fetch(`/api/search?q=${query}`)
+      .then(res => res.json())
+      .then(setResults)
+  }, [query]) // 正しい依存配列
+
+  return (
+    <ul>
+      {results.map((result, i) => (
+        <li key={i}>{result}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### 2.2 アンチパターン2: オブジェクトの依存
+
+**問題**: オブジェクトは毎レンダリングで新しい参照になるため、無限ループが発生します。
+
+```typescript
+// ❌ 悪い例：無限ループ
+function DataDisplay() {
+  const config = { url: '/api/users', method: 'GET' } // 毎レンダリングで新しいオブジェクト
+
+  useEffect(() => {
+    fetch(config.url, { method: config.method })
+      .then(res => res.json())
+      .then(console.log)
+  }, [config]) // config が毎回変わる → 無限ループ
+}
+```
+
+**解決策1: useMemo で安定化**
+
+```typescript
+// - 良い例
+function DataDisplay() {
+  const config = useMemo(() => ({
+    url: '/api/users',
+    method: 'GET' as const
+  }), []) // 空の依存配列 = 初回のみ作成
+
+  useEffect(() => {
+    fetch(config.url, { method: config.method })
+      .then(res => res.json())
+      .then(console.log)
+  }, [config])
+}
+```
+
+**解決策2: プリミティブ値のみ依存**
+
+```typescript
+// - より良い例
+function DataDisplay() {
+  const url = '/api/users'
+  const method = 'GET'
+
+  useEffect(() => {
+    fetch(url, { method })
+      .then(res => res.json())
+      .then(console.log)
+  }, [url, method]) // プリミティブ値は安定
+}
+```
+
+**解決策3: 依存なし（定数の場合）**
+
+```typescript
+// - ベスト（定数なら）
+function DataDisplay() {
+  useEffect(() => {
+    fetch('/api/users', { method: 'GET' })
+      .then(res => res.json())
+      .then(console.log)
+  }, []) // 定数なので依存不要
+}
+```
+
+### 2.3 アンチパターン3: 関数の依存
+
+**問題**: 関数も毎レンダリングで新しい参照になります。
+
+```typescript
+// ❌ 悪い例
+function UserList() {
+  const fetchUsers = () => {
+    return fetch('/api/users').then(res => res.json())
+  }
+
+  useEffect(() => {
+    fetchUsers().then(console.log)
+  }, [fetchUsers]) // 毎レンダリングで新しい関数 → 無限ループ
+}
+```
+
+**解決策1: useCallback で安定化**
+
+```typescript
+// - 良い例
+function UserList() {
+  const fetchUsers = useCallback(() => {
+    return fetch('/api/users').then(res => res.json())
+  }, []) // 空の依存配列 = 初回のみ作成
+
+  useEffect(() => {
+    fetchUsers().then(console.log)
+  }, [fetchUsers])
+}
+```
+
+**解決策2: useEffect 内で定義**
+
+```typescript
+// - より良い例（推奨）
+function UserList() {
+  useEffect(() => {
+    const fetchUsers = () => {
+      return fetch('/api/users').then(res => res.json())
+    }
+
+    fetchUsers().then(console.log)
+  }, []) // 依存なし
+}
+```
+
+### 2.4 ESLint ルールを守る
+
+**必須**: `eslint-plugin-react-hooks` を使いましょう。
+
+```json
+{
+  "extends": [
+    "plugin:react-hooks/recommended"
+  ],
+  "rules": {
+    "react-hooks/exhaustive-deps": "error" // 警告ではなくエラーに
+  }
+}
+```
+
+
+## 3. クリーンアップ関数のパターン
+
+### 3.1 クリーンアップが必要な理由
+
+useEffect が返す関数は、**コンポーネントのアンマウント時**または**次のeffect実行前**に実行されます。
+
+**クリーンアップが必要なケース**:
+- イベントリスナーの登録
+- タイマー（setInterval、setTimeout）
+- WebSocket接続
+- Subscription（RxJS等）
+- リソースのキャンセル
+
+### 3.2 パターン1: イベントリスナー
+
+```typescript
+function WindowSize() {
+  const [size, setSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight
+  })
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      })
+    }
+
+    // イベントリスナーを登録
+    window.addEventListener('resize', handleResize)
+
+    // クリーンアップ：リスナーを削除
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, []) // 初回のみ登録
+
+  return (
+    <div>
+      Window size: {size.width} x {size.height}
+    </div>
+  )
+}
+```
+
+**なぜクリーンアップが必要？**
+- リスナーを削除しないと、メモリリークが発生
+- コンポーネントがアンマウントされても、リスナーは残り続ける
+
+### 3.2 パターン2: タイマー
+
+```typescript
+function CountdownTimer({ seconds }: { seconds: number }) {
+  const [timeLeft, setTimeLeft] = useState(seconds)
+
+  useEffect(() => {
+    if (timeLeft === 0) {
+      alert('Time is up!')
+      return
+    }
+
+    const timer = setInterval(() => {
+      setTimeLeft(prev => prev - 1)
+    }, 1000)
+
+    // クリーンアップ：タイマーを停止
+    return () => {
+      clearInterval(timer)
+    }
+  }, [timeLeft]) // timeLeft が変わるたびに新しいタイマー
+
+  return <div>{timeLeft} seconds remaining</div>
+}
+```
+
+**より良い実装（無駄なタイマー再設定を避ける）**:
+
+```typescript
+function CountdownTimer({ seconds }: { seconds: number }) {
+  const [timeLeft, setTimeLeft] = useState(seconds)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTimeLeft(prev => {
+        if (prev <= 1) {
+          clearInterval(timer) // 0になったら停止
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => {
+      clearInterval(timer)
+    }
+  }, []) // 初回のみタイマー設定
+
+  useEffect(() => {
+    if (timeLeft === 0) {
+      alert('Time is up!')
+    }
+  }, [timeLeft])
+
+  return <div>{timeLeft} seconds remaining</div>
+}
+```
+
+### 3.3 パターン3: WebSocket接続
+
+```typescript
+function ChatRoom({ roomId }: { roomId: string }) {
+  const [messages, setMessages] = useState<string[]>([])
+
+  useEffect(() => {
+    const ws = new WebSocket(`ws://localhost:8080/rooms/${roomId}`)
+
+    ws.onopen = () => {
+      console.log('Connected to room:', roomId)
+    }
+
+    ws.onmessage = (event) => {
+      setMessages(prev => [...prev, event.data])
+    }
+
+    ws.onerror = (error) => {
+      console.error('WebSocket error:', error)
+    }
+
+    // クリーンアップ：接続を閉じる
+    return () => {
+      ws.close()
+      console.log('Disconnected from room:', roomId)
+    }
+  }, [roomId]) // roomId が変わったら再接続
+
+  return (
+    <ul>
+      {messages.map((msg, i) => (
+        <li key={i}>{msg}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+**動作フロー**:
+1. 初回レンダリング → WebSocket接続
+2. roomId が変更 → **クリーンアップ（古い接続を閉じる）** → 新しい接続
+3. アンマウント → クリーンアップ（接続を閉じる）
+
+### 3.4 パターン4: Subscription（RxJS）
+
+```typescript
+import { interval } from 'rxjs'
+
+function ObservableCounter() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    const subscription = interval(1000).subscribe(value => {
+      setCount(value)
+    })
+
+    // クリーンアップ：サブスクリプション解除
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return <div>Count: {count}</div>
+}
+```
+
+
+## 4. データフェッチのベストプラクティス
+
+### 4.1 Race Conditionとは
+
+**Race Condition（競合状態）**: 複数の非同期処理が競合して、古いデータで上書きされる問題です。
+
+```typescript
+// ❌ Race Conditionの問題
+// 1. userId = 'user1' でフェッチ開始（3秒かかる）
+// 2. すぐに userId = 'user2' に変更してフェッチ開始（1秒で完了）
+// 3. user2 のデータが表示される
+// 4. その後、user1 のフェッチが完了して、古いデータで上書き！
+
+// - AbortControllerで解決
+// 1. userId = 'user1' でフェッチ開始
+// 2. userId = 'user2' に変更 → controller.abort() で通信自体をキャンセル
+// 3. user1 のリクエストは中断され、帯域幅も節約される
+// 4. user2 のデータのみ表示される
+```
+
+### 4.2 AbortController を使った実装（推奨）
+
+```typescript
+function UserProfile({ userId }: { userId: string }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    // AbortController を作成
+    const abortController = new AbortController()
+
+    const fetchUser = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const response = await fetch(`/api/users/${userId}`, {
+          signal: abortController.signal // シグナルを渡す
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+
+        const data = await response.json()
+        setUser(data)
+      } catch (err) {
+        // AbortError は無視
+        if ((err as Error).name !== 'AbortError') {
+          setError(err as Error)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchUser()
+
+    // クリーンアップ：リクエストをキャンセル
+    return () => {
+      abortController.abort()
+    }
+  }, [userId])
+
+  if (loading) return <div>Loading...</div>
+  if (error) return <div>Error: {error.message}</div>
+  if (!user) return null
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+### 4.3 カスタムフック化
+
+```typescript
+function useFetch<T>(url: string) {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    const abortController = new AbortController()
+
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const response = await fetch(url, {
+          signal: abortController.signal
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+
+        const json = await response.json()
+        setData(json)
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setError(err as Error)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+
+    return () => {
+      abortController.abort()
+    }
+  }, [url])
+
+  return { data, loading, error }
+}
+
+// 使用例
+function UserProfile({ userId }: { userId: string }) {
+  const { data: user, loading, error } = useFetch<User>(`/api/users/${userId}`)
+
+  if (loading) return <div>Loading...</div>
+  if (error) return <div>Error: {error.message}</div>
+  if (!user) return null
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+### 4.4 実務ではTanStack Query / SWR を使う
+
+上記のuseEffect + fetchの手動実装は**学習目的では有用**ですが、実務では以下の理由から**データフェッチライブラリの利用が強く推奨**されます。React公式ドキュメントでも、useEffectでのデータフェッチは推奨されていません。
+
+> **対応バージョン**: TanStack Query v5（`@tanstack/react-query`） / SWR v2（`swr`）
+
+**TanStack Query（v5）の例:**
+
+```typescript
+import { useQuery } from '@tanstack/react-query'
+
+function UserProfile({ userId }: { userId: string }) {
+  const { data: user, isLoading, error } = useQuery({
+    queryKey: ['user', userId],
+    queryFn: ({ signal }) =>  // signalが自動で渡される → 自動キャンセル
+      fetch(`/api/users/${userId}`, { signal }).then(res => res.json()),
+    staleTime: 5 * 60 * 1000,  // 5分間キャッシュ
+  })
+
+  if (isLoading) return <div>Loading...</div>
+  if (error) return <div>Error: {error.message}</div>
+  if (!user) return null
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+**TanStack Query / SWR が解決すること:**
+
+| 課題 | useEffect手動実装 | TanStack Query |
+|------|------------------|----------------|
+| リクエストキャンセル | 自分でAbortController管理 | **自動** |
+| キャッシュ | なし | **自動（同じqueryKeyはキャッシュヒット）** |
+| ローディング/エラー状態 | 自分でstate管理 | **自動** |
+| 重複リクエスト排除 | なし | **自動（同じqueryKeyは1つだけ実行）** |
+| 再試行 | 自分で実装 | **自動（3回まで再試行）** |
+| バックグラウンドリフレッシュ | なし | **ウィンドウフォーカス時に自動** |
+
+**結論**: useEffectでのデータフェッチの仕組みを理解した上で、実務ではTanStack QueryやSWRを使いましょう。
+
+
+## 5. 無限ループを回避する
+
+### 5.1 原因1: オブジェクト/配列を依存配列に入れる
+
+```typescript
+// ❌ 無限ループ
+function BadExample() {
+  const [data, setData] = useState([])
+  const options = { page: 1, limit: 10 } // 毎レンダリングで新しいオブジェクト
+
+  useEffect(() => {
+    fetch('/api/data', {
+      method: 'POST',
+      body: JSON.stringify(options)
+    })
+      .then(res => res.json())
+      .then(setData) // setData → 再レンダリング → 新しい options → useEffect 実行 → 無限ループ
+  }, [options])
+}
+
+// - 解決策
+function GoodExample() {
+  const [data, setData] = useState([])
+
+  useEffect(() => {
+    const options = { page: 1, limit: 10 } // useEffect 内で定義
+
+    fetch('/api/data', {
+      method: 'POST',
+      body: JSON.stringify(options)
+    })
+      .then(res => res.json())
+      .then(setData)
+  }, []) // 依存配列に options を入れない
+}
+```
+
+### 5.2 原因2: setState を依存配列に入れる
+
+```typescript
+// ❌ 無限ループ
+function BadCounter() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    setCount(count + 1) // count を更新 → 再レンダリング → useEffect 実行 → 無限ループ
+  }, [count])
+}
+
+// - 解決策1: 依存配列を空にする
+function GoodCounter() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCount(c => c + 1) // 関数型更新
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, []) // count を依存に入れない
+}
+
+// - 解決策2: 条件を追加
+function ConditionalCounter() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (count < 10) {
+      setCount(count + 1)
+    }
+  }, [count]) // count < 10 で停止
+}
+```
+
+
+## 6. メモリリークの原因と対策
+
+### 6.1 原因: クリーンアップ関数の欠落
+
+```typescript
+// ❌ メモリリーク
+function BadTimer() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    setInterval(() => {
+      setCount(c => c + 1)
+    }, 1000)
+    // クリーンアップがない → アンマウント後もタイマーが動き続ける
+  }, [])
+
+  return <div>{count}</div>
+}
+
+// - 正しい実装
+function GoodTimer() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCount(c => c + 1)
+    }, 1000)
+
+    return () => {
+      clearInterval(timer) // クリーンアップ
+    }
+  }, [])
+
+  return <div>{count}</div>
+}
+```
+
+### 6.2 原因: 非同期処理後の状態更新
+
+```typescript
+// ❌ メモリリーク（コンポーネントがアンマウントされた後も setState が実行される）
+function BadFetch() {
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/data')
+      .then(res => res.json())
+      .then(setData) // アンマウント後も実行される可能性
+  }, [])
+
+  return <div>{data}</div>
+}
+
+// - 正しい実装（cancelled フラグ）
+function GoodFetch() {
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch('/api/data')
+      .then(res => res.json())
+      .then(result => {
+        if (!cancelled) {
+          setData(result)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return <div>{data}</div>
+}
+```
+
+
+## 7. useEffect vs useLayoutEffect
+
+### 7.1 違い
+
+| | useEffect | useLayoutEffect |
+|---|---|---|
+| **実行タイミング** | 画面描画**後** | 画面描画**前** |
+| **ブロッキング** | 非同期（ブロックしない） | 同期（ブロックする） |
+| **使用例** | データフェッチ、イベント登録 | DOM測定、スクロール位置調整 |
+
+### 7.2 useEffect の実行タイミング
+
+```typescript
+function UseEffectTiming() {
+  const [count, setCount] = useState(0)
+
+  console.log('1. Render')
+
+  useEffect(() => {
+    console.log('3. useEffect (after paint)')
+  })
+
+  console.log('2. Still rendering')
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+// コンソール出力:
+// 1. Render
+// 2. Still rendering
+// （画面に描画される）
+// 3. useEffect (after paint)
+```
+
+### 7.3 useLayoutEffect の実行タイミング
+
+```typescript
+function UseLayoutEffectTiming() {
+  const [count, setCount] = useState(0)
+
+  console.log('1. Render')
+
+  useLayoutEffect(() => {
+    console.log('2. useLayoutEffect (before paint)')
+  })
+
+  console.log('3. Still rendering')
+
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+
+// コンソール出力:
+// 1. Render
+// 3. Still rendering
+// 2. useLayoutEffect (before paint)
+// （画面に描画される）
+```
+
+### 7.4 useLayoutEffect の使用例
+
+```typescript
+// DOM測定（スクロール位置、要素のサイズなど）
+function MeasureElement() {
+  const [height, setHeight] = useState(0)
+  const divRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    if (divRef.current) {
+      // 描画前にDOMを測定
+      setHeight(divRef.current.offsetHeight)
+    }
+  })
+
+  return (
+    <>
+      <div ref={divRef}>
+        <p>Content with dynamic height</p>
+      </div>
+      <p>Height: {height}px</p>
+    </>
+  )
+}
+```
+
+**useEffect だと問題**:
+- 画面描画後に高さを測定
+- 測定結果で再レンダリング
+- **ちらつき（flicker）が発生**
+
+**useLayoutEffect なら**:
+- 画面描画前に高さを測定
+- 正しい高さで1回だけ描画
+- **ちらつきなし**
+
+
+## 8. 想定パフォーマンスデータ
+
+### 8.1 Race Condition 対策の効果
+
+**計測環境**: React 18, 遅いネットワーク（3G）
+
+```typescript
+// ❌ 対策なし
+// - ユーザーが userId を 5回変更
+// - 古いリクエストが完了して、古いデータで上書き
+// - エラー率: 60%（5回中3回が古いデータ）
+
+// - AbortController あり
+// - 古いリクエストをキャンセル
+// - エラー率: 0%（常に最新のデータ）
+```
+
+**結果**: データ整合性が **100%改善**
+
+### 8.2 メモリリーク対策の効果
+
+```typescript
+// 計測：1000個のコンポーネントをマウント/アンマウント
+
+// ❌ クリーンアップなし
+// - メモリ使用量: 150MB → 450MB（3倍）
+// - GC後も 300MB（2倍）
+
+// - クリーンアップあり
+// - メモリ使用量: 150MB → 180MB（1.2倍）
+// - GC後 155MB（ほぼ変化なし）
+```
+
+**結果**: メモリリーク **100%解消**
+
+### 8.3 依存配列の最適化効果
+
+```typescript
+// 計測：検索機能（入力ごとにAPIリクエスト）
+
+// ❌ 依存配列なし（毎レンダリングで実行）
+// - "react" と入力（5文字）
+// - APIリクエスト数: 50回（入力変化 × 10回のレンダリング）
+
+// - 依存配列あり（query が変わったときのみ）
+// - "react" と入力（5文字）
+// - APIリクエスト数: 5回（入力変化のみ）
+```
+
+**結果**: 不要なリクエストを **90%削減**
+
+
+## 9. まとめ
+
+### 9.1 重要ポイント
+
+**1. 依存配列を正しく設定する**
+- ESLint ルールを守る（`exhaustive-deps`）
+- オブジェクト/配列は useMemo で安定化
+- 関数は useCallback で安定化（または useEffect 内で定義）
+
+**2. クリーンアップ関数を忘れない**
+- イベントリスナーは必ず削除
+- タイマーは必ずクリア
+- WebSocket/Subscription は必ず解除
+
+**3. データフェッチは Race Condition 対策を**
+- AbortControllerで通信自体をキャンセル（推奨）
+- 実務ではTanStack Query / SWR を使う（自動キャンセル、キャッシュ、再試行を提供）
+
+**4. 無限ループを回避する**
+- オブジェクト/配列を依存配列に入れない
+- setState を依存配列に入れる場合は条件を追加
+
+**5. useLayoutEffect は慎重に使う**
+- DOM測定など、描画前の処理にのみ使用
+- 通常は useEffect で十分
+
+### 9.2 チェックリスト
+
+useEffect を使う際は、以下をチェックしましょう：
+
+- [ ] 依存配列は正しく設定されているか？（ESLintの警告を無視していないか？）
+- [ ] クリーンアップ関数は必要ないか？
+- [ ] データフェッチで Race Condition 対策をしているか？
+- [ ] 無限ループの可能性はないか？
+- [ ] メモリリークの可能性はないか？
+- [ ] useLayoutEffect ではなく useEffect で十分か？
+
+### 9.3 次のステップ
+
+次の Chapter 3 では、カスタムフック設計パターンを学びます：
+- 再利用可能なカスタムフックの設計原則
+- useFetch、useLocalStorage、useDebounce の実装
+- useContext + useReducer パターン（Redux代替）
+
+
+**参考リンク**:
+- [React 公式ドキュメント - useEffect](https://react.dev/reference/react/useEffect)
+- [React 公式ドキュメント - useLayoutEffect](https://react.dev/reference/react/useLayoutEffect)
+- [A Complete Guide to useEffect by Dan Abramov](https://overreacted.io/a-complete-guide-to-useeffect/)

--- a/ja/04-web-and-network/react-development/docs/02-hooks/03-custom-hooks-patterns.md
+++ b/ja/04-web-and-network/react-development/docs/02-hooks/03-custom-hooks-patterns.md
@@ -1,0 +1,835 @@
+
+# カスタムフック設計パターン
+
+## この章で学べること
+
+この章では、再利用可能なカスタムフックの設計パターンを学びます。
+
+- カスタムフックの設計原則
+- useFetch の完全実装（エラーハンドリング、キャンセル処理）
+- useLocalStorage の型安全な実装
+- useDebounce / useThrottle の実装と使い分け
+- useToggle、useAsync などの便利なヘルパー
+- カスタムフックのテスト戦略
+- よくある失敗：過剰な抽象化
+
+**前提知識**: useState、useEffect、useRef の基本
+
+**所要時間**: 60-70分
+
+
+## 目次
+
+1. [カスタムフックの設計原則](#1-カスタムフックの設計原則)
+2. [useFetch の完全実装](#2-usefetch-の完全実装)
+3. [useLocalStorage の実装](#3-uselocalstorage-の実装)
+4. [useDebounce / useThrottle](#4-usedebounce--usethrottle)
+5. [useToggle と useAsync](#5-usetoggle-と-useasync)
+6. [カスタムフックのテスト](#6-カスタムフックのテスト)
+7. [よくある失敗パターン](#7-よくある失敗パターン)
+8. [まとめ](#8-まとめ)
+
+
+## 1. カスタムフックの設計原則
+
+### 1.1 カスタムフックとは
+
+カスタムフックは、**ロジックを再利用可能な関数**として抽出したものです。
+
+**特徴**:
+- 関数名が `use` で始まる
+- 他のHooks（useState、useEffectなど）を使える
+- コンポーネント間でロジックを共有できる
+
+### 1.2 設計原則
+
+**原則1: 単一責任の原則**
+
+1つのカスタムフックは、1つの責任のみを持つべきです。
+
+```typescript
+// ❌ 悪い例：複数の責任
+function useUserAndPosts(userId: string) {
+  const [user, setUser] = useState(null)
+  const [posts, setPosts] = useState([])
+  // ユーザー情報と投稿を両方取得（責任が2つ）
+}
+
+// - 良い例：責任を分離
+function useUser(userId: string) {
+  // ユーザー情報のみ
+}
+
+function usePosts(userId: string) {
+  // 投稿のみ
+}
+```
+
+**原則2: 型安全性**
+
+TypeScript のジェネリクスを活用して、型安全なフックを作りましょう。
+
+```typescript
+// - 型安全なカスタムフック
+function useFetch<T>(url: string) {
+  const [data, setData] = useState<T | null>(null)
+  // ...
+  return data // T | null型
+}
+
+// 使用時に型を指定
+const { data } = useFetch<User>('/api/user')
+// data は User | null 型
+```
+
+**原則3: 一貫性のあるAPI**
+
+他のフックと同じようなAPIを提供しましょう。
+
+```typescript
+// - useState と同じパターン
+function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(initialValue)
+  // ...
+  return [value, setValue] as const // useStateと同じ
+}
+
+// 使用例
+const [theme, setTheme] = useLocalStorage('theme', 'light')
+```
+
+### 1.3 命名規則
+
+**パターン1: use + 動詞**
+- `useFetch` - データをフェッチする
+- `useToggle` - トグルする
+- `useDebounce` - デバウンスする
+
+**パターン2: use + 名詞**
+- `useUser` - ユーザー情報を取得
+- `useAuth` - 認証情報を取得
+
+
+## 2. useFetch の完全実装
+
+### 2.1 基本実装
+
+```typescript
+type FetchState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error }
+
+interface UseFetchOptions {
+  immediate?: boolean // 即座にフェッチするか
+}
+
+function useFetch<T>(
+  url: string,
+  options: UseFetchOptions = {}
+) {
+  const { immediate = true } = options
+  const [state, setState] = useState<FetchState<T>>({ status: 'idle' })
+
+  const execute = useCallback(async () => {
+    setState({ status: 'loading' })
+
+    try {
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setState({ status: 'success', data })
+      return data
+    } catch (error) {
+      const err = error as Error
+      setState({ status: 'error', error: err })
+      throw err
+    }
+  }, [url])
+
+  useEffect(() => {
+    if (immediate) {
+      execute()
+    }
+  }, [immediate, execute])
+
+  const refetch = execute
+
+  return { ...state, refetch }
+}
+```
+
+### 2.2 使用例
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+function UserList() {
+  const { status, data, error, refetch } = useFetch<User[]>('/api/users')
+
+  if (status === 'loading') return <Spinner />
+  if (status === 'error') return <ErrorMessage error={error} />
+  if (status === 'success') {
+    return (
+      <>
+        <button onClick={refetch}>Refresh</button>
+        <ul>
+          {data.map(user => (
+            <li key={user.id}>{user.name}</li>
+          ))}
+        </ul>
+      </>
+    )
+  }
+  return null
+}
+```
+
+### 2.3 AbortController 対応版
+
+```typescript
+function useFetch<T>(url: string, options: UseFetchOptions = {}) {
+  const { immediate = true } = options
+  const [state, setState] = useState<FetchState<T>>({ status: 'idle' })
+  const abortControllerRef = useRef<AbortController>()
+
+  const execute = useCallback(async () => {
+    // 前回のリクエストをキャンセル
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = new AbortController()
+
+    setState({ status: 'loading' })
+
+    try {
+      const response = await fetch(url, {
+        signal: abortControllerRef.current.signal
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setState({ status: 'success', data })
+      return data
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') {
+        // キャンセルされた場合は無視
+        return
+      }
+      const err = error as Error
+      setState({ status: 'error', error: err })
+      throw err
+    }
+  }, [url])
+
+  useEffect(() => {
+    if (immediate) {
+      execute()
+    }
+
+    return () => {
+      // クリーンアップ：進行中のリクエストをキャンセル
+      abortControllerRef.current?.abort()
+    }
+  }, [immediate, execute])
+
+  return { ...state, refetch: execute }
+}
+```
+
+
+## 3. useLocalStorage の実装
+
+### 3.1 完全実装
+
+```typescript
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((prev: T) => T)) => void, () => void] {
+  // 初期値の取得（Lazy Initialization）
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue
+    }
+
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.error(`Error reading localStorage key "${key}":`, error)
+      return initialValue
+    }
+  })
+
+  // 値の設定
+  const setValue = useCallback((value: T | ((prev: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      }
+    } catch (error) {
+      console.error(`Error setting localStorage key "${key}":`, error)
+    }
+  }, [key, storedValue])
+
+  // 値の削除
+  const removeValue = useCallback(() => {
+    try {
+      setStoredValue(initialValue)
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(key)
+      }
+    } catch (error) {
+      console.error(`Error removing localStorage key "${key}":`, error)
+    }
+  }, [key, initialValue])
+
+  return [storedValue, setValue, removeValue]
+}
+```
+
+### 3.2 使用例
+
+```typescript
+interface Theme {
+  mode: 'light' | 'dark'
+  primaryColor: string
+}
+
+function ThemeSettings() {
+  const [theme, setTheme, resetTheme] = useLocalStorage<Theme>('theme', {
+    mode: 'light',
+    primaryColor: '#3b82f6'
+  })
+
+  const toggleMode = () => {
+    setTheme(prev => ({
+      ...prev,
+      mode: prev.mode === 'light' ? 'dark' : 'light'
+    }))
+  }
+
+  return (
+    <div>
+      <p>Current mode: {theme.mode}</p>
+      <p>Primary color: {theme.primaryColor}</p>
+      <button onClick={toggleMode}>Toggle Mode</button>
+      <button onClick={resetTheme}>Reset to Default</button>
+    </div>
+  )
+}
+```
+
+### 3.3 Storage イベント対応版
+
+複数タブ間での同期が必要な場合：
+
+```typescript
+function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    // ... 初期化コード
+  })
+
+  const setValue = useCallback((value: T | ((prev: T) => T)) => {
+    // ... 設定コード
+  }, [key, storedValue])
+
+  // Storage イベントをリスン（他のタブでの変更を検知）
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === key && e.newValue) {
+        try {
+          setStoredValue(JSON.parse(e.newValue))
+        } catch (error) {
+          console.error('Error parsing storage event:', error)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    return () => {
+      window.removeEventListener('storage', handleStorageChange)
+    }
+  }, [key])
+
+  const removeValue = useCallback(() => {
+    // ... 削除コード
+  }, [key, initialValue])
+
+  return [storedValue, setValue, removeValue]
+}
+```
+
+
+## 4. useDebounce / useThrottle
+
+### 4.1 useDebounce の実装
+
+**デバウンス**: 連続した入力の最後の値のみを使う
+
+```typescript
+function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+```
+
+**使用例：リアルタイム検索**
+
+```typescript
+function SearchInput() {
+  const [searchTerm, setSearchTerm] = useState('')
+  const debouncedSearchTerm = useDebounce(searchTerm, 500)
+  const [results, setResults] = useState<string[]>([])
+
+  useEffect(() => {
+    if (debouncedSearchTerm) {
+      // API呼び出しは500ms後のみ（入力中は呼ばれない）
+      fetch(`/api/search?q=${debouncedSearchTerm}`)
+        .then(res => res.json())
+        .then(setResults)
+    } else {
+      setResults([])
+    }
+  }, [debouncedSearchTerm])
+
+  return (
+    <>
+      <input
+        type="text"
+        value={searchTerm}
+        onChange={e => setSearchTerm(e.target.value)}
+        placeholder="Search..."
+      />
+      <ul>
+        {results.map(result => (
+          <li key={result}>{result}</li>
+        ))}
+      </ul>
+    </>
+  )
+}
+```
+
+### 4.2 useThrottle の実装
+
+**スロットル**: 一定間隔でのみ値を更新
+
+```typescript
+function useThrottle<T>(value: T, delay: number = 500): T {
+  const [throttledValue, setThrottledValue] = useState<T>(value)
+  const lastRan = useRef(Date.now())
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (Date.now() - lastRan.current >= delay) {
+        setThrottledValue(value)
+        lastRan.current = Date.now()
+      }
+    }, delay - (Date.now() - lastRan.current))
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return throttledValue
+}
+```
+
+**使用例：スクロール位置の追跡**
+
+```typescript
+function ScrollTracker() {
+  const [scrollY, setScrollY] = useState(0)
+  const throttledScrollY = useThrottle(scrollY, 100)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrollY(window.scrollY)
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  // 100msごとにのみ更新される
+  return <div>Scroll position: {throttledScrollY}px</div>
+}
+```
+
+### 4.3 使い分け
+
+| | useDebounce | useThrottle |
+|---|---|---|
+| **タイミング** | 入力が止まった後 | 一定間隔ごと |
+| **使用例** | 検索入力、フォームバリデーション | スクロール、リサイズ |
+| **API呼び出し** | 最後の1回のみ | 一定間隔で複数回 |
+
+
+## 5. useToggle と useAsync
+
+### 5.1 useToggle の実装
+
+```typescript
+function useToggle(
+  initialValue: boolean = false
+): [boolean, () => void, (value: boolean) => void] {
+  const [value, setValue] = useState(initialValue)
+
+  const toggle = useCallback(() => {
+    setValue(prev => !prev)
+  }, [])
+
+  const setExplicit = useCallback((newValue: boolean) => {
+    setValue(newValue)
+  }, [])
+
+  return [value, toggle, setExplicit]
+}
+```
+
+**使用例**
+
+```typescript
+function Modal() {
+  const [isOpen, toggle, setIsOpen] = useToggle(false)
+
+  return (
+    <>
+      <button onClick={toggle}>Toggle Modal</button>
+      <button onClick={() => setIsOpen(true)}>Open Modal</button>
+      {isOpen && (
+        <div className="modal">
+          <p>Modal Content</p>
+          <button onClick={toggle}>Close</button>
+        </div>
+      )}
+    </>
+  )
+}
+```
+
+### 5.2 useAsync の実装
+
+汎用的な非同期処理フック：
+
+```typescript
+type AsyncState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error }
+
+function useAsync<T>(
+  asyncFunction: () => Promise<T>,
+  immediate: boolean = true
+) {
+  const [state, setState] = useState<AsyncState<T>>({ status: 'idle' })
+
+  const execute = useCallback(async () => {
+    setState({ status: 'loading' })
+
+    try {
+      const data = await asyncFunction()
+      setState({ status: 'success', data })
+      return data
+    } catch (error) {
+      setState({ status: 'error', error: error as Error })
+      throw error
+    }
+  }, [asyncFunction])
+
+  useEffect(() => {
+    if (immediate) {
+      execute()
+    }
+  }, [immediate, execute])
+
+  return { ...state, execute }
+}
+```
+
+**使用例**
+
+```typescript
+function UserProfile({ userId }: { userId: string }) {
+  const fetchUser = useCallback(
+    () => fetch(`/api/users/${userId}`).then(res => res.json()),
+    [userId]
+  )
+
+  const { status, data: user, error, execute } = useAsync<User>(fetchUser)
+
+  if (status === 'loading') return <Spinner />
+  if (status === 'error') return <ErrorMessage error={error} />
+  if (status === 'success') {
+    return (
+      <div>
+        <h1>{user.name}</h1>
+        <button onClick={execute}>Refresh</button>
+      </div>
+    )
+  }
+  return null
+}
+```
+
+
+## 6. カスタムフックのテスト
+
+### 6.1 React Testing Library の renderHook
+
+```typescript
+import { renderHook, act } from '@testing-library/react'
+
+describe('useToggle', () => {
+  it('should toggle value', () => {
+    const { result } = renderHook(() => useToggle(false))
+
+    // 初期値
+    expect(result.current[0]).toBe(false)
+
+    // トグル
+    act(() => {
+      result.current[1]()
+    })
+
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('should set explicit value', () => {
+    const { result } = renderHook(() => useToggle(false))
+
+    act(() => {
+      result.current[2](true)
+    })
+
+    expect(result.current[0]).toBe(true)
+  })
+})
+```
+
+### 6.2 useLocalStorage のテスト
+
+```typescript
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should read from localStorage', () => {
+    localStorage.setItem('test', JSON.stringify('value'))
+
+    const { result } = renderHook(() =>
+      useLocalStorage('test', 'default')
+    )
+
+    expect(result.current[0]).toBe('value')
+  })
+
+  it('should write to localStorage', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('test', 'default')
+    )
+
+    act(() => {
+      result.current[1]('new value')
+    })
+
+    expect(localStorage.getItem('test')).toBe(JSON.stringify('new value'))
+  })
+})
+```
+
+### 6.3 useFetch のテスト（MSW使用）
+
+```typescript
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('/api/users', (req, res, ctx) => {
+    return res(ctx.json([{ id: '1', name: 'John' }]))
+  })
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('useFetch', () => {
+  it('should fetch data successfully', async () => {
+    const { result, waitFor } = renderHook(() =>
+      useFetch<User[]>('/api/users')
+    )
+
+    expect(result.current.status).toBe('loading')
+
+    await waitFor(() => result.current.status === 'success')
+
+    expect(result.current.data).toEqual([{ id: '1', name: 'John' }])
+  })
+})
+```
+
+
+## 7. よくある失敗パターン
+
+### 7.1 失敗1: 過剰な抽象化
+
+```typescript
+// ❌ 悪い例：複雑すぎる
+function useEverything<T, U, V>(
+  config: {
+    fetchUrl?: string
+    storageKey?: string
+    debounceDelay?: number
+    initialValue?: T
+    transform?: (data: U) => V
+  }
+) {
+  // 100行以上のコード...
+  // 何でもできるが、使いにくい
+}
+
+// - 良い例：シンプルなフックを組み合わせる
+function MyComponent() {
+  const [value, setValue] = useLocalStorage('key', 'default')
+  const debouncedValue = useDebounce(value, 500)
+  const { data } = useFetch(`/api/search?q=${debouncedValue}`)
+}
+```
+
+### 7.2 失敗2: 依存配列の誤り
+
+```typescript
+// ❌ 悪い例
+function useBadFetch<T>(url: string) {
+  const [data, setData] = useState<T | null>(null)
+
+  const fetchData = () => {
+    fetch(url).then(res => res.json()).then(setData)
+  }
+
+  useEffect(() => {
+    fetchData() // fetchData は毎レンダリングで新しい関数
+  }, [fetchData]) // 無限ループ
+}
+
+// - 良い例
+function useGoodFetch<T>(url: string) {
+  const [data, setData] = useState<T | null>(null)
+
+  useEffect(() => {
+    fetch(url).then(res => res.json()).then(setData)
+  }, [url]) // url のみ依存
+}
+```
+
+### 7.3 失敗3: クリーンアップの欠落
+
+```typescript
+// ❌ 悪い例：メモリリーク
+function useBadInterval(callback: () => void, delay: number) {
+  useEffect(() => {
+    const id = setInterval(callback, delay)
+    // クリーンアップなし
+  }, [callback, delay])
+}
+
+// - 良い例
+function useInterval(callback: () => void, delay: number) {
+  const savedCallback = useRef(callback)
+
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    const tick = () => savedCallback.current()
+    const id = setInterval(tick, delay)
+
+    return () => {
+      clearInterval(id) // クリーンアップ
+    }
+  }, [delay])
+}
+```
+
+
+## 8. まとめ
+
+### 8.1 重要ポイント
+
+**1. 設計原則を守る**
+- 単一責任の原則
+- 型安全性
+- 一貫性のあるAPI
+
+**2. よく使うパターンを習得**
+- useFetch: データフェッチ
+- useLocalStorage: 永続化
+- useDebounce/useThrottle: パフォーマンス最適化
+- useToggle: UI状態管理
+
+**3. テストを書く**
+- renderHook を使う
+- MSW でAPIをモック
+- エッジケースをテスト
+
+**4. 過剰な抽象化を避ける**
+- シンプルなフックを組み合わせる
+- 複雑すぎるフックは分割
+
+### 8.2 チェックリスト
+
+カスタムフックを作る際は、以下をチェックしましょう：
+
+- [ ] 関数名は `use` で始まっているか？
+- [ ] 単一責任の原則を守っているか？
+- [ ] TypeScript のジェネリクスを活用しているか？
+- [ ] 依存配列は正しく設定されているか？
+- [ ] クリーンアップ関数は必要ないか？
+- [ ] テストは書いたか？
+- [ ] 他のフックと一貫性のあるAPIか？
+
+### 8.3 次のステップ
+
+次の Chapter 4 では、TypeScript を使ったコンポーネントの型定義を学びます：
+- React.FC vs 関数宣言
+- Props の型定義パターン
+- Children の型安全な扱い
+- forwardRef の型定義
+
+
+**参考リンク**:
+- [React 公式ドキュメント - Building Your Own Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)
+- [React Testing Library - renderHook](https://testing-library.com/docs/react-testing-library/api/#renderhook)
+- [MSW (Mock Service Worker)](https://mswjs.io/)


### PR DESCRIPTION
## 概要

React 応用編の `02-hooks/` セクションを追加します。

## 追加ファイル（3ファイル）

| ファイル | 内容 | 行数 |
|---|---|---|
| `01-usestate-deep-dive.md` | useState の深い理解と実践パターン | 695行 |
| `02-useeffect-complete-guide.md` | useEffect 実践ガイドと罠の回避 | 989行 |
| `03-custom-hooks-patterns.md` | カスタムフック設計パターン | 835行 |

## ソース

Zenn「React実践テクニック」ch01-03 より導入。
Zenn 固有フォーマット（frontmatter・✅マーク・Chapter番号）を除去済み。

## 方針

- 日本語コンテンツのみ（`ja/` ディレクトリ）
- 英語版は別途追加予定