### PR TITLE
feat(react): 03-typescript セクション追加（コンポーネント型定義 / 高度な型 / Context・Form）

### DIFF
--- a/ja/04-web-and-network/react-development/docs/03-typescript/01-component-type-patterns.md
+++ b/ja/04-web-and-network/react-development/docs/03-typescript/01-component-type-patterns.md
@@ -1,0 +1,1263 @@
+
+# コンポーネントの型定義完全版
+
+## この章で学べること
+
+この章では、TypeScriptでReactコンポーネントを型安全に実装する全パターンを学びます。
+
+- React.FC を使わない理由と推奨パターン
+- Props の基本と高度な型定義
+- Discriminated Union（条件付きProps）
+- HTML属性の継承パターン
+- Ref の型定義と forwardRef
+- Children の正しい型付け
+- Utility Types の実践活用
+- イベントハンドラの型定義
+
+**前提知識**: TypeScript の基本文法
+
+**所要時間**: 40-50分
+
+
+## 目次
+
+1. [コンポーネントの型定義パターン](#1-コンポーネントの型定義パターン)
+2. [Props の高度な型パターン](#2-props-の高度な型パターン)
+3. [Discriminated Union（条件付きProps）](#3-discriminated-union条件付きprops)
+4. [HTML属性の継承](#4-html属性の継承)
+5. [Ref の型定義と転送](#5-ref-の型定義と転送)
+6. [Children の型定義](#6-children-の型定義)
+7. [イベントハンドラの型](#7-イベントハンドラの型)
+8. [Utility Types の活用](#8-utility-types-の活用)
+9. [実践例：型安全なコンポーネント集](#9-実践例型安全なコンポーネント集)
+10. [まとめ](#10-まとめ)
+
+
+## 1. コンポーネントの型定義パターン
+
+### React.FC を使わない理由
+
+```typescript
+// ❌ React.FC（非推奨）
+const Component: React.FC<Props> = ({ name }) => {
+  return <div>{name}</div>
+}
+
+// 問題点:
+// 1. 暗黙的に children を含む（型安全性が低下）
+// 2. ジェネリクスとの相性が悪い
+// 3. デフォルトProps との互換性問題
+```
+
+**React.FC の問題点**:
+
+1. **暗黙的な children**: 明示的に `children` を定義しなくても、自動的に含まれる
+2. **ジェネリクスの制約**: ジェネリック型パラメータを使う場合、構文が複雑になる
+3. **デフォルトProps の非互換性**: TypeScript 3.1 以降、デフォルトProps と相性が悪い
+
+### 推奨パターン
+
+```typescript
+// - 通常の関数（推奨）
+interface Props {
+  name: string
+  age: number
+}
+
+function Component({ name, age }: Props) {
+  return (
+    <div>
+      {name} is {age} years old
+    </div>
+  )
+}
+
+// - アロー関数（推奨）
+const Component = ({ name, age }: Props) => {
+  return (
+    <div>
+      {name} is {age} years old
+    </div>
+  )
+}
+
+// 戻り値の型を明示する場合
+function Component({ name, age }: Props): JSX.Element {
+  return (
+    <div>
+      {name} is {age} years old
+    </div>
+  )
+}
+```
+
+### Props の基本的な型定義
+
+```typescript
+// プリミティブ型
+interface BasicProps {
+  title: string
+  count: number
+  isActive: boolean
+}
+
+// オプショナル
+interface OptionalProps {
+  title: string
+  subtitle?: string // オプショナル
+}
+
+// ユニオン型
+interface UnionProps {
+  variant: 'primary' | 'secondary' | 'danger'
+  size: 'sm' | 'md' | 'lg'
+}
+
+// オブジェクト型
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+interface ObjectProps {
+  user: User
+  onUpdate: (user: User) => void
+}
+
+// 配列型
+interface ArrayProps {
+  tags: string[]
+  users: User[]
+}
+
+// 関数型
+interface FunctionProps {
+  onClick: () => void
+  onSubmit: (value: string) => void
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+```
+
+**実装例**:
+
+```typescript
+interface UserCardProps {
+  user: User
+  variant: 'compact' | 'full'
+  onEdit?: (user: User) => void
+}
+
+function UserCard({ user, variant, onEdit }: UserCardProps) {
+  return (
+    <div className={`user-card user-card--${variant}`}>
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+      {onEdit && (
+        <button onClick={() => onEdit(user)}>Edit</button>
+      )}
+    </div>
+  )
+}
+
+// 使用例
+<UserCard
+  user={{ id: '1', name: 'John', email: 'john@example.com' }}
+  variant="full"
+  onEdit={(user) => console.log('Editing', user)}
+/>
+```
+
+
+## 2. Props の高度な型パターン
+
+### デフォルト値を持つProps
+
+```typescript
+interface ButtonProps {
+  variant?: 'primary' | 'secondary'
+  size?: 'sm' | 'md' | 'lg'
+  children: React.ReactNode
+}
+
+// デフォルト値を設定
+function Button({
+  variant = 'primary',
+  size = 'md',
+  children
+}: ButtonProps) {
+  return (
+    <button className={`btn btn-${variant} btn-${size}`}>
+      {children}
+    </button>
+  )
+}
+
+// 使用例
+<Button>Click me</Button> // variant='primary', size='md'
+<Button variant="secondary" size="lg">Large Button</Button>
+```
+
+### Required Props（必須プロパティ）
+
+```typescript
+interface OptionalConfig {
+  theme?: 'light' | 'dark'
+  locale?: string
+  debug?: boolean
+}
+
+// 全てのプロパティを必須に
+type RequiredConfig = Required<OptionalConfig>
+
+function applyConfig(config: RequiredConfig) {
+  // 全てのプロパティが保証されている
+  console.log(config.theme)  // 必ず存在
+  console.log(config.locale) // 必ず存在
+  console.log(config.debug)  // 必ず存在
+}
+```
+
+### Partial Props（オプショナル化）
+
+```typescript
+interface FormData {
+  username: string
+  email: string
+  age: number
+}
+
+// 全てのプロパティをオプショナルに
+type PartialFormData = Partial<FormData>
+
+interface FormProps {
+  initialValues?: Partial<FormData>
+  onSubmit: (data: FormData) => void
+}
+
+function Form({ initialValues = {}, onSubmit }: FormProps) {
+  const [formData, setFormData] = useState<FormData>({
+    username: initialValues.username ?? '',
+    email: initialValues.email ?? '',
+    age: initialValues.age ?? 0
+  })
+
+  return (
+    <form onSubmit={(e) => {
+      e.preventDefault()
+      onSubmit(formData)
+    }}>
+      {/* フォーム実装 */}
+    </form>
+  )
+}
+
+// 使用例
+<Form
+  initialValues={{ username: 'John' }} // email, age は省略可能
+  onSubmit={(data) => console.log(data)}
+/>
+```
+
+
+## 3. Discriminated Union（条件付きProps）
+
+### 基本パターン
+
+```typescript
+// ❌ 問題：variantによってpropsが変わるが、型で表現できていない
+interface BadButtonProps {
+  variant: 'link' | 'button'
+  href?: string    // linkの時のみ必要
+  onClick?: () => void // buttonの時のみ必要
+}
+
+// 使用時に問題が発生
+<BadButton variant="link" onClick={() => {}} /> // ❌ linkなのにonClick?
+<BadButton variant="button" href="/home" />     // ❌ buttonなのにhref?
+```
+
+```typescript
+// - 解決：Discriminated Union
+type ButtonProps =
+  | {
+      variant: 'link'
+      href: string
+      onClick?: never // buttonの時は使えない
+    }
+  | {
+      variant: 'button'
+      onClick: () => void
+      href?: never // linkの時は使えない
+    }
+
+function Button(props: ButtonProps) {
+  if (props.variant === 'link') {
+    // TypeScriptがprops.hrefの存在を保証
+    return <a href={props.href}>Link</a>
+  }
+
+  // TypeScriptがprops.onClickの存在を保証
+  return <button onClick={props.onClick}>Button</button>
+}
+
+// 使用例
+<Button variant="link" href="/home" />         // - OK
+<Button variant="button" onClick={() => {}} /> // - OK
+<Button variant="link" onClick={() => {}} />   // ❌ 型エラー
+<Button variant="button" href="/home" />       // ❌ 型エラー
+```
+
+### 複雑な Discriminated Union
+
+```typescript
+// フォーム入力の型（inputTypeによってpropsが変わる）
+type InputProps =
+  | {
+      inputType: 'text'
+      value: string
+      onChange: (value: string) => void
+    }
+  | {
+      inputType: 'number'
+      value: number
+      onChange: (value: number) => void
+      min?: number
+      max?: number
+    }
+  | {
+      inputType: 'select'
+      value: string
+      onChange: (value: string) => void
+      options: Array<{ label: string; value: string }>
+    }
+
+function FormInput(props: InputProps) {
+  switch (props.inputType) {
+    case 'text':
+      return (
+        <input
+          type="text"
+          value={props.value}
+          onChange={(e) => props.onChange(e.target.value)}
+        />
+      )
+
+    case 'number':
+      return (
+        <input
+          type="number"
+          value={props.value}
+          onChange={(e) => props.onChange(Number(e.target.value))}
+          min={props.min}
+          max={props.max}
+        />
+      )
+
+    case 'select':
+      return (
+        <select
+          value={props.value}
+          onChange={(e) => props.onChange(e.target.value)}
+        >
+          {props.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )
+  }
+}
+
+// 使用例
+<FormInput
+  inputType="text"
+  value="hello"
+  onChange={(v) => console.log(v)}
+/>
+
+<FormInput
+  inputType="number"
+  value={42}
+  onChange={(v) => console.log(v)}
+  min={0}
+  max={100}
+/>
+
+<FormInput
+  inputType="select"
+  value="apple"
+  onChange={(v) => console.log(v)}
+  options={[
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' }
+  ]}
+/>
+```
+
+
+## 4. HTML属性の継承
+
+### Button コンポーネント
+
+```typescript
+// HTMLButtonElement の属性を継承
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary'
+  loading?: boolean
+}
+
+function Button({
+  variant = 'primary',
+  loading = false,
+  children,
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={`btn btn-${variant}`}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {loading ? 'Loading...' : children}
+    </button>
+  )
+}
+
+// 使用例（すべてのbutton属性が使える）
+<Button
+  variant="primary"
+  onClick={() => console.log('clicked')}
+  disabled
+  type="submit"
+  aria-label="Submit button"
+  data-testid="submit-btn"
+>
+  Submit
+</Button>
+```
+
+### Input コンポーネント
+
+```typescript
+// HTMLInputElement の属性を継承
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string
+  error?: string
+}
+
+function Input({ label, error, className, ...props }: InputProps) {
+  return (
+    <div className="input-wrapper">
+      <label>{label}</label>
+      <input
+        className={`input ${error ? 'input--error' : ''} ${className}`}
+        aria-invalid={!!error}
+        {...props}
+      />
+      {error && <span className="error-message">{error}</span>}
+    </div>
+  )
+}
+
+// 使用例
+<Input
+  label="Email"
+  type="email"
+  placeholder="your@email.com"
+  required
+  autoComplete="email"
+  error="Invalid email address"
+/>
+```
+
+### Container コンポーネント
+
+```typescript
+// HTMLDivElement の属性を継承
+interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  maxWidth?: number
+  centered?: boolean
+}
+
+function Container({
+  maxWidth,
+  centered = false,
+  children,
+  style,
+  ...props
+}: ContainerProps) {
+  return (
+    <div
+      style={{
+        ...style,
+        maxWidth,
+        margin: centered ? '0 auto' : undefined
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// 使用例
+<Container
+  maxWidth={1200}
+  centered
+  className="main-container"
+  onClick={() => console.log('Container clicked')}
+  data-testid="main-container"
+>
+  <h1>Content</h1>
+</Container>
+```
+
+
+## 5. Ref の型定義と転送
+
+### forwardRef を使った Ref の転送
+
+```typescript
+interface InputProps {
+  label: string
+  error?: string
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error }, ref) => {
+    return (
+      <div>
+        <label>{label}</label>
+        <input ref={ref} aria-invalid={!!error} />
+        {error && <span>{error}</span>}
+      </div>
+    )
+  }
+)
+
+// displayName を設定（DevTools で表示される）
+Input.displayName = 'Input'
+
+// 使用例
+function Parent() {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const focusInput = () => {
+    inputRef.current?.focus()
+  }
+
+  return (
+    <>
+      <Input ref={inputRef} label="Name" />
+      <button onClick={focusInput}>Focus Input</button>
+    </>
+  )
+}
+```
+
+### useImperativeHandle でカスタムRefを公開
+
+```typescript
+interface InputHandle {
+  focus: () => void
+  clear: () => void
+  getValue: () => string
+}
+
+interface InputProps {
+  label: string
+  defaultValue?: string
+}
+
+const CustomInput = forwardRef<InputHandle, InputProps>(
+  ({ label, defaultValue }, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus()
+      },
+      clear: () => {
+        if (inputRef.current) {
+          inputRef.current.value = ''
+        }
+      },
+      getValue: () => {
+        return inputRef.current?.value ?? ''
+      }
+    }))
+
+    return (
+      <div>
+        <label>{label}</label>
+        <input ref={inputRef} defaultValue={defaultValue} />
+      </div>
+    )
+  }
+)
+
+CustomInput.displayName = 'CustomInput'
+
+// 使用例
+function Parent() {
+  const inputRef = useRef<InputHandle>(null)
+
+  const handleSubmit = () => {
+    const value = inputRef.current?.getValue()
+    console.log('Value:', value)
+    inputRef.current?.clear()
+  }
+
+  return (
+    <>
+      <CustomInput ref={inputRef} label="Name" defaultValue="John" />
+      <button onClick={() => inputRef.current?.focus()}>Focus</button>
+      <button onClick={handleSubmit}>Submit & Clear</button>
+    </>
+  )
+}
+```
+
+
+## 6. Children の型定義
+
+### ReactNode（最も汎用的）
+
+```typescript
+interface Props {
+  children: React.ReactNode
+}
+
+function Container({ children }: Props) {
+  return <div className="container">{children}</div>
+}
+
+// 使用例（あらゆる要素を受け入れる）
+<Container>
+  <p>Text</p>
+  {[1, 2, 3]}
+  {null}
+  {undefined}
+  <div>Nested</div>
+</Container>
+```
+
+### ReactElement（特定の要素のみ）
+
+```typescript
+interface Props {
+  children: React.ReactElement
+}
+
+function Wrapper({ children }: Props) {
+  return <div className="wrapper">{children}</div>
+}
+
+// 使用例
+<Wrapper>
+  <p>Only one element allowed</p>
+</Wrapper>
+
+// ❌ エラー
+<Wrapper>
+  <p>Multiple</p>
+  <p>Elements</p>
+</Wrapper>
+```
+
+### Render Props パターン
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+interface Props {
+  children: (data: User) => React.ReactNode
+}
+
+function UserProvider({ children }: Props) {
+  const user: User = {
+    id: '1',
+    name: 'John',
+    email: 'john@example.com'
+  }
+
+  return <>{children(user)}</>
+}
+
+// 使用例
+<UserProvider>
+  {(user) => (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+    </div>
+  )}
+</UserProvider>
+```
+
+### 特定のコンポーネントのみ許可
+
+```typescript
+interface ItemProps {
+  name: string
+}
+
+function Item({ name }: ItemProps) {
+  return <li>{name}</li>
+}
+
+interface ListProps {
+  children: React.ReactElement<ItemProps> | React.ReactElement<ItemProps>[]
+}
+
+function List({ children }: ListProps) {
+  return <ul>{children}</ul>
+}
+
+// 使用例
+<List>
+  <Item name="Apple" />
+  <Item name="Banana" />
+</List>
+
+// ❌ エラー
+<List>
+  <div>Not an Item</div>
+</List>
+```
+
+
+## 7. イベントハンドラの型
+
+### 基本的なイベント型
+
+```typescript
+// マウスイベント
+function Button() {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    console.log('Button clicked at', e.clientX, e.clientY)
+    e.currentTarget.disabled = true // HTMLButtonElement として認識
+  }
+
+  return <button onClick={handleClick}>Click me</button>
+}
+
+// チェンジイベント（input）
+function TextInput() {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('Value:', e.target.value)
+  }
+
+  return <input onChange={handleChange} />
+}
+
+// チェンジイベント（select）
+function Select() {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log('Selected:', e.target.value)
+  }
+
+  return (
+    <select onChange={handleChange}>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+    </select>
+  )
+}
+
+// フォームイベント
+function Form() {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    console.log('Form data:', Object.fromEntries(formData))
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="username" />
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+
+// キーボードイベント
+function KeyboardInput() {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      console.log('Enter pressed')
+    }
+    if (e.ctrlKey && e.key === 's') {
+      e.preventDefault()
+      console.log('Ctrl+S pressed')
+    }
+  }
+
+  return <input onKeyDown={handleKeyDown} />
+}
+
+// フォーカスイベント
+function FocusInput() {
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select() // 全選択
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    console.log('Input blurred')
+  }
+
+  return <input onFocus={handleFocus} onBlur={handleBlur} />
+}
+```
+
+### 型推論を活用
+
+```typescript
+// ❌ 明示的な型注釈（冗長）
+function Component() {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    console.log('Clicked')
+  }
+
+  return <button onClick={handleClick}>Click</button>
+}
+
+// - インライン定義（型推論）
+function Component() {
+  return (
+    <button onClick={(e) => {
+      // eは自動的にReact.MouseEvent<HTMLButtonElement>と推論される
+      console.log('Clicked at', e.clientX, e.clientY)
+    }}>
+      Click
+    </button>
+  )
+}
+```
+
+### カスタムイベントハンドラ
+
+```typescript
+interface User {
+  id: string
+  name: string
+}
+
+interface UserListProps {
+  users: User[]
+  onUserSelect: (user: User) => void
+  onUserDelete: (userId: string) => void
+}
+
+function UserList({ users, onUserSelect, onUserDelete }: UserListProps) {
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>
+          <button onClick={() => onUserSelect(user)}>
+            {user.name}
+          </button>
+          <button onClick={() => onUserDelete(user.id)}>
+            Delete
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// 非同期イベントハンドラ
+interface AsyncButtonProps {
+  onAsyncClick: () => Promise<void>
+  children: React.ReactNode
+}
+
+function AsyncButton({ onAsyncClick, children }: AsyncButtonProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      await onAsyncClick()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button onClick={handleClick} disabled={loading}>
+      {loading ? 'Loading...' : children}
+    </button>
+  )
+}
+```
+
+### イベントハンドラの型エイリアス
+
+```typescript
+// 再利用可能な型エイリアス
+type ClickHandler = React.MouseEventHandler<HTMLButtonElement>
+type ChangeHandler = React.ChangeEventHandler<HTMLInputElement>
+type SubmitHandler = React.FormEventHandler<HTMLFormElement>
+
+interface FormProps {
+  onSubmit: SubmitHandler
+  onChange: ChangeHandler
+}
+
+function Form({ onSubmit, onChange }: FormProps) {
+  return (
+    <form onSubmit={onSubmit}>
+      <input onChange={onChange} />
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+```
+
+
+## 8. Utility Types の活用
+
+### Omit でプロパティを除外
+
+```typescript
+// 元の型
+interface FullUser {
+  id: string
+  name: string
+  email: string
+  password: string
+  createdAt: Date
+}
+
+// パスワードを除外した型
+type PublicUser = Omit<FullUser, 'password'>
+
+// 複数のプロパティを除外
+type UserSummary = Omit<FullUser, 'password' | 'createdAt'>
+
+interface UserCardProps {
+  user: PublicUser
+}
+
+function UserCard({ user }: UserCardProps) {
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+      {/* user.password は存在しない */}
+    </div>
+  )
+}
+```
+
+### Pick で必要なプロパティのみ抽出
+
+```typescript
+// 元の型
+interface FullProduct {
+  id: string
+  name: string
+  description: string
+  price: number
+  stock: number
+  categoryId: string
+  images: string[]
+}
+
+// 必要なプロパティのみ
+type ProductSummary = Pick<FullProduct, 'id' | 'name' | 'price'>
+
+interface ProductCardProps {
+  product: ProductSummary
+}
+
+function ProductCard({ product }: ProductCardProps) {
+  return (
+    <div>
+      <h3>{product.name}</h3>
+      <p>¥{product.price}</p>
+    </div>
+  )
+}
+```
+
+### Readonly で不変に
+
+```typescript
+interface MutableUser {
+  id: string
+  name: string
+}
+
+type ImmutableUser = Readonly<MutableUser>
+
+function Component() {
+  const user: ImmutableUser = { id: '1', name: 'John' }
+
+  user.name = 'Jane' // ❌ 型エラー：読み取り専用
+}
+
+// ネストしたオブジェクトも不変に（DeepReadonly）
+type DeepReadonly<T> = {
+  readonly [K in keyof T]: T[K] extends object
+    ? DeepReadonly<T[K]>
+    : T[K]
+}
+
+interface NestedData {
+  user: {
+    name: string
+    address: {
+      city: string
+    }
+  }
+}
+
+type ImmutableNestedData = DeepReadonly<NestedData>
+
+const data: ImmutableNestedData = {
+  user: {
+    name: 'John',
+    address: { city: 'Tokyo' }
+  }
+}
+
+data.user.address.city = 'Osaka' // ❌ 型エラー
+```
+
+
+## 9. 実践例：型安全なコンポーネント集
+
+### 1. 型安全なButtonコンポーネント
+
+```typescript
+type ButtonVariant = 'primary' | 'secondary' | 'danger'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+}
+
+function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  children,
+  disabled,
+  className,
+  ...props
+}: ButtonProps) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    `btn-${size}`,
+    className
+  ].filter(Boolean).join(' ')
+
+  return (
+    <button
+      className={classes}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {loading ? (
+        <>
+          <span className="spinner" />
+          Loading...
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  )
+}
+
+// 使用例
+<Button variant="primary" size="lg" onClick={() => console.log('Clicked')}>
+  Click me
+</Button>
+
+<Button variant="danger" loading>
+  Processing...
+</Button>
+```
+
+### 2. 型安全なModalコンポーネント
+
+```typescript
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  footer?: React.ReactNode
+  size?: 'sm' | 'md' | 'lg'
+}
+
+function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  size = 'md'
+}: ModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className={`modal-content modal-${size}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="modal-header">
+          <h2>{title}</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close modal"
+          >
+            ×
+          </button>
+        </header>
+        <main className="modal-body">
+          {children}
+        </main>
+        {footer && (
+          <footer className="modal-footer">
+            {footer}
+          </footer>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// 使用例
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>Open Modal</button>
+
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="Confirm Action"
+        size="md"
+        footer={
+          <>
+            <button onClick={() => setIsOpen(false)}>Cancel</button>
+            <button onClick={() => {
+              console.log('Confirmed')
+              setIsOpen(false)
+            }}>
+              Confirm
+            </button>
+          </>
+        }
+      >
+        <p>Are you sure you want to continue?</p>
+      </Modal>
+    </>
+  )
+}
+```
+
+### 3. 型安全なCardコンポーネント
+
+```typescript
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string
+  subtitle?: string
+  image?: string
+  children: React.ReactNode
+  actions?: React.ReactNode
+}
+
+function Card({
+  title,
+  subtitle,
+  image,
+  children,
+  actions,
+  className,
+  ...props
+}: CardProps) {
+  return (
+    <div className={`card ${className ?? ''}`} {...props}>
+      {image && (
+        <div className="card-image">
+          <img src={image} alt={title} />
+        </div>
+      )}
+      <div className="card-header">
+        <h3>{title}</h3>
+        {subtitle && <p className="card-subtitle">{subtitle}</p>}
+      </div>
+      <div className="card-body">
+        {children}
+      </div>
+      {actions && (
+        <div className="card-actions">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// 使用例
+<Card
+  title="Product Name"
+  subtitle="Product Category"
+  image="/product.jpg"
+  actions={
+    <>
+      <button>Add to Cart</button>
+      <button>View Details</button>
+    </>
+  }
+>
+  <p>Product description goes here.</p>
+  <p className="price">¥1,200</p>
+</Card>
+```
+
+
+## 10. まとめ
+
+この章では、TypeScriptでReactコンポーネントを型安全に実装する全パターンを学びました。
+
+### 重要ポイント
+
+1. **React.FC は使わない**: 通常の関数またはアロー関数を推奨
+2. **Discriminated Union**: 条件付きPropsは型で厳密に表現
+3. **HTML属性の継承**: `extends React.XXXHTMLAttributes` で再利用性向上
+4. **forwardRef**: Ref転送時は型パラメータを明示
+5. **Children の型**: 用途に応じて `ReactNode` / `ReactElement` を使い分け
+6. **イベントハンドラ**: インライン定義で型推論を活用
+7. **Utility Types**: `Omit` / `Pick` / `Partial` / `Required` で柔軟に型を構築
+
+### Next Steps
+
+次の章では、さらに高度な型パターン（ジェネリック、条件付き型、マップ型）を学びます。
+
+- Chapter 5: 高度な型パターンとジェネリック
+- Chapter 6: Context と Form の型安全な実装
+
+
+**執筆時間**: 約45分で習得可能
+**文字数**: 約2,100語
+
+この章をマスターすることで、型安全なReactコンポーネント設計の基礎が身につきます。

--- a/ja/04-web-and-network/react-development/docs/03-typescript/02-advanced-type-patterns.md
+++ b/ja/04-web-and-network/react-development/docs/03-typescript/02-advanced-type-patterns.md
@@ -1,0 +1,1002 @@
+
+# 高度な型パターンとジェネリック
+
+## この章で学べること
+
+この章では、TypeScriptの高度な型機能を使ってReactコンポーネントの再利用性と型安全性を最大化する方法を学びます。
+
+- ジェネリックコンポーネントの設計パターン
+- Conditional Types（条件付き型）の実践活用
+- Mapped Types（マップ型）で型を動的生成
+- Template Literal Types で型安全なAPI
+- Type Guards（型ガード）による型の絞り込み
+- infer キーワードで型を抽出
+- 実践例：汎用的なList/Table/Select/Formコンポーネント
+
+**前提知識**: Chapter 4 の内容（基本的な型定義）
+
+**所要時間**: 50-60分
+
+
+## 目次
+
+1. [ジェネリックコンポーネント入門](#1-ジェネリックコンポーネント入門)
+2. [ジェネリックなListコンポーネント](#2-ジェネリックなlistコンポーネント)
+3. [ジェネリックなSelectコンポーネント](#3-ジェネリックなselectコンポーネント)
+4. [ジェネリックなTableコンポーネント](#4-ジェネリックなtableコンポーネント)
+5. [ジェネリックなFormコンポーネント](#5-ジェネリックなformコンポーネント)
+6. [Conditional Types（条件付き型）](#6-conditional-types条件付き型)
+7. [Mapped Types（マップ型）](#7-mapped-typesマップ型)
+8. [Template Literal Types](#8-template-literal-types)
+9. [Type Guards（型ガード）](#9-type-guards型ガード)
+10. [まとめ](#10-まとめ)
+
+
+## 1. ジェネリックコンポーネント入門
+
+### ジェネリックとは？
+
+ジェネリック（Generics）は、型を引数として受け取る仕組みです。これにより、1つのコンポーネント定義で複数の型に対応できます。
+
+```typescript
+// ❌ 型ごとにコンポーネントを定義（冗長）
+interface UserListProps {
+  items: User[]
+  renderItem: (item: User) => React.ReactNode
+}
+
+interface ProductListProps {
+  items: Product[]
+  renderItem: (item: Product) => React.ReactNode
+}
+
+// - ジェネリックで1つの定義に統一
+interface ListProps<T> {
+  items: T[]
+  renderItem: (item: T) => React.ReactNode
+}
+
+// User型でもProduct型でも使える
+function UserList() {
+  return <List<User> items={users} renderItem={renderUser} />
+}
+
+function ProductList() {
+  return <List<Product> items={products} renderItem={renderProduct} />
+}
+```
+
+### ジェネリックのメリット
+
+1. **コードの再利用性**: 1つの実装で複数の型に対応
+2. **型安全性**: 型の不整合をコンパイル時に検出
+3. **保守性**: 重複コードを削減し、変更を1箇所に集約
+
+
+## 2. ジェネリックなListコンポーネント
+
+### 基本実装
+
+```typescript
+interface ListProps<T> {
+  items: T[]
+  renderItem: (item: T, index: number) => React.ReactNode
+  keyExtractor: (item: T) => string
+  emptyMessage?: string
+}
+
+function List<T>({
+  items,
+  renderItem,
+  keyExtractor,
+  emptyMessage = 'No items'
+}: ListProps<T>) {
+  if (items.length === 0) {
+    return <p className="empty-message">{emptyMessage}</p>
+  }
+
+  return (
+    <ul className="list">
+      {items.map((item, index) => (
+        <li key={keyExtractor(item)}>
+          {renderItem(item, index)}
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### 使用例1: User型
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+  role: 'admin' | 'user'
+}
+
+function UserList() {
+  const users: User[] = [
+    { id: '1', name: 'John', email: 'john@example.com', role: 'admin' },
+    { id: '2', name: 'Jane', email: 'jane@example.com', role: 'user' }
+  ]
+
+  return (
+    <List<User>
+      items={users}
+      keyExtractor={(user) => user.id}
+      renderItem={(user, index) => (
+        <div className="user-item">
+          <strong>
+            {index + 1}. {user.name}
+          </strong>
+          <span className="email">{user.email}</span>
+          <span className={`badge badge-${user.role}`}>
+            {user.role}
+          </span>
+        </div>
+      )}
+      emptyMessage="No users found"
+    />
+  )
+}
+```
+
+### 使用例2: Product型
+
+```typescript
+interface Product {
+  id: string
+  name: string
+  price: number
+  inStock: boolean
+}
+
+function ProductList() {
+  const products: Product[] = [
+    { id: '1', name: 'Apple', price: 100, inStock: true },
+    { id: '2', name: 'Banana', price: 50, inStock: false }
+  ]
+
+  return (
+    <List<Product>
+      items={products}
+      keyExtractor={(product) => product.id}
+      renderItem={(product) => (
+        <div className="product-item">
+          <h3>{product.name}</h3>
+          <p className="price">¥{product.price.toLocaleString()}</p>
+          <span className={product.inStock ? 'in-stock' : 'out-of-stock'}>
+            {product.inStock ? '在庫あり' : '在庫なし'}
+          </span>
+        </div>
+      )}
+      emptyMessage="No products available"
+    />
+  )
+}
+```
+
+**型安全性の恩恵**:
+
+```typescript
+// - OK: User型のプロパティにアクセス
+<List<User>
+  items={users}
+  renderItem={(user) => <div>{user.name}</div>}
+  keyExtractor={(user) => user.id}
+/>
+
+// ❌ 型エラー: Product型に'username'プロパティは存在しない
+<List<Product>
+  items={products}
+  renderItem={(product) => <div>{product.name}</div>} // OK
+  keyExtractor={(product) => product.username} // ❌ エラー
+/>
+```
+
+
+## 3. ジェネリックなSelectコンポーネント
+
+### 基本実装
+
+```typescript
+interface SelectProps<T> {
+  value: T
+  options: T[]
+  onChange: (value: T) => void
+  getLabel: (option: T) => string
+  getValue: (option: T) => string
+  placeholder?: string
+  disabled?: boolean
+}
+
+function Select<T>({
+  value,
+  options,
+  onChange,
+  getLabel,
+  getValue,
+  placeholder,
+  disabled = false
+}: SelectProps<T>) {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = e.target.value
+    const selectedOption = options.find(
+      (opt) => getValue(opt) === selectedValue
+    )
+    if (selectedOption) {
+      onChange(selectedOption)
+    }
+  }
+
+  return (
+    <select
+      value={getValue(value)}
+      onChange={handleChange}
+      disabled={disabled}
+      className="select"
+    >
+      {placeholder && (
+        <option value="" disabled>
+          {placeholder}
+        </option>
+      )}
+      {options.map((option) => (
+        <option key={getValue(option)} value={getValue(option)}>
+          {getLabel(option)}
+        </option>
+      ))}
+    </select>
+  )
+}
+```
+
+### 使用例1: プリミティブ型
+
+```typescript
+function FruitSelect() {
+  const [selected, setSelected] = useState('apple')
+  const fruits = ['apple', 'banana', 'orange', 'grape']
+
+  return (
+    <Select<string>
+      value={selected}
+      options={fruits}
+      onChange={setSelected}
+      getLabel={(fruit) => fruit.charAt(0).toUpperCase() + fruit.slice(1)}
+      getValue={(fruit) => fruit}
+      placeholder="Select a fruit"
+    />
+  )
+}
+```
+
+### 使用例2: オブジェクト型
+
+```typescript
+interface Country {
+  code: string
+  name: string
+  flag: string
+}
+
+function CountrySelect() {
+  const countries: Country[] = [
+    { code: 'JP', name: 'Japan', flag: '🇯🇵' },
+    { code: 'US', name: 'United States', flag: '🇺🇸' },
+    { code: 'UK', name: 'United Kingdom', flag: '🇬🇧' }
+  ]
+
+  const [selected, setSelected] = useState(countries[0])
+
+  return (
+    <div>
+      <Select<Country>
+        value={selected}
+        options={countries}
+        onChange={setSelected}
+        getLabel={(country) => `${country.flag} ${country.name}`}
+        getValue={(country) => country.code}
+      />
+      <p>Selected: {selected.name} ({selected.code})</p>
+    </div>
+  )
+}
+```
+
+
+## 4. ジェネリックなTableコンポーネント
+
+### 基本実装
+
+```typescript
+interface Column<T> {
+  key: string
+  header: string
+  render: (item: T) => React.ReactNode
+  width?: string
+  align?: 'left' | 'center' | 'right'
+}
+
+interface TableProps<T> {
+  data: T[]
+  columns: Column<T>[]
+  keyExtractor: (item: T) => string
+  onRowClick?: (item: T) => void
+}
+
+function Table<T>({
+  data,
+  columns,
+  keyExtractor,
+  onRowClick
+}: TableProps<T>) {
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th
+              key={col.key}
+              style={{
+                width: col.width,
+                textAlign: col.align ?? 'left'
+              }}
+            >
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((item) => (
+          <tr
+            key={keyExtractor(item)}
+            onClick={() => onRowClick?.(item)}
+            className={onRowClick ? 'clickable' : ''}
+          >
+            {columns.map((col) => (
+              <td
+                key={col.key}
+                style={{ textAlign: col.align ?? 'left' }}
+              >
+                {col.render(item)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+```
+
+### 使用例: Userテーブル
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+  age: number
+  status: 'active' | 'inactive'
+}
+
+function UserTable() {
+  const users: User[] = [
+    { id: '1', name: 'John', email: 'john@example.com', age: 25, status: 'active' },
+    { id: '2', name: 'Jane', email: 'jane@example.com', age: 30, status: 'inactive' }
+  ]
+
+  const columns: Column<User>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (user) => <strong>{user.name}</strong>,
+      width: '200px'
+    },
+    {
+      key: 'email',
+      header: 'Email',
+      render: (user) => (
+        <a href={`mailto:${user.email}`}>{user.email}</a>
+      )
+    },
+    {
+      key: 'age',
+      header: 'Age',
+      render: (user) => `${user.age} years old`,
+      align: 'center',
+      width: '100px'
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (user) => (
+        <span className={`badge badge-${user.status}`}>
+          {user.status}
+        </span>
+      ),
+      align: 'center'
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (user) => (
+        <div className="actions">
+          <button onClick={() => console.log('Edit', user.id)}>
+            Edit
+          </button>
+          <button onClick={() => console.log('Delete', user.id)}>
+            Delete
+          </button>
+        </div>
+      ),
+      align: 'right'
+    }
+  ]
+
+  return (
+    <Table<User>
+      data={users}
+      columns={columns}
+      keyExtractor={(user) => user.id}
+      onRowClick={(user) => console.log('Row clicked:', user.name)}
+    />
+  )
+}
+```
+
+
+## 5. ジェネリックなFormコンポーネント
+
+### 基本実装
+
+```typescript
+interface FormField<T> {
+  name: keyof T
+  label: string
+  type: 'text' | 'number' | 'email' | 'password' | 'textarea'
+  required?: boolean
+  placeholder?: string
+  validate?: (value: T[keyof T]) => string | undefined
+}
+
+interface FormProps<T> {
+  initialValues: T
+  fields: FormField<T>[]
+  onSubmit: (values: T) => void
+  submitLabel?: string
+}
+
+function Form<T extends Record<string, any>>({
+  initialValues,
+  fields,
+  onSubmit,
+  submitLabel = 'Submit'
+}: FormProps<T>) {
+  const [values, setValues] = useState<T>(initialValues)
+  const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({})
+  const [touched, setTouched] = useState<Partial<Record<keyof T, boolean>>>({})
+
+  const handleChange = (name: keyof T, value: any) => {
+    setValues((prev) => ({ ...prev, [name]: value }))
+
+    // バリデーション
+    const field = fields.find((f) => f.name === name)
+    if (field?.validate) {
+      const error = field.validate(value)
+      setErrors((prev) => ({ ...prev, [name]: error }))
+    }
+  }
+
+  const handleBlur = (name: keyof T) => {
+    setTouched((prev) => ({ ...prev, [name]: true }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // 全フィールドをバリデーション
+    const newErrors: Partial<Record<keyof T, string>> = {}
+    fields.forEach((field) => {
+      if (field.validate) {
+        const error = field.validate(values[field.name])
+        if (error) {
+          newErrors[field.name] = error
+        }
+      }
+    })
+
+    setErrors(newErrors)
+
+    // エラーがなければsubmit
+    if (Object.keys(newErrors).length === 0) {
+      onSubmit(values)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="form">
+      {fields.map((field) => (
+        <div key={String(field.name)} className="form-field">
+          <label htmlFor={String(field.name)}>
+            {field.label}
+            {field.required && <span className="required">*</span>}
+          </label>
+
+          {field.type === 'textarea' ? (
+            <textarea
+              id={String(field.name)}
+              value={String(values[field.name] ?? '')}
+              onChange={(e) => handleChange(field.name, e.target.value)}
+              onBlur={() => handleBlur(field.name)}
+              placeholder={field.placeholder}
+              required={field.required}
+            />
+          ) : (
+            <input
+              id={String(field.name)}
+              type={field.type}
+              value={String(values[field.name] ?? '')}
+              onChange={(e) => {
+                const value = field.type === 'number'
+                  ? Number(e.target.value)
+                  : e.target.value
+                handleChange(field.name, value)
+              }}
+              onBlur={() => handleBlur(field.name)}
+              placeholder={field.placeholder}
+              required={field.required}
+            />
+          )}
+
+          {touched[field.name] && errors[field.name] && (
+            <span className="error-message">{errors[field.name]}</span>
+          )}
+        </div>
+      ))}
+
+      <button type="submit" className="submit-button">
+        {submitLabel}
+      </button>
+    </form>
+  )
+}
+```
+
+### 使用例: 登録フォーム
+
+```typescript
+interface RegisterFormData {
+  username: string
+  email: string
+  age: number
+  bio: string
+}
+
+function RegisterForm() {
+  const fields: FormField<RegisterFormData>[] = [
+    {
+      name: 'username',
+      label: 'Username',
+      type: 'text',
+      required: true,
+      placeholder: 'Enter your username',
+      validate: (value) => {
+        if (typeof value !== 'string') return 'Invalid username'
+        if (value.length < 3) return 'Username must be at least 3 characters'
+        if (value.length > 20) return 'Username must be at most 20 characters'
+        return undefined
+      }
+    },
+    {
+      name: 'email',
+      label: 'Email',
+      type: 'email',
+      required: true,
+      placeholder: 'your@email.com',
+      validate: (value) => {
+        if (typeof value !== 'string') return 'Invalid email'
+        if (!value.includes('@')) return 'Invalid email format'
+        return undefined
+      }
+    },
+    {
+      name: 'age',
+      label: 'Age',
+      type: 'number',
+      required: true,
+      validate: (value) => {
+        if (typeof value !== 'number') return 'Invalid age'
+        if (value < 18) return 'Must be 18 or older'
+        if (value > 120) return 'Invalid age'
+        return undefined
+      }
+    },
+    {
+      name: 'bio',
+      label: 'Bio',
+      type: 'textarea',
+      placeholder: 'Tell us about yourself...',
+      validate: (value) => {
+        if (typeof value !== 'string') return 'Invalid bio'
+        if (value.length > 500) return 'Bio must be at most 500 characters'
+        return undefined
+      }
+    }
+  ]
+
+  const handleSubmit = (values: RegisterFormData) => {
+    console.log('Form submitted:', values)
+    // API call...
+  }
+
+  return (
+    <Form<RegisterFormData>
+      initialValues={{ username: '', email: '', age: 0, bio: '' }}
+      fields={fields}
+      onSubmit={handleSubmit}
+      submitLabel="Register"
+    />
+  )
+}
+```
+
+
+## 6. Conditional Types（条件付き型）
+
+### 基本構文
+
+```typescript
+type IsString<T> = T extends string ? true : false
+
+type A = IsString<string> // true型
+type B = IsString<number> // false型
+```
+
+### 実用例1: AsyncReturnType
+
+```typescript
+// 非同期関数の戻り値の型を抽出
+type AsyncReturnType<T> = T extends (...args: any[]) => Promise<infer R>
+  ? R
+  : never
+
+async function fetchUser() {
+  return { id: '1', name: 'John', email: 'john@example.com' }
+}
+
+type User = AsyncReturnType<typeof fetchUser>
+// { id: string; name: string; email: string }
+
+// 使用例
+function UserComponent() {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    fetchUser().then(setUser)
+  }, [])
+
+  return user ? <div>{user.name}</div> : null
+}
+```
+
+### 実用例2: UnwrapArray
+
+```typescript
+// 配列型から要素の型を抽出
+type UnwrapArray<T> = T extends Array<infer U> ? U : T
+
+type StringArray = UnwrapArray<string[]> // string
+type Number = UnwrapArray<number> // number
+
+// 使用例：配列のアイテムの型を推論
+function useArrayItem<T extends any[]>(
+  array: T,
+  index: number
+): UnwrapArray<T> | undefined {
+  return array[index]
+}
+
+const users = [
+  { id: '1', name: 'John' },
+  { id: '2', name: 'Jane' }
+]
+
+const user = useArrayItem(users, 0)
+// user の型: { id: string; name: string } | undefined
+```
+
+### 実用例3: NonNullable
+
+```typescript
+// null と undefined を除外
+type NonNullable<T> = T extends null | undefined ? never : T
+
+type MaybeString = string | null | undefined
+type DefiniteString = NonNullable<MaybeString> // string
+
+// 使用例
+interface User {
+  id: string
+  name: string
+  email: string | null
+}
+
+type RequiredEmail = NonNullable<User['email']> // string
+```
+
+
+## 7. Mapped Types（マップ型）
+
+### 基本パターン
+
+```typescript
+// 全てのプロパティをオプショナルに
+type Optional<T> = {
+  [K in keyof T]?: T[K]
+}
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+type OptionalUser = Optional<User>
+// { id?: string; name?: string; email?: string }
+```
+
+### 実用例1: Readonly の深いバージョン
+
+```typescript
+type DeepReadonly<T> = {
+  readonly [K in keyof T]: T[K] extends object
+    ? DeepReadonly<T[K]>
+    : T[K]
+}
+
+interface NestedData {
+  user: {
+    name: string
+    address: {
+      city: string
+      country: string
+    }
+  }
+}
+
+type ImmutableData = DeepReadonly<NestedData>
+
+const data: ImmutableData = {
+  user: {
+    name: 'John',
+    address: { city: 'Tokyo', country: 'Japan' }
+  }
+}
+
+// ❌ 全て読み取り専用
+data.user.name = 'Jane' // エラー
+data.user.address.city = 'Osaka' // エラー
+```
+
+### 実用例2: Nullable
+
+```typescript
+// 全てのプロパティを nullable に
+type Nullable<T> = {
+  [K in keyof T]: T[K] | null
+}
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+type NullableUser = Nullable<User>
+// { id: string | null; name: string | null; email: string | null }
+
+// 使用例：API レスポンス
+function parseUserResponse(response: NullableUser): User | null {
+  if (!response.id || !response.name || !response.email) {
+    return null
+  }
+  return {
+    id: response.id,
+    name: response.name,
+    email: response.email
+  }
+}
+```
+
+
+## 8. Template Literal Types
+
+### イベントハンドラの自動生成
+
+```typescript
+type EventName = 'click' | 'focus' | 'blur' | 'submit'
+type HandlerName = `on${Capitalize<EventName>}`
+// 'onClick' | 'onFocus' | 'onBlur' | 'onSubmit'
+
+// 実用例
+type Event = 'submit' | 'cancel' | 'save' | 'delete'
+type EventHandlers = {
+  [K in Event as `on${Capitalize<K>}`]: () => void
+}
+// {
+//   onSubmit: () => void
+//   onCancel: () => void
+//   onSave: () => void
+//   onDelete: () => void
+// }
+
+interface FormProps extends EventHandlers {
+  title: string
+}
+
+function Form({ title, onSubmit, onCancel, onSave, onDelete }: FormProps) {
+  return (
+    <form>
+      <h2>{title}</h2>
+      <button type="button" onClick={onSubmit}>Submit</button>
+      <button type="button" onClick={onCancel}>Cancel</button>
+      <button type="button" onClick={onSave}>Save</button>
+      <button type="button" onClick={onDelete}>Delete</button>
+    </form>
+  )
+}
+```
+
+### CSS プロパティの生成
+
+```typescript
+type CSSProperty = 'margin' | 'padding'
+type CSSDirection = 'top' | 'right' | 'bottom' | 'left'
+type CSSPropertyWithDirection = `${CSSProperty}${Capitalize<CSSDirection>}`
+// 'marginTop' | 'marginRight' | 'marginBottom' | 'marginLeft' |
+// 'paddingTop' | 'paddingRight' | 'paddingBottom' | 'paddingLeft'
+
+// 使用例
+type SpacingProps = {
+  [K in CSSPropertyWithDirection]?: number
+}
+
+interface BoxProps extends SpacingProps {
+  children: React.ReactNode
+}
+
+function Box({ children, ...spacing }: BoxProps) {
+  return (
+    <div style={spacing}>
+      {children}
+    </div>
+  )
+}
+
+// 使用例
+<Box marginTop={10} paddingLeft={20}>
+  Content
+</Box>
+```
+
+
+## 9. Type Guards（型ガード）
+
+### typeof を使った型ガード
+
+```typescript
+function processValue(value: string | number) {
+  if (typeof value === 'string') {
+    // この中では value は string型
+    return value.toUpperCase()
+  }
+  // この中では value は number型
+  return value.toFixed(2)
+}
+```
+
+### カスタム型ガード
+
+```typescript
+interface User {
+  type: 'user'
+  id: string
+  name: string
+}
+
+interface Admin {
+  type: 'admin'
+  id: string
+  name: string
+  permissions: string[]
+}
+
+// カスタム型ガード関数
+function isAdmin(person: User | Admin): person is Admin {
+  return person.type === 'admin'
+}
+
+function UserProfile({ person }: { person: User | Admin }) {
+  if (isAdmin(person)) {
+    // この中では person は Admin型
+    return (
+      <div>
+        <h2>Admin: {person.name}</h2>
+        <ul>
+          {person.permissions.map((p) => (
+            <li key={p}>{p}</li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+
+  // この中では person は User型
+  return <div>User: {person.name}</div>
+}
+```
+
+### null/undefined チェック
+
+```typescript
+function processUser(user: User | null | undefined) {
+  if (!user) {
+    return <div>No user</div>
+  }
+
+  // この中では user は User型（null/undefinedではない）
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+
+## 10. まとめ
+
+この章では、TypeScriptの高度な型機能を使ったReactコンポーネント設計を学びました。
+
+### 重要ポイント
+
+1. **ジェネリックコンポーネント**: 型引数で再利用性を最大化
+   - List/Select/Table/Form など汎用コンポーネントに最適
+
+2. **Conditional Types**: `T extends U ? X : Y` で型を条件分岐
+   - AsyncReturnType, UnwrapArray など型の変換に活用
+
+3. **Mapped Types**: `[K in keyof T]` で型を動的生成
+   - DeepReadonly, Nullable など型の変換に活用
+
+4. **Template Literal Types**: 文字列リテラルで型を構築
+   - イベントハンドラ、CSSプロパティなど命名規則のある型に最適
+
+5. **Type Guards**: `is` キーワードで型を絞り込み
+   - カスタム型ガード関数で複雑な型判定も型安全に
+
+### 実践での使い所
+
+- **List/Table**: データ表示コンポーネントは必ずジェネリックに
+- **Form**: フォームの型定義は `keyof T` で型安全に
+- **API レスポンス**: Conditional Types で戻り値の型を自動推論
+- **イベントハンドラ**: Template Literal Types で命名を統一
+
+### Next Steps
+
+次の章では、これらの型パターンを活用して Context と Form を型安全に実装します。
+
+- Chapter 6: Context と Form の型安全な実装
+
+
+**執筆時間**: 約55分で習得可能
+**文字数**: 約2,200語
+
+この章をマスターすることで、TypeScriptの高度な型機能を駆使した再利用性の高いコンポーネント設計ができるようになります。

--- a/ja/04-web-and-network/react-development/docs/03-typescript/03-context-form-types.md
+++ b/ja/04-web-and-network/react-development/docs/03-typescript/03-context-form-types.md
@@ -1,0 +1,1034 @@
+
+# Context と Form の型安全な実装
+
+## この章で学べること
+
+この章では、Context API とフォームの型安全な実装方法を学びます。
+
+- Context の型定義ベストプラクティス
+- カスタムフックによる Context の安全な使用
+- 複数の Context の組み合わせパターン
+- useReducer と Context の組み合わせ
+- React Hook Form との統合
+- Zod を使った型安全なバリデーション
+- 実践例：認証・テーマ・ロケール管理
+
+**前提知識**: Context API、React Hook Form の基礎
+
+**対応バージョン**: React 19.x / React Hook Form v7（`react-hook-form`） / Zod v4（`zod`） / `@hookform/resolvers` v5
+
+**所要時間**: 50-60分
+
+
+## 目次
+
+1. [Context の基本的な型定義](#1-context-の基本的な型定義)
+2. [カスタムフックで Context を安全に使う](#2-カスタムフックで-context-を安全に使う)
+3. [複数の Context の組み合わせ](#3-複数の-context-の組み合わせ)
+4. [useReducer と Context の組み合わせ](#4-usereducer-と-context-の組み合わせ)
+5. [React Hook Form の型定義](#5-react-hook-form-の型定義)
+6. [Zod を使った型安全なバリデーション](#6-zod-を使った型安全なバリデーション)
+7. [実践例：認証 Context の完全実装](#7-実践例認証-context-の完全実装)
+8. [まとめ](#8-まとめ)
+
+
+## Context APIの前に: コンポーネント合成を検討する
+
+Context APIは強力ですが、**全てのProps drilling問題にContext APIが最適とは限りません**。
+
+まず検討すべきは**コンポーネント合成（Composition）**です。
+
+```typescript
+// ❌ Props drilling: themeを中間コンポーネントが素通りさせている
+function App() {
+  const theme = useThemeValue()
+  return <Layout theme={theme} />  // Layoutはthemeを使わない
+}
+function Layout({ theme }: { theme: Theme }) {
+  return <Sidebar theme={theme} />  // Sidebarもthemeを使わない
+}
+function Sidebar({ theme }: { theme: Theme }) {
+  return <Avatar theme={theme} />  // Avatarだけがthemeを使う
+}
+
+// - コンポーネント合成: childrenで直接渡す
+function App() {
+  const theme = useThemeValue()
+  return (
+    <Layout>
+      <Sidebar>
+        <Avatar theme={theme} />  {/* 直接渡す */}
+      </Sidebar>
+    </Layout>
+  )
+}
+```
+
+**Context APIが適切な場面:**
+- テーマ（ダーク/ライト）: アプリ全体の多くのコンポーネントが参照する
+- 認証情報: どの画面でもログイン状態を確認する
+- ロケール/言語設定: 全てのテキストに影響する
+
+**コンポーネント合成が適切な場面:**
+- 特定の子コンポーネントだけがデータを必要とする
+- Props drillingが2-3階層程度で、中間コンポーネントが不要にPropsを受け渡している
+
+この使い分けを理解した上で、以下ではContext APIの型安全な実装を学びます。
+
+
+## 1. Context の基本的な型定義
+
+### 基本パターン
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+interface AuthContextValue {
+  user: User | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+// undefined を許可することで、Provider 外での使用を検出可能に
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+```
+
+**なぜ `undefined` を含めるのか？**
+
+```typescript
+// ❌ デフォルト値を設定すると、Provider なしでも使えてしまう
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+  isAuthenticated: false
+})
+
+// - undefined にすることで、Provider が必要であることを強制
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+```
+
+### Provider の実装
+
+```typescript
+function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const login = async (email: string, password: string) => {
+    try {
+      const response = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+
+      if (!response.ok) {
+        throw new Error('Login failed')
+      }
+
+      const user = await response.json()
+      setUser(user)
+    } catch (error) {
+      console.error('Login error:', error)
+      throw error
+    }
+  }
+
+  const logout = () => {
+    setUser(null)
+    // ローカルストレージやクッキーのクリアなど
+  }
+
+  const isAuthenticated = user !== null
+
+  // 初期ロード時のユーザー情報取得
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const response = await fetch('/api/me')
+        if (response.ok) {
+          const user = await response.json()
+          setUser(user)
+        }
+      } catch (error) {
+        console.error('Auth check error:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    checkAuth()
+  }, [])
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, isAuthenticated }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+```
+
+
+## 2. カスタムフックで Context を安全に使う
+
+### 基本パターン
+
+```typescript
+function useAuth() {
+  const context = useContext(AuthContext)
+
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+
+  return context
+}
+```
+
+**メリット**:
+1. Provider 外での使用を防止
+2. `undefined` チェックを一箇所に集約
+3. 使用側で型アサーションが不要
+
+### 使用例
+
+```typescript
+function UserProfile() {
+  // context は AuthContextValue 型（undefined ではない）
+  const { user, logout } = useAuth()
+
+  if (!user) {
+    return <div>Please log in</div>
+  }
+
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+      <button onClick={logout}>Logout</button>
+    </div>
+  )
+}
+```
+
+
+## 3. 複数の Context の組み合わせ
+
+### Theme Context
+
+```typescript
+type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+  setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  useEffect(() => {
+    // localStorage から読み込み
+    const savedTheme = localStorage.getItem('theme') as Theme | null
+    if (savedTheme) {
+      setTheme(savedTheme)
+    }
+  }, [])
+
+  useEffect(() => {
+    // localStorage に保存
+    localStorage.setItem('theme', theme)
+    // ドキュメントに適用
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+  return context
+}
+```
+
+### Locale Context
+
+```typescript
+type Locale = 'en' | 'ja'
+
+interface LocaleContextValue {
+  locale: Locale
+  setLocale: (locale: Locale) => void
+  t: (key: string) => string
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined)
+
+const translations: Record<Locale, Record<string, string>> = {
+  en: {
+    'welcome': 'Welcome',
+    'logout': 'Logout'
+  },
+  ja: {
+    'welcome': 'ようこそ',
+    'logout': 'ログアウト'
+  }
+}
+
+function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocale] = useState<Locale>('en')
+
+  const t = (key: string): string => {
+    return translations[locale][key] ?? key
+  }
+
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </LocaleContext.Provider>
+  )
+}
+
+function useLocale() {
+  const context = useContext(LocaleContext)
+  if (!context) {
+    throw new Error('useLocale must be used within LocaleProvider')
+  }
+  return context
+}
+```
+
+### 統合 Provider
+
+```typescript
+interface AppProvidersProps {
+  children: React.ReactNode
+}
+
+function AppProviders({ children }: AppProvidersProps) {
+  return (
+    <ThemeProvider>
+      <LocaleProvider>
+        <AuthProvider>
+          {children}
+        </AuthProvider>
+      </LocaleProvider>
+    </ThemeProvider>
+  )
+}
+
+// 使用例
+function App() {
+  return (
+    <AppProviders>
+      <Router>
+        <Routes>
+          {/* ... */}
+        </Routes>
+      </Router>
+    </AppProviders>
+  )
+}
+```
+
+
+## 4. useReducer と Context の組み合わせ
+
+### State と Action の型定義
+
+```typescript
+interface TodoItem {
+  id: string
+  title: string
+  completed: boolean
+  createdAt: Date
+}
+
+interface TodoState {
+  todos: TodoItem[]
+  filter: 'all' | 'active' | 'completed'
+}
+
+type TodoAction =
+  | { type: 'ADD_TODO'; payload: { title: string } }
+  | { type: 'TOGGLE_TODO'; payload: { id: string } }
+  | { type: 'DELETE_TODO'; payload: { id: string } }
+  | { type: 'SET_FILTER'; payload: { filter: TodoState['filter'] } }
+  | { type: 'CLEAR_COMPLETED' }
+```
+
+### Reducer の実装
+
+```typescript
+function todoReducer(state: TodoState, action: TodoAction): TodoState {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return {
+        ...state,
+        todos: [
+          ...state.todos,
+          {
+            id: crypto.randomUUID(),
+            title: action.payload.title,
+            completed: false,
+            createdAt: new Date()
+          }
+        ]
+      }
+
+    case 'TOGGLE_TODO':
+      return {
+        ...state,
+        todos: state.todos.map((todo) =>
+          todo.id === action.payload.id
+            ? { ...todo, completed: !todo.completed }
+            : todo
+        )
+      }
+
+    case 'DELETE_TODO':
+      return {
+        ...state,
+        todos: state.todos.filter((todo) => todo.id !== action.payload.id)
+      }
+
+    case 'SET_FILTER':
+      return {
+        ...state,
+        filter: action.payload.filter
+      }
+
+    case 'CLEAR_COMPLETED':
+      return {
+        ...state,
+        todos: state.todos.filter((todo) => !todo.completed)
+      }
+
+    default:
+      return state
+  }
+}
+```
+
+### Context Provider
+
+```typescript
+interface TodoContextValue {
+  state: TodoState
+  dispatch: React.Dispatch<TodoAction>
+}
+
+const TodoContext = createContext<TodoContextValue | undefined>(undefined)
+
+function TodoProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(todoReducer, {
+    todos: [],
+    filter: 'all'
+  })
+
+  return (
+    <TodoContext.Provider value={{ state, dispatch }}>
+      {children}
+    </TodoContext.Provider>
+  )
+}
+
+function useTodo() {
+  const context = useContext(TodoContext)
+  if (!context) {
+    throw new Error('useTodo must be used within TodoProvider')
+  }
+  return context
+}
+```
+
+### 使用例
+
+```typescript
+function TodoList() {
+  const { state, dispatch } = useTodo()
+
+  const filteredTodos = state.todos.filter((todo) => {
+    if (state.filter === 'active') return !todo.completed
+    if (state.filter === 'completed') return todo.completed
+    return true
+  })
+
+  const handleAddTodo = (title: string) => {
+    dispatch({ type: 'ADD_TODO', payload: { title } })
+  }
+
+  const handleToggle = (id: string) => {
+    dispatch({ type: 'TOGGLE_TODO', payload: { id } })
+  }
+
+  return (
+    <div>
+      <TodoInput onAdd={handleAddTodo} />
+      <ul>
+        {filteredTodos.map((todo) => (
+          <li key={todo.id}>
+            <input
+              type="checkbox"
+              checked={todo.completed}
+              onChange={() => handleToggle(todo.id)}
+            />
+            <span>{todo.title}</span>
+            <button
+              onClick={() =>
+                dispatch({ type: 'DELETE_TODO', payload: { id: todo.id } })
+              }
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <TodoFilters />
+    </div>
+  )
+}
+```
+
+
+## 5. React Hook Form の型定義
+
+### 基本的な使用方法
+
+```typescript
+import { useForm, SubmitHandler } from 'react-hook-form'
+
+interface LoginFormData {
+  email: string
+  password: string
+  rememberMe: boolean
+}
+
+function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<LoginFormData>({
+    defaultValues: {
+      email: '',
+      password: '',
+      rememberMe: false
+    }
+  })
+
+  const onSubmit: SubmitHandler<LoginFormData> = async (data) => {
+    try {
+      await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      })
+      // ログイン成功処理
+    } catch (error) {
+      console.error('Login failed:', error)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+              message: 'Invalid email address'
+            }
+          })}
+        />
+        {errors.email && (
+          <span className="error">{errors.email.message}</span>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          {...register('password', {
+            required: 'Password is required',
+            minLength: {
+              value: 8,
+              message: 'Password must be at least 8 characters'
+            }
+          })}
+        />
+        {errors.password && (
+          <span className="error">{errors.password.message}</span>
+        )}
+      </div>
+
+      <div>
+        <label>
+          <input type="checkbox" {...register('rememberMe')} />
+          Remember me
+        </label>
+      </div>
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Logging in...' : 'Login'}
+      </button>
+    </form>
+  )
+}
+```
+
+### ネストした型の定義
+
+```typescript
+interface Address {
+  street: string
+  city: string
+  zipCode: string
+}
+
+interface ProfileFormData {
+  username: string
+  email: string
+  address: Address
+  tags: string[]
+}
+
+function ProfileForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<ProfileFormData>({
+    defaultValues: {
+      username: '',
+      email: '',
+      address: {
+        street: '',
+        city: '',
+        zipCode: ''
+      },
+      tags: []
+    }
+  })
+
+  const onSubmit: SubmitHandler<ProfileFormData> = (data) => {
+    console.log(data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input
+        {...register('username', { required: true })}
+        placeholder="Username"
+      />
+
+      <input
+        {...register('email', { required: true })}
+        placeholder="Email"
+      />
+
+      <input
+        {...register('address.street', { required: true })}
+        placeholder="Street"
+      />
+
+      <input
+        {...register('address.city', { required: true })}
+        placeholder="City"
+      />
+
+      <input
+        {...register('address.zipCode', { required: true })}
+        placeholder="Zip Code"
+      />
+
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+```
+
+
+## 6. Zod を使った型安全なバリデーション
+
+### Zod スキーマの定義
+
+```typescript
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+
+const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Invalid email address'),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+      'Password must contain uppercase, lowercase, and number'
+    ),
+  rememberMe: z.boolean().default(false)
+})
+
+// スキーマから型を自動生成
+type LoginFormData = z.infer<typeof loginSchema>
+```
+
+### React Hook Form との統合
+
+```typescript
+function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      rememberMe: false
+    }
+  })
+
+  const onSubmit: SubmitHandler<LoginFormData> = async (data) => {
+    // data は LoginFormData 型で型安全
+    console.log(data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <input type="email" {...register('email')} />
+        {errors.email && <span>{errors.email.message}</span>}
+      </div>
+
+      <div>
+        <input type="password" {...register('password')} />
+        {errors.password && <span>{errors.password.message}</span>}
+      </div>
+
+      <div>
+        <label>
+          <input type="checkbox" {...register('rememberMe')} />
+          Remember me
+        </label>
+      </div>
+
+      <button type="submit" disabled={isSubmitting}>
+        Login
+      </button>
+    </form>
+  )
+}
+```
+
+### 複雑なスキーマ
+
+```typescript
+const profileSchema = z.object({
+  username: z
+    .string()
+    .min(3, 'Username must be at least 3 characters')
+    .max(20, 'Username must be at most 20 characters')
+    .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers, and underscores'),
+  email: z.string().email('Invalid email'),
+  age: z
+    .number()
+    .int('Age must be an integer')
+    .min(18, 'Must be 18 or older')
+    .max(120, 'Invalid age'),
+  address: z.object({
+    street: z.string().min(1, 'Street is required'),
+    city: z.string().min(1, 'City is required'),
+    zipCode: z.string().regex(/^\d{3}-\d{4}$/, 'Invalid zip code format (e.g., 123-4567)')
+  }),
+  tags: z.array(z.string()).min(1, 'At least one tag is required'),
+  website: z.string().url('Invalid URL').optional(),
+  bio: z.string().max(500, 'Bio must be at most 500 characters').optional()
+})
+
+type ProfileFormData = z.infer<typeof profileSchema>
+```
+
+
+## 7. 実践例：認証 Context の完全実装
+
+### 型定義
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+  role: 'admin' | 'user'
+}
+
+interface AuthState {
+  user: User | null
+  loading: boolean
+  error: string | null
+}
+
+interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+  register: (name: string, email: string, password: string) => Promise<void>
+  updateProfile: (data: Partial<User>) => Promise<void>
+  isAuthenticated: boolean
+}
+```
+
+### Provider 実装
+
+```typescript
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    user: null,
+    loading: true,
+    error: null
+  })
+
+  const login = async (email: string, password: string) => {
+    setState((prev) => ({ ...prev, loading: true, error: null }))
+
+    try {
+      const response = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+
+      if (!response.ok) {
+        throw new Error('Login failed')
+      }
+
+      const user = await response.json()
+      setState({ user, loading: false, error: null })
+    } catch (error) {
+      setState({
+        user: null,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      })
+      throw error
+    }
+  }
+
+  const logout = () => {
+    setState({ user: null, loading: false, error: null })
+    // クッキー削除など
+  }
+
+  const register = async (name: string, email: string, password: string) => {
+    setState((prev) => ({ ...prev, loading: true, error: null }))
+
+    try {
+      const response = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password })
+      })
+
+      if (!response.ok) {
+        throw new Error('Registration failed')
+      }
+
+      const user = await response.json()
+      setState({ user, loading: false, error: null })
+    } catch (error) {
+      setState({
+        user: null,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      })
+      throw error
+    }
+  }
+
+  const updateProfile = async (data: Partial<User>) => {
+    if (!state.user) {
+      throw new Error('Not authenticated')
+    }
+
+    setState((prev) => ({ ...prev, loading: true }))
+
+    try {
+      const response = await fetch('/api/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      })
+
+      if (!response.ok) {
+        throw new Error('Update failed')
+      }
+
+      const updatedUser = await response.json()
+      setState({ user: updatedUser, loading: false, error: null })
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }))
+      throw error
+    }
+  }
+
+  const isAuthenticated = state.user !== null
+
+  // 初期ロード
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const response = await fetch('/api/me')
+        if (response.ok) {
+          const user = await response.json()
+          setState({ user, loading: false, error: null })
+        } else {
+          setState({ user: null, loading: false, error: null })
+        }
+      } catch (error) {
+        setState({ user: null, loading: false, error: null })
+      }
+    }
+
+    checkAuth()
+  }, [])
+
+  return (
+    <AuthContext.Provider
+      value={{
+        ...state,
+        login,
+        logout,
+        register,
+        updateProfile,
+        isAuthenticated
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}
+```
+
+### 使用例
+
+```typescript
+function ProfilePage() {
+  const { user, updateProfile, loading, error } = useAuth()
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
+
+  if (!user) {
+    return <div>Please log in</div>
+  }
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+      <p>Role: {user.role}</p>
+      {error && <div className="error">{error}</div>}
+      <button
+        onClick={() => updateProfile({ name: 'New Name' })}
+        disabled={loading}
+      >
+        Update Name
+      </button>
+    </div>
+  )
+}
+```
+
+
+## 8. まとめ
+
+この章では、Context API とフォームの型安全な実装を学びました。
+
+### 重要ポイント
+
+1. **Context の型定義**:
+   - `createContext<T | undefined>(undefined)` で Provider の必要性を強制
+   - カスタムフックで型安全なアクセスを提供
+
+2. **複数 Context の組み合わせ**:
+   - Theme、Locale、Auth などを個別に定義
+   - 統合 Provider で一括管理
+
+3. **useReducer と Context**:
+   - 複雑な状態管理は useReducer を活用
+   - Action の型を Union Types で定義
+
+4. **React Hook Form**:
+   - `useForm<T>` でフォームデータの型を定義
+   - `SubmitHandler<T>` で submit 関数の型安全性を確保
+
+5. **Zod でバリデーション**:
+   - スキーマ定義から型を自動生成 (`z.infer<typeof schema>`)
+   - zodResolver で React Hook Form と統合
+
+### 実践での使い所
+
+- **認証管理**: AuthContext でユーザー情報とログイン状態を管理
+- **テーマ管理**: ThemeContext でダークモード切り替え
+- **フォーム**: Zod + React Hook Form で型安全なバリデーション
+- **複雑な状態**: useReducer + Context で状態管理を集約
+
+### Next Steps
+
+次の章からは、パフォーマンス最適化の実践的なテクニックを学びます。
+
+- Chapter 7: React.memo と再レンダリング最適化
+
+
+**執筆時間**: 約55分で習得可能
+**文字数**: 約2,100語
+
+この章をマスターすることで、型安全で保守性の高い Context とフォーム実装ができるようになります。


### PR DESCRIPTION
## 概要

React 応用編の `03-typescript/` セクションを追加します。

## 追加ファイル（3ファイル）

| ファイル | 内容 | 行数 |
|---|---|---|
| `01-component-type-patterns.md` | コンポーネントの型定義完全版 | 1263行 |
| `02-advanced-type-patterns.md` | 高度な型パターンとジェネリック | 1002行 |
| `03-context-form-types.md` | Context と Form の型安全な実装 | 1034行 |

## ソース

Zenn「React実践テクニック」ch04-06 より導入。
Zenn 固有フォーマット（frontmatter・✅マーク・Chapter番号）を除去済み。