### PR TITLE
translate(nodejs): 02-async-patterns セクション 日本語版追加（4本）

### DIFF
--- a/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/01-callbacks.md
+++ b/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/01-callbacks.md
@@ -1,0 +1,447 @@
+# Node.js における Callbacks
+
+callback は Node.js における非同期プログラミングの基盤です。Promise や async/await に進む前に、まずこれを理解することが重要です。
+
+---
+
+## 目次
+
+1. [callback とは](#1-callback-とは)
+2. [基本的な callback パターン](#2-基本的な-callback-パターン)
+3. [Callback Hell](#3-callback-hell)
+4. [Callback Hell の問題点](#4-callback-hell-の問題点)
+5. [アンチパターン](#5-アンチパターン)
+6. [FAQ](#6-faq)
+
+---
+
+## 1. callback とは
+
+**callback** とは、別の関数に引数として渡される関数のことで、処理が完了したタイミングで呼び出されます。Node.js では、callback が非同期 I/O 処理を扱う主要な仕組みです。
+
+```js
+// callback の基本的な概念
+function greet(name, callback) {
+  const message = `Hello, ${name}!`;
+  callback(message);
+}
+
+greet("Alice", (msg) => {
+  console.log(msg); // Hello, Alice!
+});
+```
+
+Node.js は **error-first callback 規約**（「Node スタイルの callback」または「errback」とも呼ばれる）を採用しています。第1引数は常にエラーオブジェクト（エラーがなければ `null`）、第2引数が結果値です。
+
+```js
+// error-first callback 規約
+function readData(id, callback) {
+  if (id <= 0) {
+    return callback(new Error("ID must be positive"));
+  }
+  // 非同期処理のシミュレーション
+  setTimeout(() => {
+    callback(null, { id, value: "data" });
+  }, 100);
+}
+
+readData(1, (err, data) => {
+  if (err) {
+    console.error("Error:", err.message);
+    return;
+  }
+  console.log("Data:", data);
+});
+```
+
+**なぜ error-first なのか？**
+- すべての非同期 API でエラーハンドリングを一貫させるため
+- Node.js のコアモジュール（`fs`、`net`、`http`）がすべてこの規約に従っている
+- 呼び出し側がエラーを必ず処理しなければならないことを明示するため
+
+---
+
+## 2. 基本的な callback パターン
+
+### 2.1 ファイルシステム操作
+
+Node.js における最もよくある callback の実用例は `fs` モジュールの操作です。
+
+```js
+const fs = require("fs");
+
+// ファイルを非同期で読み込む
+fs.readFile("./data.txt", "utf8", (err, content) => {
+  if (err) {
+    console.error("Failed to read file:", err.message);
+    return;
+  }
+  console.log("File content:", content);
+});
+
+console.log("This runs before file content is logged");
+```
+
+```
+出力:
+  This runs before file content is logged
+  File content: (ファイルの内容)
+```
+
+### 2.2 ファイルへの書き込み
+
+```js
+const fs = require("fs");
+
+const data = JSON.stringify({ name: "Alice", age: 30 }, null, 2);
+
+fs.writeFile("./output.json", data, "utf8", (err) => {
+  if (err) {
+    console.error("Write failed:", err.message);
+    return;
+  }
+  console.log("File written successfully");
+});
+```
+
+### 2.3 callback を使った HTTP リクエスト
+
+```js
+const https = require("https");
+
+function fetchData(url, callback) {
+  https
+    .get(url, (res) => {
+      let body = "";
+
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+
+      res.on("end", () => {
+        try {
+          const parsed = JSON.parse(body);
+          callback(null, parsed);
+        } catch (parseErr) {
+          callback(parseErr);
+        }
+      });
+    })
+    .on("error", (err) => {
+      callback(err);
+    });
+}
+
+fetchData("https://jsonplaceholder.typicode.com/todos/1", (err, data) => {
+  if (err) {
+    console.error("Fetch error:", err.message);
+    return;
+  }
+  console.log("Fetched:", data);
+});
+```
+
+### 2.4 データベースクエリのシミュレーション
+
+```js
+// 非同期データベースクエリのシミュレーション
+function queryUser(userId, callback) {
+  // ネットワーク遅延をシミュレーション
+  setTimeout(() => {
+    const users = {
+      1: { id: 1, name: "Alice", role: "admin" },
+      2: { id: 2, name: "Bob", role: "user" },
+    };
+
+    const user = users[userId];
+    if (!user) {
+      return callback(new Error(`User ${userId} not found`));
+    }
+    callback(null, user);
+  }, 50);
+}
+
+queryUser(1, (err, user) => {
+  if (err) {
+    console.error(err.message);
+    return;
+  }
+  console.log("Found user:", user.name); // Found user: Alice
+});
+```
+
+---
+
+## 3. Callback Hell
+
+**Callback hell**（「ピラミッド・オブ・ドゥーム」とも呼ばれる）は、複数の非同期処理が互いに依存しており、それぞれ前の callback の中にネストしなければならない状況で発生します。
+
+### 3.1 実際のシナリオ
+
+設定ファイルの読み込み → データベースへのクエリ → API からの追加データ取得 → 統合結果のファイル書き込み、というワークフローを想像してみてください。
+
+```js
+const fs = require("fs");
+
+fs.readFile("./config.json", "utf8", (err, configData) => {
+  if (err) {
+    console.error("Config read error:", err.message);
+    return;
+  }
+
+  const config = JSON.parse(configData);
+
+  queryUser(config.userId, (err, user) => {
+    if (err) {
+      console.error("User query error:", err.message);
+      return;
+    }
+
+    fetchUserPosts(user.id, (err, posts) => {
+      if (err) {
+        console.error("Posts fetch error:", err.message);
+        return;
+      }
+
+      const report = JSON.stringify({ user, posts }, null, 2);
+
+      fs.writeFile("./report.json", report, "utf8", (err) => {
+        if (err) {
+          console.error("Write error:", err.message);
+          return;
+        }
+
+        console.log("Report written successfully");
+
+        notifyAdmin(user.name, (err) => {
+          if (err) {
+            console.error("Notification error:", err.message);
+            return;
+          }
+          console.log("Admin notified");
+        });
+      });
+    });
+  });
+});
+```
+
+インデントが問題を視覚的に示しています：
+
+```
+readFile(
+  queryUser(
+    fetchUserPosts(
+      writeFile(
+        notifyAdmin(
+          // callback hell
+        )
+      )
+    )
+  )
+)
+```
+
+---
+
+## 4. Callback Hell の問題点
+
+### 4.1 可読性
+
+コードが縦ではなく横に伸びていきます。深いネストのせいで、処理の流れをひと目で追うことが難しくなります。
+
+### 4.2 エラーハンドリングの重複
+
+ネストされた callback はそれぞれ自分のエラーを処理しなければならず、`if (err) { return; }` のブロックがコード全体に散らばります。
+
+```js
+// エラー処理がすべてのレベルで繰り返される
+step1((err, result1) => {
+  if (err) return handleError(err); // 繰り返し
+  step2(result1, (err, result2) => {
+    if (err) return handleError(err); // 繰り返し
+    step3(result2, (err, result3) => {
+      if (err) return handleError(err); // 繰り返し
+      // ...
+    });
+  });
+});
+```
+
+### 4.3 リファクタリングの困難さ
+
+途中に新しいステップを追加するには、ネスト構造全体を作り直す必要があります。
+
+### 4.4 戻り値が使えない
+
+callback では `return` を使ってコールスタックの上位に値を返すことができません。すべてのデータは callback の引数を通じて受け渡さなければなりません。
+
+### 4.5 緩和策：名前付き関数
+
+視覚的なネストを減らす方法の1つは、callback を名前付き関数として切り出すことです：
+
+```js
+const fs = require("fs");
+
+function onAdminNotified(err) {
+  if (err) {
+    console.error("Notification error:", err.message);
+    return;
+  }
+  console.log("Admin notified");
+}
+
+function onReportWritten(err, user) {
+  // 注意: user はクロージャで参照するか、別の方法で渡す必要がある
+  if (err) {
+    console.error("Write error:", err.message);
+    return;
+  }
+  notifyAdmin(user.name, onAdminNotified);
+}
+
+// このアプローチはインデントを改善するが、逐次依存の問題は残る
+```
+
+名前付き関数はネストを視覚的に減らしますが、エラー伝播やコンポーザビリティの本質的な問題は解決しません。
+
+---
+
+## 5. アンチパターン
+
+### 5.1 callback の後に return を忘れる
+
+```js
+// 悪い例: return がないと callback が2回呼ばれる
+function badFunction(input, callback) {
+  if (!input) {
+    callback(new Error("No input")); // 実行が続いてしまう！
+  }
+  callback(null, processInput(input)); // 再度呼び出される → バグ
+}
+
+// 良い例: エラー時は必ず return してから callback を呼ぶ
+function goodFunction(input, callback) {
+  if (!input) {
+    return callback(new Error("No input")); // ここで止まる
+  }
+  callback(null, processInput(input));
+}
+```
+
+### 5.2 エラーを callback で渡さずに throw する
+
+```js
+// 悪い例: 非同期の callback 内で throw するとプロセスがクラッシュする
+fs.readFile("file.txt", "utf8", (err, data) => {
+  if (err) throw err; // 非同期コンテキストでの未処理例外
+});
+
+// 良い例: callback を通じてエラーを渡す
+function readAndProcess(path, callback) {
+  fs.readFile(path, "utf8", (err, data) => {
+    if (err) return callback(err);
+    callback(null, data.toUpperCase());
+  });
+}
+```
+
+### 5.3 非同期ラッパー内での同期処理
+
+```js
+// 悪い例: 非同期であるべき関数内で同期の fs を使う
+function getConfig(callback) {
+  try {
+    const data = fs.readFileSync("config.json"); // Event Loop をブロックする
+    callback(null, JSON.parse(data));
+  } catch (err) {
+    callback(err);
+  }
+}
+
+// 良い例: 非同期バージョンを使う
+function getConfig(callback) {
+  fs.readFile("config.json", "utf8", (err, data) => {
+    if (err) return callback(err);
+    try {
+      callback(null, JSON.parse(data));
+    } catch (parseErr) {
+      callback(parseErr);
+    }
+  });
+}
+```
+
+### 5.4 同期と非同期の戻り値が混在する
+
+```js
+// 悪い例: 同期になったり非同期になったりする — 予測不能な動作
+function getData(useCache, callback) {
+  if (useCache) {
+    callback(null, cachedData); // 同期呼び出し — 現在のティックが終わる前に実行される
+  } else {
+    fetchFromDB(callback); // 非同期呼び出し
+  }
+}
+
+// 良い例: process.nextTick を使って常に非同期にする
+function getData(useCache, callback) {
+  if (useCache) {
+    return process.nextTick(() => callback(null, cachedData));
+  }
+  fetchFromDB(callback);
+}
+```
+
+---
+
+## 6. FAQ
+
+**Q: error-first callback 規約は必須ですか？**
+
+A: 言語仕様として強制されているわけではありませんが、Node.js エコシステムにおけるデファクトスタンダードです。この規約を破ると、`util.promisify` などのユーティリティとの連携が難しくなります。
+
+---
+
+**Q: `util.promisify` を使って callback ベースの関数を Promise に変換できますか？**
+
+A: できます。ただし、その関数が error-first callback 規約に従っている必要があります。
+
+```js
+const fs = require("fs");
+const { promisify } = require("util");
+
+const readFile = promisify(fs.readFile);
+
+readFile("./data.txt", "utf8")
+  .then((content) => console.log(content))
+  .catch((err) => console.error(err));
+```
+
+---
+
+**Q: async/await を常に使うなら、callback を学ぶ必要はありますか？**
+
+A: あります。Node.js のコアモジュールや多くのサードパーティライブラリは依然として callback ベースの API を提供しています。callback を理解することで、async/await がどのようにコンパイルされるかを把握でき、Event Loop に関する問題のデバッグにも役立ちます。
+
+---
+
+**Q: `process.nextTick` とは何ですか？いつ使うべきですか？**
+
+A: `process.nextTick` は、現在の処理の終わりに、Event Loop が次のフェーズに進む前に callback をスケジュールします。結果が同期的に得られる場合でも callback を常に非同期で実行したいときに使います。
+
+```js
+function alwaysAsync(value, callback) {
+  process.nextTick(() => callback(null, value));
+}
+```
+
+---
+
+**Q: リファクタリングの目安として、何段階のネストまでが許容範囲ですか？**
+
+A: 一般的なガイドラインとして、callback のネストが2〜3段階を超えたらリファクタリングのサインです。非同期ステップが2つ以上続くワークフローには Promise または async/await を使いましょう。
+
+---
+
+**親ガイド**: [Node.js Development - SKILL.md](../../SKILL.md)

--- a/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/02-promises.md
+++ b/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/02-promises.md
@@ -1,0 +1,492 @@
+# Node.js における Promises
+
+Promise は、callback に比べてより簡潔で組み合わせやすい非同期処理の手段です。ES2015 で標準化され、現在のすべての Node.js バージョンでネイティブにサポートされています。
+
+---
+
+## 目次
+
+1. [Promise とは](#1-promise-とは)
+2. [Promise の3つの状態](#2-promise-の3つの状態)
+3. [`.then()` と `.catch()` のチェーン](#3-then-と-catch-のチェーン)
+4. [`Promise.all()` / `Promise.race()` / `Promise.allSettled()`](#4-promiseall--promiserace--promiseallsettled)
+5. [エラーハンドリング](#5-エラーハンドリング)
+6. [アンチパターン](#6-アンチパターン)
+7. [FAQ](#7-faq)
+
+---
+
+## 1. Promise とは
+
+**Promise** は、非同期処理の最終的な完了または失敗を表すオブジェクトです。callback ベースのコードが抱える2つの核心的な問題を解決します：
+
+- **Callback hell** — 連続する非同期ステップをネストではなく `.then()` でチェーンできる
+- **一貫性のないエラーハンドリング** — チェーンの末尾に `.catch()` を1つ置くだけですべてのエラーを処理できる
+
+```js
+// callback スタイル
+readFile("config.json", (err, data) => {
+  if (err) return handleError(err);
+  processData(data, (err, result) => {
+    if (err) return handleError(err);
+    saveResult(result, (err) => {
+      if (err) return handleError(err);
+      console.log("Done");
+    });
+  });
+});
+
+// Promise スタイル — 同じロジックを線形に記述
+readFile("config.json")
+  .then((data) => processData(data))
+  .then((result) => saveResult(result))
+  .then(() => console.log("Done"))
+  .catch((err) => handleError(err));
+```
+
+### Promise の生成
+
+`new Promise(executor)` を使います。executor は `resolve` と `reject` の2つの関数を受け取ります。
+
+```js
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function fetchUser(id) {
+  return new Promise((resolve, reject) => {
+    if (id <= 0) {
+      return reject(new Error("Invalid ID"));
+    }
+    setTimeout(() => {
+      resolve({ id, name: "Alice" });
+    }, 100);
+  });
+}
+
+fetchUser(1).then((user) => console.log(user.name)); // Alice
+```
+
+### `util.promisify` による callback の Promise 化
+
+Node.js には、error-first callback 関数を Promise を返す関数に変換するビルトインユーティリティが用意されています。
+
+```js
+const fs = require("fs");
+const { promisify } = require("util");
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+readFile("./data.txt", "utf8")
+  .then((content) => {
+    console.log(content);
+    return writeFile("./copy.txt", content, "utf8");
+  })
+  .then(() => console.log("Copy written"))
+  .catch((err) => console.error(err));
+```
+
+---
+
+## 2. Promise の3つの状態
+
+Promise は常に、互いに排他的な3つの状態のいずれかにあります：
+
+```
+            ┌─────────────────────────────┐
+            │         PENDING             │
+            │  (初期状態 — 待機中)         │
+            └──────────┬──────────────────┘
+                       │
+          ┌────────────┴────────────┐
+          │ resolve(value)          │ reject(reason)
+          ▼                         ▼
+  ┌──────────────┐         ┌──────────────────┐
+  │  FULFILLED   │         │    REJECTED       │
+  │ (成功)       │         │ (失敗)            │
+  └──────────────┘         └──────────────────┘
+```
+
+- **Pending（保留中）**: 非同期処理がまだ完了していない
+- **Fulfilled（成功）**: 処理が正常に完了し、`resolve(value)` が呼ばれた
+- **Rejected（失敗）**: 処理が失敗し、`reject(reason)` が呼ばれた
+
+Promise が一度 settled（pending から fulfilled または rejected に遷移）すると、その状態は**変更不可**になります。`resolve` や `reject` を2回目に呼び出しても無効です。
+
+```js
+const p = new Promise((resolve, reject) => {
+  resolve("first");
+  resolve("second"); // 無視される — すでに settled 状態
+  reject(new Error("too late")); // これも無視される
+});
+
+p.then((val) => console.log(val)); // "first"
+```
+
+---
+
+## 3. `.then()` と `.catch()` のチェーン
+
+### `.then(onFulfilled, onRejected)`
+
+`.then()` は成功時と失敗時の2つの callback を受け取ります。
+
+```js
+fetchUser(1)
+  .then(
+    (user) => console.log("Success:", user.name),
+    (err) => console.error("Error:", err.message)
+  );
+```
+
+実際には、成功とエラーのハンドラを `.then()` と `.catch()` に分けて書く方がわかりやすいです：
+
+```js
+fetchUser(1)
+  .then((user) => console.log("Success:", user.name))
+  .catch((err) => console.error("Error:", err.message));
+```
+
+### `.then()` のチェーン
+
+`.then()` はそれぞれ**新しい Promise** を返すため、連続する非同期ステップを線形にチェーンできます。
+
+```js
+const { promisify } = require("util");
+const fs = require("fs");
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+readFile("./input.txt", "utf8")
+  .then((content) => {
+    const transformed = content.toUpperCase();
+    return writeFile("./output.txt", transformed, "utf8");
+  })
+  .then(() => {
+    console.log("Transformation complete");
+    return readFile("./output.txt", "utf8");
+  })
+  .then((result) => {
+    console.log("Verified output:", result.slice(0, 50));
+  })
+  .catch((err) => {
+    console.error("Pipeline failed:", err.message);
+  });
+```
+
+### チェーンを通じた値の受け渡し
+
+`.then()` の callback が返した値は、次の `.then()` の解決値になります。
+
+```js
+Promise.resolve(1)
+  .then((n) => n + 1)   // 2 を返す
+  .then((n) => n * 3)   // 6 を返す
+  .then((n) => console.log(n)); // 6
+```
+
+### `.finally()`
+
+`.finally()` は成功・失敗にかかわらず実行されます。クリーンアップ処理に便利です。
+
+```js
+let connection;
+
+openConnection()
+  .then((conn) => {
+    connection = conn;
+    return conn.query("SELECT * FROM users");
+  })
+  .then((rows) => console.log(rows))
+  .catch((err) => console.error(err))
+  .finally(() => {
+    if (connection) connection.close();
+  });
+```
+
+---
+
+## 4. `Promise.all()` / `Promise.race()` / `Promise.allSettled()`
+
+### `Promise.all(iterable)`
+
+複数の Promise を**並行して**実行し、**すべて**が fulfilled になったときに解決します。**いずれか1つ**が reject されると即座に reject されます。
+
+```js
+const fetchPost = (id) =>
+  fetch(`https://jsonplaceholder.typicode.com/posts/${id}`).then((r) =>
+    r.json()
+  );
+
+Promise.all([fetchPost(1), fetchPost(2), fetchPost(3)])
+  .then(([post1, post2, post3]) => {
+    console.log(post1.title);
+    console.log(post2.title);
+    console.log(post3.title);
+  })
+  .catch((err) => {
+    // いずれかのリクエストが失敗すると実行される
+    console.error("One or more requests failed:", err.message);
+  });
+```
+
+```
+処理時間の比較:
+  逐次実行: [---1---][---2---][---3---]  約300ms
+  並行実行: [---1---]
+            [---2---]                    約100ms（同時に実行）
+            [---3---]
+```
+
+### `Promise.race(iterable)`
+
+**最初に**settled になった Promise の結果（成功または失敗）で解決または reject し、残りは無視します。
+
+```js
+function timeout(ms) {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms)
+  );
+}
+
+function fetchWithTimeout(url, ms) {
+  return Promise.race([fetch(url).then((r) => r.json()), timeout(ms)]);
+}
+
+fetchWithTimeout("https://api.example.com/data", 3000)
+  .then((data) => console.log(data))
+  .catch((err) => console.error(err.message));
+```
+
+### `Promise.allSettled(iterable)`
+
+**すべての** Promise が settled（fulfilled または rejected）になるまで待ち、結果オブジェクトの配列を返します。決して reject されません。
+
+```js
+const requests = [
+  fetch("https://api.example.com/users").then((r) => r.json()),
+  fetch("https://api.example.com/posts").then((r) => r.json()),
+  fetch("https://api.invalid.com/data").then((r) => r.json()), // 失敗する
+];
+
+Promise.allSettled(requests).then((results) => {
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      console.log(`Request ${index + 1} succeeded:`, result.value);
+    } else {
+      console.log(`Request ${index + 1} failed:`, result.reason.message);
+    }
+  });
+});
+```
+
+### `Promise.any(iterable)`（ES2021）
+
+**最初に fulfilled** になった Promise で解決します。**すべての** Promise が reject された場合のみ reject されます。
+
+```js
+// 複数のミラーを試し、最初に応答したものを使う
+Promise.any([
+  fetch("https://mirror1.example.com/file"),
+  fetch("https://mirror2.example.com/file"),
+  fetch("https://mirror3.example.com/file"),
+])
+  .then((response) => response.blob())
+  .then((blob) => console.log("Downloaded from fastest mirror"))
+  .catch((err) => console.error("All mirrors failed"));
+```
+
+### 比較表
+
+| メソッド              | 解決するとき           | reject されるとき     |
+|---------------------|-----------------------|----------------------|
+| `Promise.all`       | すべて fulfilled       | いずれか1つが reject  |
+| `Promise.race`      | 最初が settled         | 最初が settled（失敗）|
+| `Promise.allSettled`| すべてが settled       | しない               |
+| `Promise.any`       | 最初が fulfilled       | すべてが reject      |
+
+---
+
+## 5. エラーハンドリング
+
+### チェーン全体に対する単一の `.catch()`
+
+```js
+readConfig()
+  .then((config) => validateConfig(config))
+  .then((config) => connectDB(config.dbUrl))
+  .then((db) => db.query("SELECT 1"))
+  .then((result) => console.log("DB OK:", result))
+  .catch((err) => {
+    // 上記のどのステップのエラーもここでキャッチされる
+    console.error("Pipeline error:", err.message);
+  });
+```
+
+### チェーン途中でのエラー回復
+
+チェーンの途中に `.catch()` を置いてエラーを処理し、フォールバック値を返すことでチェーンを継続させることができます。
+
+```js
+fetchUserFromAPI(userId)
+  .catch((err) => {
+    console.warn("API unavailable, falling back to cache:", err.message);
+    return fetchUserFromCache(userId); // 回復 — チェーンが続く
+  })
+  .then((user) => {
+    console.log("Got user:", user.name);
+  })
+  .catch((err) => {
+    console.error("Both API and cache failed:", err.message);
+  });
+```
+
+### エラーの再スロー
+
+```js
+fetchData()
+  .catch((err) => {
+    if (err.code === "ENOENT") {
+      return defaultData; // 処理してリカバリー
+    }
+    throw err; // 不明なエラーは再スロー
+  })
+  .then((data) => process(data))
+  .catch((err) => console.error("Unhandled:", err.message));
+```
+
+### 未処理の Promise rejection
+
+`.catch()` が付いていない reject された Promise があると、Node.js は `unhandledRejection` イベントを発行します。最近の Node.js バージョン（v15以降）ではプロセスがクラッシュします。
+
+```js
+// 必ず .catch() を付けるか、async/await と try/catch を使う
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled rejection:", reason);
+  process.exit(1);
+});
+```
+
+---
+
+## 6. アンチパターン
+
+### 6.1 Promise コンストラクタのアンチパターン（Deferred）
+
+```js
+// 悪い例: 既存の Promise を新しい Promise でラップしている
+function getUser(id) {
+  return new Promise((resolve, reject) => {
+    fetchUser(id) // fetchUser はすでに Promise を返している
+      .then((user) => resolve(user))
+      .catch((err) => reject(err));
+  });
+}
+
+// 良い例: Promise を直接返す
+function getUser(id) {
+  return fetchUser(id);
+}
+```
+
+### 6.2 `.then()` 内で Promise を return し忘れる
+
+```js
+// 悪い例: チェーンが saveUser の完了を待たない
+fetchUser(1)
+  .then((user) => {
+    saveUser(user); // return がない — fire and forget
+  })
+  .then(() => console.log("Saved")); // saveUser が終わる前に実行される
+
+// 良い例: 内側の Promise を return する
+fetchUser(1)
+  .then((user) => {
+    return saveUser(user); // チェーンがこれを待つ
+  })
+  .then(() => console.log("Saved"));
+```
+
+### 6.3 空の `.catch()` でエラーを握りつぶす
+
+```js
+// 悪い例: エラーが黙って無視される
+doSomething()
+  .catch(() => {}); // ブラックホール — エラーが消える
+
+// 良い例: 最低限ログに出力する
+doSomething()
+  .catch((err) => console.error("doSomething failed:", err));
+```
+
+### 6.4 callback と Promise を混在させる
+
+```js
+// 悪い例: 予測不能 — callback が実行された後に .then() も実行される
+function mixedBad(callback) {
+  return fetchData().then((data) => {
+    callback(null, data);
+    return data; // .then() も実行される
+  });
+}
+
+// 良い例: どちらか一方のスタイルに統一する
+function promiseBased() {
+  return fetchData();
+}
+```
+
+---
+
+## 7. FAQ
+
+**Q: `.then(null, onRejected)` と `.catch(onRejected)` の違いは何ですか？**
+
+A: 機能的には同等です。`.catch(fn)` は `.then(undefined, fn)` の糖衣構文です。わかりやすさのために `.catch()` を使うことを推奨します。
+
+---
+
+**Q: Promise でない値を `await` できますか？**
+
+A: できます。`await someValue` は Promise でない値を `Promise.resolve()` でラップするため、即座に解決されます。便利な場合もありますが、あまり必要になることはありません。
+
+---
+
+**Q: `Promise.all` はリクエストを並行して実行しますか？**
+
+A: `Promise.all` に渡される Promise はすでに実行中です（生成された時点で開始されます）。`Promise.all` はすべてが settled になるのを待つだけです。並行性は `Promise.all` ではなく、Promise を生成するタイミングによって決まります。
+
+---
+
+**Q: Promise をキャンセルするにはどうすればいいですか？**
+
+A: ネイティブの Promise はキャンセルできません。一般的な回避策として、`AbortController`（`fetch` や一部の Node.js API で利用可能）や、タイムアウト Promise を使った `Promise.race` があります。
+
+```js
+const controller = new AbortController();
+
+fetch("https://api.example.com/data", { signal: controller.signal })
+  .then((r) => r.json())
+  .then(console.log)
+  .catch((err) => {
+    if (err.name === "AbortError") {
+      console.log("Request cancelled");
+    }
+  });
+
+// 2秒後にキャンセル
+setTimeout(() => controller.abort(), 2000);
+```
+
+---
+
+**Q: `Promise.allSettled` と `Promise.all` はどう使い分けますか？**
+
+A: 個別の失敗にかかわらずすべての処理結果を扱う必要がある場合（例：部分的な成功が許容されるバッチ API 呼び出し）は `Promise.allSettled` を使います。すべての処理が成功しなければワークフローを続けられない場合は `Promise.all` を使います。
+
+---
+
+**親ガイド**: [Node.js Development - SKILL.md](../../SKILL.md)

--- a/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/03-async-await.md
+++ b/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/03-async-await.md
@@ -1,0 +1,543 @@
+# Node.js における async/await
+
+`async/await` は Promise の上に構築された糖衣構文であり、非同期コードを同期的なスタイルで書けるようにします。ES2017（Node.js 7.6以降）で導入され、現在は非同期 Node.js コードの主流パターンとなっています。
+
+---
+
+## 目次
+
+1. [async/await とは](#1-asyncawait-とは)
+2. [基本的な `async` 関数](#2-基本的な-async-関数)
+3. [`await` の仕組み](#3-await-の仕組み)
+4. [try/catch によるエラーハンドリング](#4-trycatch-によるエラーハンドリング)
+5. [`Promise.all` による並行実行](#5-promiseall-による並行実行)
+6. [よくある間違い](#6-よくある間違い)
+7. [FAQ](#7-faq)
+
+---
+
+## 1. async/await とは
+
+`async/await` は新たな非同期機能を導入するものではなく、Promise の上に置かれた層です。すべての `async` 関数は Promise を返し、`await` は待機中の Promise が settled になるまでその関数の実行を一時停止します。
+
+**同じロジックを3つのスタイルで書く：**
+
+```js
+// 1. callback スタイル
+readFile("config.json", "utf8", (err, data) => {
+  if (err) return console.error(err);
+  const cfg = JSON.parse(data);
+  connectDB(cfg.dbUrl, (err, db) => {
+    if (err) return console.error(err);
+    console.log("Connected");
+  });
+});
+
+// 2. Promise チェーンスタイル
+readFile("config.json", "utf8")
+  .then((data) => JSON.parse(data))
+  .then((cfg) => connectDB(cfg.dbUrl))
+  .then(() => console.log("Connected"))
+  .catch(console.error);
+
+// 3. async/await スタイル
+async function init() {
+  const data = await readFile("config.json", "utf8");
+  const cfg = JSON.parse(data);
+  await connectDB(cfg.dbUrl);
+  console.log("Connected");
+}
+
+init().catch(console.error);
+```
+
+3つはすべて同じ動作をします。async/await バージョンはノンブロッキングでありながら、同期コードのように読めます。
+
+---
+
+## 2. 基本的な `async` 関数
+
+### async 関数の宣言
+
+`async` キーワードは任意の関数宣言や関数式の前に付けられます。
+
+```js
+// 関数宣言
+async function fetchUser(id) {
+  return { id, name: "Alice" };
+}
+
+// 関数式
+const fetchPost = async function (id) {
+  return { id, title: "Hello" };
+};
+
+// アロー関数
+const fetchComment = async (id) => {
+  return { id, body: "Great post!" };
+};
+
+// クラスメソッド
+class UserService {
+  async getUser(id) {
+    return { id, name: "Bob" };
+  }
+}
+```
+
+### 戻り値
+
+`async` 関数は、プレーンな値を返した場合でも**常に Promise を返します**。
+
+```js
+async function add(a, b) {
+  return a + b; // Promise.resolve(a + b) と同等
+}
+
+add(2, 3).then(console.log); // 5
+```
+
+### 実践例：ファイル操作
+
+```js
+const fs = require("fs/promises"); // Node.js 14以降のビルトイン Promise API
+
+async function processConfig(path) {
+  const raw = await fs.readFile(path, "utf8");
+  const config = JSON.parse(raw);
+
+  config.processedAt = new Date().toISOString();
+
+  const output = JSON.stringify(config, null, 2);
+  await fs.writeFile(path.replace(".json", ".out.json"), output, "utf8");
+
+  return config;
+}
+
+processConfig("./config.json")
+  .then((cfg) => console.log("Processed:", cfg.processedAt))
+  .catch((err) => console.error("Failed:", err.message));
+```
+
+---
+
+## 3. `await` の仕組み
+
+### 実行の一時停止
+
+`await` はその時点で `async` 関数の実行を一時停止し、Event Loop に制御を返します。待機していた Promise が settled になると実行が再開されます。
+
+```js
+async function demo() {
+  console.log("1 - before await");
+
+  const result = await new Promise((resolve) => {
+    setTimeout(() => resolve("done"), 1000);
+  });
+
+  console.log("3 - after await:", result); // 約1秒後に実行される
+}
+
+demo();
+console.log("2 - this runs while demo() is awaiting");
+```
+
+```
+出力:
+  1 - before await
+  2 - this runs while demo() is awaiting
+  3 - after await: done
+```
+
+### Promise でない値への `await`
+
+`await` は Promise でない値を `Promise.resolve()` でラップします。つまり `await 42` は有効であり、`42` を即座に返します。
+
+```js
+async function test() {
+  const x = await 42;       // 即座に解決される
+  const y = await "hello";  // これも有効
+  console.log(x, y);        // 42 hello
+}
+```
+
+### `await` は `async` 内でのみ使用可能
+
+CommonJS モジュールのトップレベルで `await` を使うと構文エラーになります。async IIFE を使うか、ES モジュールに切り替えてください（Node.js 14.8以降ではトップレベル `await` がサポートされています）。
+
+```js
+// CommonJS — async 関数でラップする
+(async () => {
+  const data = await fetchData();
+  console.log(data);
+})();
+
+// ES モジュール（.mjs または package.json で "type": "module"） — トップレベル await が使える
+const data = await fetchData();
+console.log(data);
+```
+
+### 内部の仕組み
+
+`async/await` は Promise 上のジェネレータベースのコルーチンスケジューリングに脱糖されます。以下の2つのコードは同等です：
+
+```js
+// async/await
+async function getUser(id) {
+  const user = await fetchUser(id);
+  return user.name;
+}
+
+// 同等の Promise チェーン
+function getUser(id) {
+  return fetchUser(id).then((user) => user.name);
+}
+```
+
+---
+
+## 4. try/catch によるエラーハンドリング
+
+### 基本的な try/catch
+
+`await` 式を try/catch で囲むことで、reject された Promise を処理できます。
+
+```js
+async function loadUser(id) {
+  try {
+    const user = await fetchUser(id);
+    console.log("User:", user.name);
+    return user;
+  } catch (err) {
+    console.error("Failed to load user:", err.message);
+    return null;
+  }
+}
+```
+
+### 複数ステップのエラーハンドリング
+
+1つの try ブロックで複数の await 処理をカバーできます。
+
+```js
+const fs = require("fs/promises");
+
+async function buildReport(userId) {
+  try {
+    const user = await fetchUser(userId);
+    const posts = await fetchPosts(userId);
+    const report = { user, posts, generatedAt: new Date() };
+    await fs.writeFile("./report.json", JSON.stringify(report, null, 2));
+    console.log("Report saved");
+    return report;
+  } catch (err) {
+    console.error("Report generation failed:", err.message);
+    throw err; // 呼び出し元に失敗を伝えるために再スロー
+  }
+}
+```
+
+### きめ細かいエラーハンドリング
+
+エラーの種類によって異なる処理が必要な場合は、try/catch ブロックを分けます。
+
+```js
+async function syncData(userId) {
+  let user;
+
+  try {
+    user = await fetchUser(userId);
+  } catch (err) {
+    console.error("Could not fetch user:", err.message);
+    return; // 早期終了
+  }
+
+  try {
+    await syncToRemote(user);
+    console.log("Sync complete");
+  } catch (err) {
+    // 同期の失敗は致命的でない — ログに記録して続行
+    console.warn("Sync failed, will retry later:", err.message);
+    await scheduleRetry(userId);
+  }
+}
+```
+
+### ヘルパー：`to` パターン（任意）
+
+チームによっては、ネストした try/catch を避けるため、reject された Promise を `[err, null]` / `[null, data]` に変換するヘルパーを使うことがあります。
+
+```js
+async function to(promise) {
+  try {
+    const data = await promise;
+    return [null, data];
+  } catch (err) {
+    return [err, null];
+  }
+}
+
+async function getUser(id) {
+  const [err, user] = await to(fetchUser(id));
+  if (err) {
+    console.error("Fetch failed:", err.message);
+    return null;
+  }
+  return user;
+}
+```
+
+---
+
+## 5. `Promise.all` による並行実行
+
+### 逐次実行の落とし穴
+
+並行して実行できる処理を1つずつ await してしまうのはよくある間違いです。
+
+```js
+// 遅い: 合計300ms（100 + 100 + 100）
+async function slowFetch() {
+  const user = await fetchUser(1);    // 100ms 待つ
+  const posts = await fetchPosts(1);  // さらに100ms 待つ
+  const tags = await fetchTags(1);    // さらに100ms 待つ
+  return { user, posts, tags };
+}
+```
+
+### `Promise.all` による並行実行
+
+```js
+// 速い: 約100ms（すべて同時に実行）
+async function fastFetch() {
+  const [user, posts, tags] = await Promise.all([
+    fetchUser(1),
+    fetchPosts(1),
+    fetchTags(1),
+  ]);
+  return { user, posts, tags };
+}
+```
+
+```
+逐次実行: [fetchUser][fetchPosts][fetchTags]   約300ms
+並行実行: [fetchUser ]
+          [fetchPosts]                          約100ms
+          [fetchTags ]
+```
+
+### 逐次処理と並行処理の組み合わせ
+
+独立したステップは並行して、前の結果に依存するステップは逐次的に実行します。
+
+```js
+async function loadDashboard(userId) {
+  // Step 1: まずユーザーを取得（次のステップで必要）
+  const user = await fetchUser(userId);
+
+  // Step 2: 投稿と設定を並行取得（どちらも userId が必要）
+  const [posts, preferences] = await Promise.all([
+    fetchPosts(user.id),
+    fetchPreferences(user.id),
+  ]);
+
+  return { user, posts, preferences };
+}
+```
+
+### `Promise.allSettled` による部分的な失敗の処理
+
+```js
+async function loadOptionalData(userId) {
+  const results = await Promise.allSettled([
+    fetchUser(userId),             // 必須
+    fetchRecommendations(userId),  // 任意
+    fetchAds(userId),              // 任意
+  ]);
+
+  const [userResult, recsResult, adsResult] = results;
+
+  if (userResult.status === "rejected") {
+    throw userResult.reason; // ユーザーは必須
+  }
+
+  return {
+    user: userResult.value,
+    recommendations: recsResult.status === "fulfilled" ? recsResult.value : [],
+    ads: adsResult.status === "fulfilled" ? adsResult.value : [],
+  };
+}
+```
+
+---
+
+## 6. よくある間違い
+
+### 6.1 ループ内での不必要な逐次 await
+
+```js
+const userIds = [1, 2, 3, 4, 5];
+
+// 悪い例: 前のフェッチが終わるまで次を待つ
+async function slowAll() {
+  const users = [];
+  for (const id of userIds) {
+    const user = await fetchUser(id); // 逐次実行！
+    users.push(user);
+  }
+  return users;
+}
+
+// 良い例: すべてのフェッチを開始してから結果をまとめて待つ
+async function fastAll() {
+  const promises = userIds.map((id) => fetchUser(id));
+  return await Promise.all(promises);
+}
+```
+
+**例外**: 各イテレーションが前の結果に依存する場合（例：ページネーション付き API のトラバーサル）は、ループ内の逐次 await が適切です。
+
+### 6.2 async 関数の未処理 rejection
+
+```js
+// 悪い例: .catch() も try/catch もなく async 関数を呼び出している
+async function dangerousOperation() {
+  await doSomethingRisky(); // reject される可能性がある
+}
+
+dangerousOperation(); // rejection が未処理 — Node.js がクラッシュする可能性
+
+// 良い例: 呼び出し側でハンドリングする
+dangerousOperation().catch((err) => console.error(err));
+
+// または async コンテキスト内で try/catch を使う
+async function safeWrapper() {
+  try {
+    await dangerousOperation();
+  } catch (err) {
+    console.error(err);
+  }
+}
+```
+
+### 6.3 `forEach` 内の `await` は期待通りに動かない
+
+```js
+const ids = [1, 2, 3];
+
+// 悪い例: forEach は async callback を await しない
+async function wrong() {
+  ids.forEach(async (id) => {
+    const user = await fetchUser(id); // 実行されるが forEach は待たない
+    console.log(user.name);
+  });
+  console.log("Done?"); // ユーザーが取得される前に出力される
+}
+
+// 良い例: 逐次処理なら for...of、並行処理なら map + Promise.all を使う
+async function correctSequential() {
+  for (const id of ids) {
+    const user = await fetchUser(id);
+    console.log(user.name);
+  }
+}
+
+async function correctParallel() {
+  await Promise.all(ids.map(async (id) => {
+    const user = await fetchUser(id);
+    console.log(user.name);
+  }));
+  console.log("All done");
+}
+```
+
+### 6.4 `await` の戻り値を無視する
+
+```js
+// 悪い例: 結果が捨てられ、変数が undefined になる
+async function bad() {
+  const user = fetchUser(1); // await がない！
+  console.log(user.name);   // TypeError: Promise のプロパティを読み取れない
+}
+
+// 良い例
+async function good() {
+  const user = await fetchUser(1);
+  console.log(user.name);
+}
+```
+
+### 6.5 不要な `async` の使用
+
+```js
+// 不要: 関数本体に await がない
+async function getConfig() {
+  return { host: "localhost", port: 3000 }; // 非同期処理なし
+}
+
+// よりシンプル: 必要に応じてプレーンな値または Promise.resolve を返す
+function getConfig() {
+  return { host: "localhost", port: 3000 };
+}
+```
+
+---
+
+## 7. FAQ
+
+**Q: `async/await` は単なる糖衣構文ですか？**
+
+A: はい。すべての `async` 関数は Promise を返し、`await` は `.then()` と同等です。JavaScript エンジンは `async/await` を内部で Promise チェーンにコンパイルします。パフォーマンスの差はありません。
+
+---
+
+**Q: 古い Node.js バージョンで `async/await` は使えますか？**
+
+A: `async/await` は Node.js 7.6以降（ネイティブ）、または Babel トランスパイルを使えば Node.js 4以降で利用できます。2025年時点では Node.js 18以降が LTS のベースラインとなっており、ネイティブサポートは事実上すべての環境で利用可能です。
+
+---
+
+**Q: `await` はスレッドをブロックしますか？**
+
+A: いいえ。`await` は現在の `async` 関数を一時停止しますが、Event Loop に制御を返すため、他の callback や Promise が実行できます。スレッドがブロックされることはありません。
+
+---
+
+**Q: `Promise.all` と逐次 `await` はどう使い分けますか？**
+
+A: 処理が**独立している**（順序に依存せず、データの依存関係もない）場合は `Promise.all` を使います。各ステップが**前のステップの結果に依存する**場合や、順序が重要な場合（例：書き込み前に読み込む）は逐次 `await` を使います。
+
+---
+
+**Q: `async/await` でタイムアウトを処理するにはどうすればいいですか？**
+
+A: `Promise.race` とタイムアウト Promise を組み合わせます。
+
+```js
+function withTimeout(promise, ms) {
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms)
+  );
+  return Promise.race([promise, timeout]);
+}
+
+async function fetchWithTimeout(url) {
+  try {
+    const data = await withTimeout(fetch(url).then((r) => r.json()), 5000);
+    return data;
+  } catch (err) {
+    console.error(err.message);
+    throw err;
+  }
+}
+```
+
+---
+
+**Q: Node.js でトップレベル `await` は使えますか？**
+
+A: はい、ES モジュール（`.mjs` 拡張子または `package.json` に `"type": "module"` を指定したファイル）では使えます。CommonJS モジュールでは async IIFE でコードをラップしてください。
+
+---
+
+**親ガイド**: [Node.js Development - SKILL.md](../../SKILL.md)

--- a/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/04-event-loop.md
+++ b/ja/04-web-and-network/nodejs-development/docs/02-async-patterns/04-event-loop.md
@@ -1,0 +1,431 @@
+# Node.js の Event Loop
+
+Event Loop は、Node.js がシングルスレッドで動作しながらもノンブロッキング I/O を実現するための中核的な仕組みです。予測可能な非同期コードの作成やパフォーマンス問題の診断において、Event Loop の理解は不可欠です。
+
+---
+
+## 目次
+
+1. [Event Loop とは](#1-event-loop-とは)
+2. [Call Stack](#2-call-stack)
+3. [Task Queue（macrotask）](#3-task-queuemacrotask)
+4. [Microtask Queue](#4-microtask-queue)
+5. [Event Loop のフェーズ](#5-event-loop-のフェーズ)
+6. [実行順序の例](#6-実行順序の例)
+7. [よくある面接での質問](#7-よくある面接での質問)
+
+---
+
+## 1. Event Loop とは
+
+Node.js は **libuv** という C ライブラリの上に構築されており、libuv が Event Loop と非同期 I/O のプリミティブを提供しています。Event Loop は保留中の処理を継続的に確認し、その callback をディスパッチします。
+
+```
+  ┌─────────────────────────────────────────┐
+  │         Node.js Process                 │
+  │                                         │
+  │  ┌───────────┐   ┌───────────────────┐  │
+  │  │ Call Stack│   │   libuv / OS      │  │
+  │  │ (V8)      │   │  Thread Pool      │  │
+  │  └─────┬─────┘   │  (fs, crypto...)  │  │
+  │        │          └────────┬──────────┘  │
+  │        │                   │             │
+  │  ┌─────▼─────────────────▼──────────┐  │
+  │  │            Event Loop             │  │
+  │  │  timers → I/O → poll → check     │  │
+  │  └──────────────────────────────────┘  │
+  └─────────────────────────────────────────┘
+```
+
+**重要なポイント**: Event Loop 自体はメインスレッドで動きます。I/O 処理（ファイル読み込み、ネットワークリクエスト）がディスパッチされると、libuv はそれらを OS カーネルの非同期 API またはスレッドプールにオフロードします。完了した callback は Event Loop が拾い上げるためにキューに入れられ、メインスレッドが待機でブロックされることはありません。
+
+---
+
+## 2. Call Stack
+
+**Call Stack** は現在実行中の関数を追跡する LIFO（後入れ先出し）のデータ構造です。関数が呼ばれるとフレームがプッシュされ、返るとポップされます。
+
+```js
+function multiply(a, b) {
+  return a * b;
+}
+
+function square(n) {
+  return multiply(n, n);
+}
+
+function main() {
+  const result = square(5);
+  console.log(result);
+}
+
+main();
+```
+
+```
+Call Stack の遷移:
+
+  main()          →  square(5)       →  multiply(5,5)
+  ┌─────────┐       ┌─────────┐        ┌─────────────┐
+  │  main   │       │ square  │        │  multiply   │
+  └─────────┘       │  main   │        │  square     │
+                    └─────────┘        │  main       │
+                                       └─────────────┘
+                    ← multiply が返る
+                    ← square が返る
+  ← main が返る  (スタックが空 → Event Loop がキューを確認)
+```
+
+**Call Stack のブロック**: 同期処理に時間がかかると（例：大きなファイルへの `fs.readFileSync`、重い計算処理）、その間 Call Stack が占有されます。スタックが空になるまで Event Loop はどの callback も処理できません。これが「Node.js をブロックする」ということの意味です。
+
+```js
+// 危険: Call Stack を数秒間ブロックする可能性がある
+const data = fs.readFileSync("huge-file.csv"); // この間 I/O は処理されない
+
+// 安全: チャンク間に Event Loop へ制御を返す
+const stream = fs.createReadStream("huge-file.csv");
+stream.on("data", (chunk) => processChunk(chunk));
+```
+
+---
+
+## 3. Task Queue（macrotask）
+
+**Task Queue**（macrotask queue または callback queue とも呼ばれる）は実行待ちの callback を保持します。macrotask の主なソース：
+
+| ソース | 説明 |
+|--------|-------------|
+| `setTimeout(fn, delay)` | 少なくとも `delay` ミリ秒後に実行 |
+| `setInterval(fn, delay)` | `delay` ミリ秒ごとに繰り返し実行 |
+| `setImmediate(fn)` | check フェーズで実行（I/O の後） |
+| I/O callback | `fs.readFile`、ネットワーク応答など |
+
+Event Loop は**1回のループ反復で1つの macrotask** を処理し、次に進む前に microtask queue をすべて空にします。
+
+```js
+setTimeout(() => console.log("setTimeout"), 0);
+setImmediate(() => console.log("setImmediate"));
+
+// Node.js での出力順（I/O callback の外側では）:
+// どちらが先になるかは不確定 — システムのタイマー精度に依存する
+// I/O callback の内側では: setImmediate が setTimeout より常に先に実行される
+```
+
+---
+
+## 4. Microtask Queue
+
+**Microtask Queue** は、現在の処理が完了した直後、Event Loop が次のフェーズに移るまたは別の macrotask を処理する前に実行すべき callback を保持します。
+
+microtask のソース：
+
+| ソース | 説明 |
+|--------|-------------|
+| `Promise.then()` / `.catch()` / `.finally()` | Promise 解決の callback |
+| `queueMicrotask(fn)` | 明示的な microtask のスケジューリング |
+| `process.nextTick(fn)` | Node.js 固有 — 最高優先度の microtask |
+
+### 優先度の順序
+
+```
+各タスクの後（またはスタートアップ時）:
+  1. process.nextTick キューをすべて処理
+  2. Promise microtask キューをすべて処理
+  3. Event Loop に戻る → 次の macrotask
+```
+
+```js
+Promise.resolve().then(() => console.log("Promise microtask"));
+process.nextTick(() => console.log("nextTick"));
+setTimeout(() => console.log("setTimeout macrotask"), 0);
+
+console.log("synchronous");
+
+// 出力:
+// synchronous
+// nextTick          ← process.nextTick が最初に実行される
+// Promise microtask ← 次に Promise の .then()
+// setTimeout macrotask ← 最後に macrotask キュー
+```
+
+### Microtask の枯渇（Starvation）
+
+Microtask queue はどの macrotask よりも先にすべて処理されるため、無限再帰的な microtask が Event Loop を飢餓状態にする可能性があります。
+
+```js
+// 危険: I/O callback を永久にブロックする
+function infinite() {
+  Promise.resolve().then(infinite);
+}
+infinite();
+// setTimeout の callback は実行されず、I/O も応答しなくなる
+```
+
+---
+
+## 5. Event Loop のフェーズ
+
+Node.js の Event Loop には6つのフェーズがあり、固定の順序で実行されます。各フェーズには FIFO の callback キューがあります。
+
+```
+  ┌──────────────────────────────────────────────┐
+  │                                              │
+  │   ┌─────────┐                               │
+  │   │ timers  │  setTimeout, setInterval       │
+  │   └────┬────┘                               │
+  │        │                                    │
+  │   ┌────▼──────────┐                         │
+  │   │ pending I/O   │  遅延 I/O エラー         │
+  │   └────┬──────────┘                         │
+  │        │                                    │
+  │   ┌────▼──────┐                             │
+  │   │  idle,    │  内部使用のみ               │
+  │   │  prepare  │                             │
+  │   └────┬──────┘                             │
+  │        │                                    │
+  │   ┌────▼──────┐     ┌──────────────────┐   │
+  │   │   poll    │◄────│ 受信 I/O /       │   │
+  │   └────┬──────┘     │ 空なら待機       │   │
+  │        │            └──────────────────┘   │
+  │   ┌────▼──────┐                             │
+  │   │   check   │  setImmediate               │
+  │   └────┬──────┘                             │
+  │        │                                    │
+  │   ┌────▼───────────┐                        │
+  │   │ close callbacks│  socket.on('close')    │
+  │   └────────────────┘                        │
+  │        │                                    │
+  └────────┘ (ループが繰り返される)
+```
+
+### 各フェーズの詳細
+
+**timers フェーズ**: 遅延時間が経過した `setTimeout` および `setInterval` の callback を実行します。なお、`setTimeout(fn, 0)` は内部的に最低 1ms にクランプされます。
+
+**pending I/O フェーズ**: 前のループ反復から次のループ反復に延期された I/O callback（主にエラー callback）を実行します。
+
+**poll フェーズ**: 最も重要なフェーズです。
+- 新しい I/O イベントのためにどれくらい待機するかを計算する
+- poll キューの I/O callback を処理する
+- poll キューが空の場合、I/O イベントを待機する（`setImmediate` の callback が保留中でない限り）
+
+**check フェーズ**: `setImmediate` の callback を実行します。poll フェーズ完了後に常に実行されます。
+
+**close callbacks フェーズ**: クローズされたハンドルの callback を実行します（例：`socket.on('close', ...)`）。
+
+**各フェーズの間**: microtask キュー（`process.nextTick` → Promise の順）がすべて処理されます。
+
+---
+
+## 6. 実行順序の例
+
+### 例1: 基本的な順序
+
+```js
+console.log("A"); // 同期
+
+setTimeout(() => console.log("B"), 0); // macrotask
+
+Promise.resolve().then(() => console.log("C")); // microtask
+
+process.nextTick(() => console.log("D")); // 最高優先度の microtask
+
+console.log("E"); // 同期
+
+// 出力: A, E, D, C, B
+```
+
+解説:
+1. `A` と `E` が同期的に実行される（Call Stack）
+2. `D` が実行される — `process.nextTick` キューが最初にすべて処理される
+3. `C` が実行される — Promise microtask キューが処理される
+4. `B` が実行される — Event Loop が timers フェーズに入る
+
+### 例2: ネストした microtask
+
+```js
+process.nextTick(() => {
+  console.log("nextTick 1");
+  process.nextTick(() => console.log("nextTick 2 (nested)"));
+});
+
+Promise.resolve().then(() => {
+  console.log("Promise 1");
+  return Promise.resolve();
+}).then(() => console.log("Promise 2 (chained)"));
+
+// 出力:
+// nextTick 1
+// nextTick 2 (nested)  ← Promise より先に nextTick キューがすべて処理される
+// Promise 1
+// Promise 2 (chained)
+```
+
+### 例3: I/O 内での `setImmediate` と `setTimeout` の比較
+
+```js
+const fs = require("fs");
+
+fs.readFile(__filename, () => {
+  // I/O callback の内側 — poll フェーズが完了した直後
+  setTimeout(() => console.log("setTimeout"), 0);
+  setImmediate(() => console.log("setImmediate"));
+});
+
+// 出力（I/O callback 内では確定的）:
+// setImmediate  ← check フェーズは常に次の timers フェーズより前に来る
+// setTimeout
+```
+
+### 例4: フルパイプライン
+
+```js
+const fs = require("fs/promises");
+
+async function pipeline() {
+  console.log("1 - start");
+
+  const data = await fs.readFile(__filename, "utf8"); // ここで一時停止
+
+  console.log("3 - after await (I/O complete)");
+
+  process.nextTick(() => console.log("4 - nextTick after resume"));
+
+  await Promise.resolve();
+
+  console.log("5 - after inner await");
+}
+
+pipeline();
+console.log("2 - synchronous after pipeline() call");
+
+// 出力:
+// 1 - start
+// 2 - synchronous after pipeline() call
+// 3 - after await (I/O complete)
+// 4 - nextTick after resume
+// 5 - after inner await
+```
+
+### 例5: タイマーの精度
+
+```js
+const start = Date.now();
+
+setTimeout(() => {
+  console.log(`Timer fired after ${Date.now() - start}ms`);
+}, 100);
+
+// ブロッキング処理のシミュレーション
+const until = Date.now() + 200;
+while (Date.now() < until) {} // Call Stack を200ms間ブロック
+
+// 出力: Timer fired after ~200ms（100ms ではない）
+// callback は約100ms でキューに入ったが、スタックが空になるまで実行できなかった
+```
+
+この例は、Call Stack をブロックするとすべての保留中の callback が遅延することを示しています。
+
+---
+
+## 7. よくある面接での質問
+
+### Q1: `process.nextTick` と `Promise.then` の違いは何ですか？
+
+どちらも microtask ですが、`process.nextTick` の callback は毎回の microtask ドレインサイクルにおいて Promise callback より**先に**実行されます。
+
+```js
+Promise.resolve().then(() => console.log("Promise"));
+process.nextTick(() => console.log("nextTick"));
+
+// 出力:
+// nextTick
+// Promise
+```
+
+現在のターンで I/O や Promise 解決より前に callback をスケジュールしたい場合は `process.nextTick` を使います。標準的な非同期の順序付けには `Promise.then` を使います。
+
+---
+
+### Q2: `setImmediate` と `setTimeout(fn, 0)` の違いは何ですか？
+
+- `setImmediate` は poll フェーズの後の **check フェーズ**で実行される
+- `setTimeout(fn, 0)` は次のループ開始時の **timers フェーズ**で実行される
+
+I/O callback の内側では `setImmediate` が常に先に実行されます。I/O callback の外側では順序が不確定です（OS のタイマー精度に依存）。
+
+```js
+// I/O callback の内側 → setImmediate が常に先
+fs.readFile("file.txt", () => {
+  setImmediate(() => console.log("setImmediate")); // 先
+  setTimeout(() => console.log("setTimeout"), 0);  // 後
+});
+```
+
+---
+
+### Q3: Event Loop は「詰まる」ことがありますか？
+
+はい、2つの方法で詰まります：
+
+1. **Call Stack のブロック** — CPU 負荷の高い同期コード（重いループ、大きなファイルへの `readFileSync` など）が、callback を処理できない状態にする。
+
+2. **Microtask の枯渇** — microtask の無限連鎖（再帰的な `Promise.resolve().then(...)` や `process.nextTick(...)`）が macrotask を永遠に実行させない。
+
+---
+
+### Q4: `async/await` は Event Loop とどのように連携しますか？
+
+`await` 式は `async` 関数を一時停止し、待機していた Promise が settled になったときに、再開を **microtask** としてスケジュールします。つまり `await` 後のコードは、新しい macrotask としてではなく microtask キューで実行されます。
+
+```js
+async function example() {
+  await Promise.resolve(); // ここで一時停止
+  console.log("resumed"); // microtask としてキューに追加される
+}
+
+example();
+console.log("synchronous");
+
+// 出力:
+// synchronous
+// resumed
+```
+
+---
+
+### Q5: `setTimeout(fn, 0)` はなぜ即座に実行されないのですか？
+
+3つの理由があります：
+1. 最小クランプ: Node.js は内部的に `setTimeout` の遅延を最低 1ms にクランプする。
+2. Event Loop が現在のフェーズを完了してから timers フェーズに到達する必要がある。
+3. すべての microtask（nextTick + Promise）が macrotask より先に処理される。
+
+---
+
+### Q6: スレッドプールとは何ですか？Event Loop とどのように関係しますか？
+
+libuv は OS レベルで非同期実行できない処理のためにスレッドプール（デフォルトサイズ: 4スレッド、`UV_THREADPOOL_SIZE` で設定可能）を使用します。対象の処理には以下が含まれます：
+
+- ファイルシステム操作（`fs.readFile` など）
+- `crypto` モジュールの操作
+- `dns.lookup`（`dns.resolve` ではない）
+- 一部の `zlib` 操作
+
+スレッドプールは**メインスレッドとは別に**実行されます。スレッドプールのタスクが完了すると、その callback は poll キューに置かれ、メインスレッドの Event Loop が拾い上げます。
+
+```
+  Main Thread        Thread Pool（4スレッド）
+  ┌──────────┐       ┌────────────────────┐
+  │ Event    │──────►│ fs.readFile        │
+  │ Loop     │       │ crypto.pbkdf2      │
+  │          │◄──────│ (完了したら        │
+  └──────────┘       │  callback をキューへ) │
+                     └────────────────────┘
+```
+
+スレッドプールの4スロットがすべて使用中の場合、後続の I/O 操作はキューで待機します。CPU 負荷の高い crypto 処理が I/O スループットを低下させることがあるのはこのためです。
+
+---
+
+**親ガイド**: [Node.js Development - SKILL.md](../../SKILL.md)


### PR DESCRIPTION
## 概要

Node.js開発スキルの `02-async-patterns` セクション（4本）を日本語化しました。

## 追加ファイル

- `01-callbacks.md` — コールバック・コールバック地獄
- `02-promises.md` — Promise・チェーン・エラーハンドリング
- `03-async-await.md` — async/await・並列処理
- `04-event-loop.md` — イベントループの仕組み・面接Q&A

## 翻訳方針

- 技術用語（Promise、async/await、Event Loop等）は英語のまま
- コードブロックはそのまま、コメントのみ日本語化
- 自然な日本語表現に統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)